### PR TITLE
Implement heartbeat and websocket sensors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,3 +81,4 @@ This design supports cognitive modularity, streamability, emotional realism, and
 * Use symbolic abstractions like `Genie`, `FondDuCoeur`, and `HereAndNow` when naming narrative components.
 * Use `docker-compose.yml` to start the local Coqui TTS server.
 * Memory is stored in Qdrant and Neo4j using a GraphRAG approach.
+* Sensors implement the `Sensor` trait and stream `Sensation` objects through an `mpsc` channel.

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,3 +16,6 @@ log = "0.4"
 env_logger = "0.10"
 sensor = { path = "../sensor" }
 voice = { path = "../voice" }
+memory = { path = "../memory" }
+llm = { path = "../llm" }
+futures-util = "0.3"

--- a/core/src/witness.rs
+++ b/core/src/witness.rs
@@ -1,4 +1,6 @@
 use sensor::Sensation;
+use memory::{self, Experience, Memory, MemoryError};
+use llm::traits::{LLMClient, LLMError};
 
 #[derive(Default)]
 pub struct WitnessAgent {
@@ -12,5 +14,22 @@ impl WitnessAgent {
 
     pub fn last(&self) -> Option<&Sensation> {
         self.sensations.last()
+    }
+
+    pub async fn feel<C: LLMClient>(
+        &mut self,
+        sensation: Sensation,
+        llm: &C,
+    ) -> Result<Experience, LLMError> {
+        self.ingest(sensation.clone());
+        memory::explain_and_embed(sensation, llm).await
+    }
+
+    pub async fn witness<M: Memory>(
+        &self,
+        exp: Experience,
+        memory: &M,
+    ) -> Result<(), MemoryError> {
+        memory.store(exp).await
     }
 }

--- a/sensor/Cargo.toml
+++ b/sensor/Cargo.toml
@@ -12,3 +12,7 @@ async-trait = "0.1"
 log = "0.4"
 env_logger = "0.10"
 chrono = { version = "0.4", features = ["serde", "clock"] }
+tokio-stream = "0.1"
+tokio-tungstenite = "0.20"
+futures-util = "0.3"
+url = "2"

--- a/sensor/src/heartbeat.rs
+++ b/sensor/src/heartbeat.rs
@@ -1,0 +1,30 @@
+use async_trait::async_trait;
+use tokio::{sync::mpsc, time::{self, Duration}};
+use chrono::Utc;
+
+use crate::{Sensation, Sensor};
+
+pub struct HeartbeatSensor {
+    interval: Duration,
+}
+
+impl HeartbeatSensor {
+    pub fn new(interval: Duration) -> Self {
+        Self { interval }
+    }
+}
+
+#[async_trait]
+impl Sensor for HeartbeatSensor {
+    async fn run(&mut self, tx: mpsc::Sender<Sensation>) {
+        let mut ticker = time::interval(self.interval);
+        loop {
+            ticker.tick().await;
+            let when = Utc::now();
+            let msg = format!("Heartbeat at {} - I'm alive", when.to_rfc3339());
+            if tx.send(Sensation::new(msg, None::<String>)).await.is_err() {
+                break;
+            }
+        }
+    }
+}

--- a/sensor/src/lib.rs
+++ b/sensor/src/lib.rs
@@ -1,6 +1,10 @@
 pub mod sensation;
+pub mod sensor;
+pub mod heartbeat;
+pub mod ws;
 
 pub use sensation::Sensation;
+pub use sensor::Sensor;
 
 pub fn placeholder() {
     println!("sensor module initialized");

--- a/sensor/src/sensor.rs
+++ b/sensor/src/sensor.rs
@@ -1,0 +1,9 @@
+use async_trait::async_trait;
+use tokio::sync::mpsc;
+
+use crate::Sensation;
+
+#[async_trait]
+pub trait Sensor: Send {
+    async fn run(&mut self, tx: mpsc::Sender<Sensation>);
+}

--- a/sensor/src/ws.rs
+++ b/sensor/src/ws.rs
@@ -1,0 +1,34 @@
+use async_trait::async_trait;
+use tokio::{net::TcpListener, sync::mpsc};
+use futures_util::StreamExt;
+use tokio_tungstenite::{accept_async, tungstenite::Message};
+use std::net::SocketAddr;
+
+use crate::{Sensation, Sensor};
+
+pub struct WebSocketSensor {
+    addr: SocketAddr,
+}
+
+impl WebSocketSensor {
+    pub fn new(addr: SocketAddr) -> Self {
+        Self { addr }
+    }
+}
+
+#[async_trait]
+impl Sensor for WebSocketSensor {
+    async fn run(&mut self, tx: mpsc::Sender<Sensation>) {
+        let listener = TcpListener::bind(self.addr).await.expect("bind ws");
+        while let Ok((stream, _)) = listener.accept().await {
+            let tx = tx.clone();
+            tokio::spawn(async move {
+                let ws_stream = accept_async(stream).await.expect("ws accept");
+                let (_, mut read) = ws_stream.split();
+                while let Some(Ok(Message::Text(text))) = read.next().await {
+                    let _ = tx.send(Sensation::new("user message", Some(text))).await;
+                }
+            });
+        }
+    }
+}

--- a/sensor/tests/heartbeat.rs
+++ b/sensor/tests/heartbeat.rs
@@ -1,0 +1,12 @@
+use sensor::{heartbeat::HeartbeatSensor, Sensor};
+use tokio::sync::mpsc;
+use std::time::Duration;
+
+#[tokio::test]
+async fn heartbeat_emits() {
+    let (tx, mut rx) = mpsc::channel(2);
+    let mut hb = HeartbeatSensor::new(Duration::from_millis(100));
+    tokio::spawn(async move { hb.run(tx).await; });
+    let s = rx.recv().await.unwrap();
+    assert!(s.how.contains("Heartbeat"));
+}

--- a/sensor/tests/ws.rs
+++ b/sensor/tests/ws.rs
@@ -1,0 +1,20 @@
+use sensor::{ws::WebSocketSensor, Sensor};
+use tokio::sync::mpsc;
+use tokio_tungstenite::connect_async;
+use futures_util::SinkExt;
+use url::Url;
+use std::net::SocketAddr;
+
+#[tokio::test]
+async fn ws_emits_message() {
+    let addr: SocketAddr = "127.0.0.1:32154".parse().unwrap();
+    let (tx, mut rx) = mpsc::channel(1);
+    let mut ws = WebSocketSensor::new(addr);
+    tokio::spawn(async move { ws.run(tx).await; });
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    let url = Url::parse(&format!("ws://{}", addr)).unwrap();
+    let (mut stream, _) = connect_async(url).await.unwrap();
+    stream.send(tokio_tungstenite::tungstenite::Message::Text("hi".into())).await.unwrap();
+    let s = rx.recv().await.unwrap();
+    assert_eq!(s.what.as_deref(), Some("hi"));
+}


### PR DESCRIPTION
## Summary
- add Sensor trait with HeartbeatSensor and WebSocketSensor implementations
- expose new witness methods to transform sensations into experiences and store them
- cover the new behaviour with unit tests
- mention Sensor trait usage in AGENTS notes

## Testing
- `cargo check --workspace --all-targets`
- `cargo test --workspace --all-targets`

------
https://chatgpt.com/codex/tasks/task_e_68427c095408832095e84188f8a257d2