### PR TITLE
Add Genie abstractions with FondDuCoeur

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,3 +78,4 @@ This design supports cognitive modularity, streamability, emotional realism, and
 * Continuous integration runs `cargo check` and `cargo test` via `.github/workflows/ci.yml` on pushes and pull requests.
 * Keep this file updated with new reminders as the project evolves.
 * Remember "ants across the bridge" when connecting modules.
+* Use symbolic abstractions like `Genie`, `FondDuCoeur`, and `HereAndNow` when naming narrative components.

--- a/core/src/fond/mod.rs
+++ b/core/src/fond/mod.rs
@@ -1,0 +1,42 @@
+use async_trait::async_trait;
+use sensor::Sensation;
+
+use crate::genie::{Genie, GenieError};
+
+pub struct FondDuCoeur {
+    identity: String,
+    queue: Vec<Sensation>,
+}
+
+impl FondDuCoeur {
+    pub fn new() -> Self {
+        Self { identity: String::new(), queue: Vec::new() }
+    }
+
+    pub fn identity(&self) -> &str {
+        &self.identity
+    }
+}
+
+#[async_trait]
+impl Genie for FondDuCoeur {
+    async fn feel(&mut self, sensation: Sensation) {
+        self.queue.push(sensation);
+    }
+
+    async fn consult(&mut self) -> Result<String, GenieError> {
+        if !self.queue.is_empty() {
+            for s in self.queue.drain(..) {
+                if !self.identity.is_empty() {
+                    self.identity.push(' ');
+                }
+                self.identity.push_str(&s.how);
+            }
+        }
+        if self.identity.is_empty() {
+            Err(GenieError::Empty)
+        } else {
+            Ok(self.identity.clone())
+        }
+    }
+}

--- a/core/src/genie.rs
+++ b/core/src/genie.rs
@@ -1,0 +1,15 @@
+use async_trait::async_trait;
+use sensor::Sensation;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum GenieError {
+    #[error("no reflection available")] 
+    Empty,
+}
+
+#[async_trait]
+pub trait Genie {
+    async fn feel(&mut self, sensation: Sensation);
+    async fn consult(&mut self) -> Result<String, GenieError>;
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod witness;
 pub mod psyche;
+pub mod genie;
+pub mod fond;
 
 pub fn placeholder() {
     println!("core module initialized");
@@ -10,6 +12,7 @@ mod tests {
     use super::*;
     use sensor::Sensation;
     use voice::{ThinkMessage, VoiceAgent};
+    use crate::genie::{Genie, GenieError};
 
     struct MockNarrator;
 
@@ -23,9 +26,41 @@ mod tests {
     #[tokio::test]
     async fn bridge_sensation_to_think() {
         let mut witness = witness::WitnessAgent::default();
-        witness.ingest(Sensation { text: "hello".into() });
+        witness.ingest(Sensation::new("hello", None::<String>));
         let narrator = MockNarrator;
-        let msg = psyche::tick(&witness, &narrator).await;
+        let mut psyche = psyche::Psyche::new();
+        let msg = psyche.tick(&witness, &narrator).await;
+        assert_eq!(psyche.here_and_now, "hello");
         assert_eq!(msg, ThinkMessage { content: "echo: hello".into() });
+    }
+
+    struct FixedGenie {
+        summary: String,
+        felt: usize,
+    }
+
+    #[async_trait::async_trait]
+    impl Genie for FixedGenie {
+        async fn feel(&mut self, _s: Sensation) { self.felt += 1; }
+        async fn consult(&mut self) -> Result<String, GenieError> { Ok(self.summary.clone()) }
+    }
+
+    #[tokio::test]
+    async fn fixed_genie_works() {
+        let mut g = FixedGenie { summary: "ok".into(), felt: 0 };
+        g.feel(Sensation::new("hi", None::<String>)).await;
+        assert_eq!(g.felt, 1);
+        let out = g.consult().await.unwrap();
+        assert_eq!(out, "ok");
+    }
+
+    #[tokio::test]
+    async fn fond_updates_identity() {
+        let mut fond = fond::FondDuCoeur::new();
+        fond.feel(Sensation::new("I saw a bird", None::<String>)).await;
+        fond.feel(Sensation::new("It was blue", None::<String>)).await;
+        let summary = fond.consult().await.unwrap();
+        assert!(summary.contains("I saw a bird"));
+        assert!(summary.contains("It was blue"));
     }
 }

--- a/core/src/psyche.rs
+++ b/core/src/psyche.rs
@@ -1,9 +1,28 @@
+use crate::{fond::FondDuCoeur, witness::WitnessAgent, genie::Genie};
 use voice::{ThinkMessage, VoiceAgent};
 
-use crate::witness::WitnessAgent;
+pub struct Psyche {
+    pub here_and_now: String,
+    fond: FondDuCoeur,
+}
 
-pub async fn tick<V: VoiceAgent>(witness: &WitnessAgent, voice: &V) -> ThinkMessage {
-    let context = witness.last_text().unwrap_or("");
-    let content = voice.narrate(context).await;
-    ThinkMessage { content }
+impl Psyche {
+    pub fn new() -> Self {
+        Self { here_and_now: String::new(), fond: FondDuCoeur::new() }
+    }
+
+    pub async fn tick<V: VoiceAgent>(&mut self, witness: &WitnessAgent, voice: &V) -> ThinkMessage {
+        if let Some(s) = witness.last().cloned() {
+            let _ = self.fond.feel(s).await;
+            if let Ok(sum) = self.fond.consult().await {
+                self.here_and_now = sum;
+            }
+        }
+        let content = voice.narrate(&self.here_and_now).await;
+        ThinkMessage { content }
+    }
+
+    pub fn fond_identity(&self) -> &str {
+        self.fond.identity()
+    }
 }

--- a/core/src/witness.rs
+++ b/core/src/witness.rs
@@ -10,7 +10,7 @@ impl WitnessAgent {
         self.sensations.push(sensation);
     }
 
-    pub fn last_text(&self) -> Option<&str> {
-        self.sensations.last().map(|s| s.text.as_str())
+    pub fn last(&self) -> Option<&Sensation> {
+        self.sensations.last()
     }
 }

--- a/sensor/Cargo.toml
+++ b/sensor/Cargo.toml
@@ -11,3 +11,4 @@ thiserror = "1"
 async-trait = "0.1"
 log = "0.4"
 env_logger = "0.10"
+chrono = { version = "0.4", features = ["serde", "clock"] }

--- a/sensor/src/sensation.rs
+++ b/sensor/src/sensation.rs
@@ -1,4 +1,22 @@
+use chrono::{DateTime, Utc};
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Sensation {
-    pub text: String,
+    /// Timestamp of when the sensation was perceived
+    pub when: DateTime<Utc>,
+    /// Brief interpretation of how Pete feels about it
+    pub how: String,
+    /// Optional raw content of what was perceived
+    pub what: Option<String>,
+}
+
+impl Sensation {
+    /// Create a new sensation with the current timestamp
+    pub fn new(how: impl Into<String>, what: Option<impl Into<String>>) -> Self {
+        Self {
+            when: Utc::now(),
+            how: how.into(),
+            what: what.map(|w| w.into()),
+        }
+    }
 }

--- a/voice/src/context.rs
+++ b/voice/src/context.rs
@@ -1,0 +1,6 @@
+/// Utilities to compose prompts for the language model in Pete's first-person voice.
+pub fn compose_prompt(here_and_now: &str, identity: &str, input: &str) -> String {
+    format!(
+        "Pete Daringsby muses: {identity}\nCurrent thought: {here_and_now}\nUser said: {input}"
+    )
+}

--- a/voice/src/lib.rs
+++ b/voice/src/lib.rs
@@ -15,3 +15,4 @@ pub fn placeholder() {
 }
 
 pub mod model;
+pub mod context;


### PR DESCRIPTION
## Summary
- create `Genie` trait and `FondDuCoeur` implementation
- extend `Sensation` with timestamp, how, and what fields
- introduce `Psyche` with `here_and_now` using `FondDuCoeur`
- add prompt tools in `voice::context`
- update AGENTS reminders
- test symbolic layers and psyche updates

## Testing
- `cargo check --workspace --all-targets`
- `cargo test --workspace --all-targets`

------
https://chatgpt.com/codex/tasks/task_e_68426c466f508320a3c70cfae5347f5c