### PR TITLE
Fix conversation order and webcam interval cleanup

### DIFF
--- a/islands/Webcam.tsx
+++ b/islands/Webcam.tsx
@@ -61,7 +61,7 @@ export default function Webcam({ onSnap, interval = 10000 }: WebcamProps) {
         }, interval);
 
         // Clear the interval when the component unmounts
-        // return () => clearInterval(captureInterval);
+        return () => clearInterval(captureInterval);
     }, [interval, onSnap]);
 
     return (

--- a/lib/daringsby/core/voice.ts
+++ b/lib/daringsby/core/voice.ts
@@ -142,7 +142,9 @@ export class Voice implements Sensitive<Message[]> {
         LIMIT 10
       `;
       const result = await session.run(query);
-      return result.records.map((record) => record.get("e").properties);
+      return result.records
+        .map((record) => record.get("e").properties)
+        .reverse(); // chronological order
     } catch (e) {
       logger.error({ e }, `Failed to load experiences`);
       return [];


### PR DESCRIPTION
## Summary
- maintain chronological order when loading the last messages
- clear snapshot interval when Webcam unmounts

## Testing
- `deno task check` *(fails: deno not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6842328f4b9083209432d58742f88227