### PR TITLE
Add capability-aware model scheduler

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,3 +77,4 @@ This design supports cognitive modularity, streamability, emotional realism, and
 * Add unit tests alongside new features when possible.
 * Continuous integration runs `cargo check` and `cargo test` via `.github/workflows/ci.yml` on pushes and pull requests.
 * Keep this file updated with new reminders as the project evolves.
+* Remember "ants across the bridge" when connecting modules.

--- a/voice/Cargo.toml
+++ b/voice/Cargo.toml
@@ -11,3 +11,7 @@ thiserror = "1"
 async-trait = "0.1"
 log = "0.4"
 env_logger = "0.10"
+reqwest = { version = "0.11", features = ["json", "stream"] }
+tokio-stream = "0.1"
+futures-core = "0.3"
+futures-util = "0.3"

--- a/voice/src/lib.rs
+++ b/voice/src/lib.rs
@@ -13,3 +13,5 @@ pub trait VoiceAgent: Send + Sync {
 pub fn placeholder() {
     println!("voice module initialized");
 }
+
+pub mod model;

--- a/voice/src/model/mod.rs
+++ b/voice/src/model/mod.rs
@@ -1,0 +1,133 @@
+use async_trait::async_trait;
+use futures_core::Stream;
+use futures_util::StreamExt;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use std::pin::Pin;
+
+pub mod registry;
+pub mod scheduler;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Capability {
+    Chat,
+    Embedding,
+    Vision,
+    Code,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Attribute {
+    Fast,
+    Slow,
+    LowMemory,
+    HighMemory,
+}
+
+#[derive(Debug, Error)]
+pub enum ModelError {
+    #[error("network error: {0}")]
+    Network(#[from] reqwest::Error),
+    #[error("invalid response")]
+    InvalidResponse,
+}
+
+#[async_trait]
+pub trait ModelClient {
+    async fn stream_chat(
+        &self,
+        model: &str,
+        prompt: &str,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<String, ModelError>> + Send>>, ModelError>;
+
+    async fn embed(&self, model: &str, input: &str) -> Result<Vec<f32>, ModelError>;
+}
+
+pub struct OllamaClient {
+    pub base_url: String,
+    client: reqwest::Client,
+}
+
+impl OllamaClient {
+    pub fn new(base_url: impl Into<String>) -> Self {
+        Self { base_url: base_url.into(), client: reqwest::Client::new() }
+    }
+}
+
+#[async_trait]
+impl ModelClient for OllamaClient {
+    async fn stream_chat(
+        &self,
+        model: &str,
+        prompt: &str,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<String, ModelError>> + Send>>, ModelError> {
+        let url = format!("{}/api/generate", self.base_url);
+        let resp = self
+            .client
+            .post(url)
+            .json(&serde_json::json!({"model": model, "prompt": prompt, "stream": true}))
+            .send()
+            .await?;
+        let stream = resp.bytes_stream().map(|b| {
+            b.map_err(ModelError::from).and_then(|chunk| {
+                let text = String::from_utf8_lossy(&chunk);
+                for line in text.lines() {
+                    if let Ok(v) = serde_json::from_str::<serde_json::Value>(line) {
+                        if let Some(resp) = v.get("response").and_then(|r| r.as_str()) {
+                            return Ok(resp.to_string());
+                        }
+                    }
+                }
+                Err(ModelError::InvalidResponse)
+            })
+        });
+        Ok(Box::pin(stream))
+    }
+
+    async fn embed(&self, model: &str, input: &str) -> Result<Vec<f32>, ModelError> {
+        let url = format!("{}/api/embeddings", self.base_url);
+        let resp = self
+            .client
+            .post(url)
+            .json(&serde_json::json!({"model": model, "prompt": input}))
+            .send()
+            .await?
+            .json::<serde_json::Value>()
+            .await?;
+        if let Some(arr) = resp.get("embedding").and_then(|e| e.as_array()) {
+            let vec = arr
+                .iter()
+                .filter_map(|v| v.as_f64())
+                .map(|f| f as f32)
+                .collect();
+            Ok(vec)
+        } else {
+            Err(ModelError::InvalidResponse)
+        }
+    }
+}
+
+pub struct MockModelClient {
+    pub responses: Vec<String>,
+    pub embeddings: Vec<f32>,
+}
+
+impl MockModelClient {
+    pub fn new(responses: Vec<String>, embeddings: Vec<f32>) -> Self { Self { responses, embeddings } }
+}
+
+#[async_trait]
+impl ModelClient for MockModelClient {
+    async fn stream_chat(
+        &self,
+        _model: &str,
+        _prompt: &str,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<String, ModelError>> + Send>>, ModelError> {
+        let iter = self.responses.clone().into_iter().map(Ok);
+        Ok(Box::pin(tokio_stream::iter(iter)))
+    }
+
+    async fn embed(&self, _model: &str, _input: &str) -> Result<Vec<f32>, ModelError> {
+        Ok(self.embeddings.clone())
+    }
+}

--- a/voice/src/model/registry.rs
+++ b/voice/src/model/registry.rs
@@ -1,0 +1,46 @@
+use std::collections::HashMap;
+
+use super::{Attribute, Capability};
+
+#[derive(Clone)]
+pub struct ModelInfo {
+    pub name: String,
+    pub capabilities: Vec<Capability>,
+    pub attributes: Vec<Attribute>,
+}
+
+#[derive(Clone)]
+pub struct ServerInfo {
+    pub address: String,
+    pub models: HashMap<String, ModelInfo>,
+    pub attributes: Vec<Attribute>,
+}
+
+pub struct ModelRegistry {
+    servers: Vec<ServerInfo>,
+}
+
+impl ModelRegistry {
+    pub fn new() -> Self { Self { servers: Vec::new() } }
+
+    pub fn add_server(&mut self, server: ServerInfo) { self.servers.push(server); }
+
+    pub fn servers(&self) -> &[ServerInfo] { &self.servers }
+}
+
+impl ServerInfo {
+    pub fn new(address: impl Into<String>) -> Self {
+        Self { address: address.into(), models: HashMap::new(), attributes: Vec::new() }
+    }
+
+    pub fn with_model(mut self, info: ModelInfo) -> Self {
+        self.models.insert(info.name.clone(), info);
+        self
+    }
+}
+
+impl ModelInfo {
+    pub fn new(name: impl Into<String>, capabilities: Vec<Capability>, attributes: Vec<Attribute>) -> Self {
+        Self { name: name.into(), capabilities, attributes }
+    }
+}

--- a/voice/src/model/scheduler.rs
+++ b/voice/src/model/scheduler.rs
@@ -1,0 +1,16 @@
+use super::{registry::{ModelRegistry, ServerInfo}, Capability, Attribute};
+
+pub struct ModelScheduler {
+    registry: ModelRegistry,
+}
+
+impl ModelScheduler {
+    pub fn new(registry: ModelRegistry) -> Self { Self { registry } }
+
+    pub fn select(&self, capability: Capability, prefer: Option<Attribute>) -> Option<&ServerInfo> {
+        self.registry.servers().iter().find(|s| {
+            s.models.values().any(|m| m.capabilities.contains(&capability))
+                && prefer.map_or(true, |attr| s.attributes.contains(&attr))
+        })
+    }
+}

--- a/voice/tests/model_routing.rs
+++ b/voice/tests/model_routing.rs
@@ -1,0 +1,26 @@
+use tokio_stream::StreamExt;
+use voice::model::{registry::{ModelRegistry, ModelInfo, ServerInfo}, scheduler::ModelScheduler, Capability, Attribute, MockModelClient, ModelClient};
+
+#[tokio::test]
+async fn select_server_by_capability() {
+    let mut registry = ModelRegistry::new();
+    let server = ServerInfo::new("http://host1:11434")
+        .with_model(ModelInfo::new("gemma", vec![Capability::Chat], vec![Attribute::Slow]));
+    registry.add_server(server.clone());
+    let scheduler = ModelScheduler::new(registry);
+    let selected = scheduler.select(Capability::Chat, None).unwrap();
+    assert_eq!(selected.address, server.address);
+}
+
+#[tokio::test]
+async fn stream_from_mock() {
+    let mock = MockModelClient::new(vec!["hi".into(), "there".into()], vec![1.0, 2.0]);
+    let mut stream = mock.stream_chat("mock", "hello").await.unwrap();
+    let mut out = Vec::new();
+    while let Some(chunk) = stream.next().await {
+        out.push(chunk.unwrap());
+    }
+    assert_eq!(out, vec!["hi", "there"]);
+    let emb = mock.embed("mock", "foo").await.unwrap();
+    assert_eq!(emb, vec![1.0, 2.0]);
+}


### PR DESCRIPTION
## Summary
- create `Capability`/`Attribute` tagging system
- implement `ModelRegistry` and `ModelScheduler`
- add `OllamaClient` and `MockModelClient` with streaming support
- expose new modules and write integration tests
- document reminder about "ants across the bridge"

## Testing
- `cargo check --workspace --all-targets`
- `cargo test --workspace --all-targets`

------
https://chatgpt.com/codex/tasks/task_e_6842572da0c8832098d551e2ded86b66