### PR TITLE
Implement TTS sentence streamer and compose config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 OLLAMA_URL=http://localhost:11434
-COQUI_TTS_URL=http://localhost:5002
+COQUI_URL=http://localhost:5002
+SPEAKER=Royston Min
 QDRANT_URL=http://localhost:6333
 NEO4J_URI=bolt://localhost:7687
 NEO4J_USER=neo4j

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,3 +79,4 @@ This design supports cognitive modularity, streamability, emotional realism, and
 * Keep this file updated with new reminders as the project evolves.
 * Remember "ants across the bridge" when connecting modules.
 * Use symbolic abstractions like `Genie`, `FondDuCoeur`, and `HereAndNow` when naming narrative components.
+* Use `docker-compose.yml` to start the local Coqui TTS server.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: "3.9"
+services:
+  tts:
+    image: ghcr.io/coqui-ai/tts
+    ports:
+      - "5002:5002"
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
+      - COQUI_TOS_AGREED=1
+      - TTS_MODEL="tts_models/en/ljspeech/tacotron2-DDC"
+      - VOCODER_MODEL="vocoder_models/en/ljspeech/hifigan_v1"
+    command: ["TTS/server/server.py", "--model_name", "tts_models/en/vctk/vits"]
+    runtime: nvidia
+    volumes:
+      - ./tts:/root/.local/share
+      - /etc/timezone:/etc/timezone:ro
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - count: all
+              capabilities: [gpu]

--- a/docs/task5_tts_sentence_streamer.md
+++ b/docs/task5_tts_sentence_streamer.md
@@ -1,0 +1,46 @@
+# Task 5: TTS Sentence Streamer
+
+This document describes how to stream a sentence from the LLM and speak it using Coqui TTS.
+
+## Overview
+
+1. Stream text from `gemma3:27b` using the `llm` crate.
+2. Detect the first complete sentence and extract any emoji.
+3. Send the cleaned sentence to a Coqui TTS server.
+4. Receive audio bytes and return them to the caller.
+
+## Docker Compose
+
+Run the Coqui TTS server locally using the following service definition:
+
+```yaml
+tts:
+  image: ghcr.io/coqui-ai/tts
+  ports:
+    - "5002:5002"
+  environment:
+    - NVIDIA_VISIBLE_DEVICES=all
+    - COQUI_TOS_AGREED=1
+    - TTS_MODEL="tts_models/en/ljspeech/tacotron2-DDC"
+    - VOCODER_MODEL="vocoder_models/en/ljspeech/hifigan_v1"
+  command: ["TTS/server/server.py", "--model_name", "tts_models/en/vctk/vits"]
+  runtime: nvidia
+  volumes:
+    - ./tts:/root/.local/share
+    - /etc/timezone:/etc/timezone:ro
+  deploy:
+    resources:
+      reservations:
+        devices:
+          - count: all
+            capabilities: [gpu]
+```
+
+Set the following environment variables in `.env` or your configuration:
+
+```dotenv
+COQUI_URL=http://tts:5002
+SPEAKER=Royston Min
+```
+
+Use this file when wiring TTS playback into the Voice Genie.

--- a/tts/Cargo.toml
+++ b/tts/Cargo.toml
@@ -11,3 +11,11 @@ thiserror = "1"
 async-trait = "0.1"
 log = "0.4"
 env_logger = "0.10"
+tokio-stream = "0.1"
+reqwest = { version = "0.11", features = ["json"] }
+regex = "1"
+emojito = "0.3"
+llm = { path = "../llm" }
+
+[dev-dependencies]
+warp = "0.3"

--- a/tts/src/lib.rs
+++ b/tts/src/lib.rs
@@ -1,3 +1,75 @@
-pub fn placeholder() {
-    println!("tts module initialized");
+use emojito::find_emoji;
+use llm::{OllamaClient, LLMError, LLMClient};
+use regex::Regex;
+use reqwest::Client;
+use std::env;
+use tokio_stream::StreamExt;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum TTSError {
+    #[error(transparent)]
+    LLM(#[from] LLMError),
+    #[error(transparent)]
+    Http(#[from] reqwest::Error),
+}
+
+pub type Result<T> = std::result::Result<T, TTSError>;
+
+fn strip_emojis(input: &str) -> (String, Vec<String>) {
+    let found = find_emoji(input);
+    let mut cleaned = input.to_string();
+    for e in &found {
+        cleaned = cleaned.replace(e.glyph, "");
+    }
+    let emojis = found.iter().map(|e| e.glyph.to_string()).collect();
+    (cleaned, emojis)
+}
+
+pub async fn speak_from_llm(prompt: &str) -> Result<Vec<u8>> {
+    let ollama_url = env::var("OLLAMA_URL").unwrap_or_else(|_| "http://localhost:11434".into());
+    let coqui_url = env::var("COQUI_URL").unwrap_or_else(|_| "http://localhost:5002".into());
+    let speaker = env::var("SPEAKER").unwrap_or_else(|_| "default".into());
+
+    let llm = OllamaClient::new(&ollama_url);
+    let mut stream = llm.stream_chat("gemma3:27b", prompt).await?;
+    let re = Regex::new(r"[.!?]\s").unwrap();
+    let mut buffer = String::new();
+    let mut sentence = None;
+
+    while let Some(chunk) = stream.next().await {
+        let piece = chunk?;
+        buffer.push_str(&piece);
+        if let Some(mat) = re.find(&buffer) {
+            sentence = Some(buffer[..mat.end()].to_string());
+            break;
+        }
+    }
+
+    let sentence = sentence.unwrap_or(buffer);
+    let (clean, emojis) = strip_emojis(&sentence);
+    let emotion = if emojis.is_empty() { None } else { Some(emojis.join("")) };
+
+    #[derive(serde::Serialize)]
+    struct TtsRequest<'a> {
+        text: &'a str,
+        speaker_id: &'a str,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        emotion: Option<String>,
+    }
+
+    let payload = TtsRequest {
+        text: clean.trim(),
+        speaker_id: &speaker,
+        emotion,
+    };
+
+    let client = Client::new();
+    let res = client
+        .post(format!("{}/api/tts", coqui_url))
+        .json(&payload)
+        .send()
+        .await?;
+    let bytes = res.bytes().await?;
+    Ok(bytes.to_vec())
 }

--- a/tts/tests/mock_llm_server.rs
+++ b/tts/tests/mock_llm_server.rs
@@ -1,0 +1,46 @@
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+use warp::Filter;
+use tokio::sync::mpsc;
+use serde_json::json;
+
+pub async fn spawn_mock_server(responses: Vec<&'static str>) -> (String, mpsc::Sender<()>) {
+    let (shutdown_tx, mut shutdown_rx) = mpsc::channel(1);
+    let queue = Arc::new(Mutex::new(VecDeque::from(responses)));
+    let shared = warp::any().map(move || queue.clone());
+
+    let route = warp::post()
+        .and(warp::path("api").and(warp::path("generate")))
+        .and(shared)
+        .map(|queue: Arc<Mutex<VecDeque<&'static str>>>| {
+            let (mut tx, body) = warp::hyper::Body::channel();
+            tokio::spawn(async move {
+                loop {
+                    let item = { queue.lock().unwrap().pop_front() };
+                    if let Some(r) = item {
+                        let done = queue.lock().unwrap().is_empty();
+                        let obj = json!({
+                            "model": "gemma3:27b",
+                            "created_at": "now",
+                            "response": r,
+                            "done": done
+                        });
+                        let line = serde_json::to_string(&obj).unwrap() + "\n";
+                        if tx.send_data(line.into()).await.is_err() {
+                            break;
+                        }
+                    } else {
+                        break;
+                    }
+                }
+            });
+            warp::reply::Response::new(body)
+        });
+
+    let (addr, server) = warp::serve(route).bind_with_graceful_shutdown(([127,0,0,1],0), async move {
+        shutdown_rx.recv().await;
+    });
+    tokio::spawn(server);
+    let url = format!("http://{}", addr);
+    (url, shutdown_tx)
+}

--- a/tts/tests/mock_tts_server.rs
+++ b/tts/tests/mock_tts_server.rs
@@ -1,0 +1,17 @@
+use warp::Filter;
+use tokio::sync::mpsc;
+
+pub async fn spawn_mock_tts(response: &'static [u8]) -> (String, mpsc::Sender<()>) {
+    let (shutdown_tx, mut shutdown_rx) = mpsc::channel(1);
+    let data = response.to_vec();
+    let route = warp::post()
+        .and(warp::path("api").and(warp::path("tts")))
+        .map(move || warp::reply::Response::new(data.clone().into()));
+
+    let (addr, server) = warp::serve(route).bind_with_graceful_shutdown(([127,0,0,1],0), async move {
+        shutdown_rx.recv().await;
+    });
+    tokio::spawn(server);
+    let url = format!("http://{}", addr);
+    (url, shutdown_tx)
+}

--- a/tts/tests/test_speak.rs
+++ b/tts/tests/test_speak.rs
@@ -1,0 +1,23 @@
+use std::env;
+
+use tts::speak_from_llm;
+
+mod mock_tts_server;
+mod mock_llm_server;
+use mock_tts_server::spawn_mock_tts;
+use mock_llm_server::spawn_mock_server;
+
+#[tokio::test]
+async fn speak_from_llm_pipeline() {
+    let (llm_url, llm_shutdown) = spawn_mock_server(vec!["Hello world! 😊"]).await;
+    let (tts_url, tts_shutdown) = spawn_mock_tts(b"wav").await;
+    env::set_var("OLLAMA_URL", &llm_url);
+    env::set_var("COQUI_URL", &tts_url);
+    env::set_var("SPEAKER", "test");
+
+    let bytes = speak_from_llm("hi").await.unwrap();
+    assert_eq!(bytes, b"wav");
+
+    let _ = llm_shutdown.send(()).await;
+    let _ = tts_shutdown.send(()).await;
+}


### PR DESCRIPTION
## Summary
- document Task 5 TTS Sentence Streamer with Docker setup
- add docker-compose service for Coqui TTS
- expose COQUI_URL and SPEAKER in `.env.example`
- implement `speak_from_llm` in the `tts` crate
- add unit tests for the TTS pipeline
- remind contributors about Coqui in `AGENTS.md`

## Testing
- `cargo check --workspace --all-targets`
- `cargo test --workspace --all-targets`


------
https://chatgpt.com/codex/tasks/task_e_6842718912f0832092faeae132333dcf