### PR TITLE
Implement Ollama client pool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,4 @@ members = [
   "tts",
   "sensor",
   "vision"
-]
+, "llm"]

--- a/llm/Cargo.toml
+++ b/llm/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "llm"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "1", features = ["full"] }
+async-trait = "0.1"
+thiserror = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio-stream = "0.1"
+futures-core = "0.3"
+ollama-rs = { version = "0.3", features = ["stream"] }
+
+
+[dev-dependencies]
+warp = "0.3"
+

--- a/llm/src/client.rs
+++ b/llm/src/client.rs
@@ -1,0 +1,48 @@
+use crate::traits::{LLMClient, LLMError};
+use async_trait::async_trait;
+use futures_core::Stream;
+use std::pin::Pin;
+use tokio_stream::StreamExt;
+
+use ollama_rs::{Ollama, generation::{completion::request::GenerationRequest, embeddings::request::GenerateEmbeddingsRequest}};
+
+pub struct OllamaClient {
+    inner: Ollama,
+}
+
+impl OllamaClient {
+    pub fn new(base_url: impl AsRef<str>) -> Self {
+        Self { inner: Ollama::try_new(base_url.as_ref()).unwrap() }
+    }
+}
+
+#[async_trait]
+impl LLMClient for OllamaClient {
+    async fn stream_chat(
+        &self,
+        model: &str,
+        prompt: &str,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<String, LLMError>> + Send>>, LLMError> {
+        let req = GenerationRequest::new(model.to_string(), prompt.to_string());
+        let stream = self.inner
+            .generate_stream(req)
+            .await
+            .map_err(|e| LLMError::Network(e.to_string()))?;
+        let mapped = stream.map(|res| {
+            res.map_err(|e| LLMError::Network(e.to_string())).map(|chunk| {
+                chunk.into_iter().map(|c| c.response).collect::<Vec<_>>().join("")
+            })
+        });
+        Ok(Box::pin(mapped))
+    }
+
+    async fn embed(&self, model: &str, input: &str) -> Result<Vec<f32>, LLMError> {
+        let req = GenerateEmbeddingsRequest::new(model.to_string(), input.into());
+        let res = self
+            .inner
+            .generate_embeddings(req)
+            .await
+            .map_err(|e| LLMError::Network(e.to_string()))?;
+        Ok(res.embeddings.into_iter().next().unwrap_or_default())
+    }
+}

--- a/llm/src/lib.rs
+++ b/llm/src/lib.rs
@@ -1,0 +1,9 @@
+pub mod client;
+pub mod model;
+pub mod pool;
+pub mod traits;
+
+pub use client::OllamaClient;
+pub use model::{LLMModel, LLMServer};
+pub use pool::LLMClientPool;
+pub use traits::{LLMAttribute, LLMCapability, LLMClient, LLMError};

--- a/llm/src/model.rs
+++ b/llm/src/model.rs
@@ -1,0 +1,39 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::traits::{LLMAttribute, LLMCapability, LLMClient};
+
+#[derive(Clone)]
+pub struct LLMModel {
+    pub name: String,
+    pub capabilities: Vec<LLMCapability>,
+}
+
+#[derive(Clone)]
+pub struct LLMServer {
+    pub client: Arc<dyn LLMClient>,
+    pub models: HashMap<String, LLMModel>,
+    pub attributes: Vec<LLMAttribute>,
+}
+
+impl LLMServer {
+    pub fn new(client: Arc<dyn LLMClient>) -> Self {
+        Self { client, models: HashMap::new(), attributes: Vec::new() }
+    }
+
+    pub fn with_attribute(mut self, attr: LLMAttribute) -> Self {
+        self.attributes.push(attr);
+        self
+    }
+
+    pub fn with_model(mut self, model: LLMModel) -> Self {
+        self.models.insert(model.name.clone(), model);
+        self
+    }
+}
+
+impl LLMModel {
+    pub fn new(name: impl Into<String>, capabilities: Vec<LLMCapability>) -> Self {
+        Self { name: name.into(), capabilities }
+    }
+}

--- a/llm/src/pool.rs
+++ b/llm/src/pool.rs
@@ -1,0 +1,47 @@
+use std::pin::Pin;
+use futures_core::Stream;
+
+use crate::model::LLMServer;
+use crate::traits::{LLMAttribute, LLMCapability, LLMError};
+
+pub struct LLMClientPool {
+    servers: Vec<LLMServer>,
+}
+
+impl LLMClientPool {
+    pub fn new() -> Self {
+        Self { servers: Vec::new() }
+    }
+
+    pub fn add_server(&mut self, server: LLMServer) {
+        self.servers.push(server);
+    }
+
+    fn find_server(&self, model: &str, attr: Option<LLMAttribute>) -> Option<&LLMServer> {
+        self.servers.iter().find(|s| {
+            s.models.contains_key(model) && attr.map_or(true, |a| s.attributes.contains(&a))
+        })
+    }
+
+    pub fn model_capabilities(&self, model: &str) -> Option<Vec<LLMCapability>> {
+        for server in &self.servers {
+            if let Some(m) = server.models.get(model) {
+                return Some(m.capabilities.clone());
+            }
+        }
+        None
+    }
+
+    pub fn has_attribute(&self, model: &str, attr: LLMAttribute) -> bool {
+        self.find_server(model, Some(attr)).is_some()
+    }
+
+    pub async fn stream_chat(
+        &self,
+        model: &str,
+        prompt: &str,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<String, LLMError>> + Send>>, LLMError> {
+        let server = self.find_server(model, None).ok_or(LLMError::ModelNotFound)?;
+        server.client.stream_chat(model, prompt).await
+    }
+}

--- a/llm/src/traits.rs
+++ b/llm/src/traits.rs
@@ -1,0 +1,42 @@
+use async_trait::async_trait;
+use futures_core::Stream;
+use std::pin::Pin;
+use thiserror::Error;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum LLMCapability {
+    Chat,
+    Embed,
+    Vision,
+    Code,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum LLMAttribute {
+    Fast,
+    Slow,
+    LowMemory,
+    Local,
+    Remote,
+}
+
+#[derive(Debug, Error)]
+pub enum LLMError {
+    #[error("network error: {0}")]
+    Network(String),
+    #[error("invalid response")]
+    InvalidResponse,
+    #[error("model not found")]
+    ModelNotFound,
+}
+
+#[async_trait]
+pub trait LLMClient: Send + Sync {
+    async fn stream_chat(
+        &self,
+        model: &str,
+        prompt: &str,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<String, LLMError>> + Send>>, LLMError>;
+
+    async fn embed(&self, model: &str, input: &str) -> Result<Vec<f32>, LLMError>;
+}

--- a/llm/tests/mock_server.rs
+++ b/llm/tests/mock_server.rs
@@ -1,0 +1,46 @@
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+use warp::Filter;
+use tokio::sync::mpsc;
+use serde_json::json;
+
+pub async fn spawn_mock_server(responses: Vec<&'static str>) -> (String, mpsc::Sender<()>) {
+    let (shutdown_tx, mut shutdown_rx) = mpsc::channel(1);
+    let queue = Arc::new(Mutex::new(VecDeque::from(responses)));
+    let shared = warp::any().map(move || queue.clone());
+
+    let route = warp::post()
+        .and(warp::path("api").and(warp::path("generate")))
+        .and(shared)
+        .map(|queue: Arc<Mutex<VecDeque<&'static str>>>| {
+            let (mut tx, body) = warp::hyper::Body::channel();
+            tokio::spawn(async move {
+                loop {
+                    let item = { queue.lock().unwrap().pop_front() };
+                    if let Some(r) = item {
+                        let done = queue.lock().unwrap().is_empty();
+                        let obj = json!({
+                            "model": "gemma3:27b",
+                            "created_at": "now",
+                            "response": r,
+                            "done": done
+                        });
+                        let line = serde_json::to_string(&obj).unwrap() + "\n";
+                        if tx.send_data(line.into()).await.is_err() {
+                            break;
+                        }
+                    } else {
+                        break;
+                    }
+                }
+            });
+            warp::reply::Response::new(body)
+        });
+
+    let (addr, server) = warp::serve(route).bind_with_graceful_shutdown(([127,0,0,1],0), async move {
+        shutdown_rx.recv().await;
+    });
+    tokio::spawn(server);
+    let url = format!("http://{}", addr);
+    (url, shutdown_tx)
+}

--- a/llm/tests/test_pool.rs
+++ b/llm/tests/test_pool.rs
@@ -1,0 +1,39 @@
+use tokio_stream::StreamExt;
+use std::sync::Arc;
+
+use llm::{LLMClientPool, LLMModel, LLMServer, LLMCapability, LLMAttribute, OllamaClient};
+
+mod mock_server;
+use mock_server::spawn_mock_server;
+
+#[tokio::test]
+async fn capability_and_tag_lookup() {
+    let client = Arc::new(OllamaClient::new("http://localhost:1234"));
+    let server = LLMServer::new(client)
+        .with_attribute(LLMAttribute::Fast)
+        .with_model(LLMModel::new("gemma3:27b", vec![LLMCapability::Chat, LLMCapability::Vision]));
+
+    let mut pool = LLMClientPool::new();
+    pool.add_server(server);
+
+    let caps = pool.model_capabilities("gemma3:27b").unwrap();
+    assert_eq!(caps, vec![LLMCapability::Chat, LLMCapability::Vision]);
+    assert!(pool.has_attribute("gemma3:27b", LLMAttribute::Fast));
+}
+
+#[tokio::test]
+async fn stream_chat_from_mock() {
+    let (url, shutdown) = spawn_mock_server(vec!["hi", "there"]).await;
+    let client = Arc::new(OllamaClient::new(&url));
+    let server = LLMServer::new(client).with_model(LLMModel::new("gemma3:27b", vec![LLMCapability::Chat]));
+    let mut pool = LLMClientPool::new();
+    pool.add_server(server);
+
+    let mut stream = pool.stream_chat("gemma3:27b", "hello").await.unwrap();
+    let mut out = Vec::new();
+    while let Some(c) = stream.next().await {
+        out.push(c.unwrap());
+    }
+    assert_eq!(out, vec!["hi".to_string(), "there".to_string()]);
+    let _ = shutdown.send(()).await;
+}


### PR DESCRIPTION
## Summary
- add new `llm` crate exposing an Ollama-backed client pool
- support model capability/attribute lookup and streaming chat
- include tests using a warp-based mock server

## Testing
- `cargo check --workspace --all-targets`
- `cargo test --workspace --all-targets`


------
https://chatgpt.com/codex/tasks/task_e_68426e54361c83208c668a53ed2e71d2