### PR TITLE
Implement chat voice and conversation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,3 +82,4 @@ This design supports cognitive modularity, streamability, emotional realism, and
 * Use `docker-compose.yml` to start the local Coqui TTS server.
 * Memory is stored in Qdrant and Neo4j using a GraphRAG approach.
 * Sensors implement the `Sensor` trait and stream `Sensation` objects through an `mpsc` channel.
+* Conversation history should retain only a recent tail to keep prompts concise.

--- a/voice/src/conversation.rs
+++ b/voice/src/conversation.rs
@@ -1,0 +1,36 @@
+use serde::{Serialize, Deserialize};
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Role {
+    Assistant,
+    User,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Message {
+    pub role: Role,
+    pub content: String,
+}
+
+pub struct Conversation {
+    messages: Vec<Message>,
+    max_len: usize,
+}
+
+impl Conversation {
+    pub fn new(max_len: usize) -> Self {
+        Self { messages: Vec::new(), max_len }
+    }
+
+    pub fn push(&mut self, role: Role, content: impl Into<String>) {
+        self.messages.push(Message { role, content: content.into() });
+        if self.messages.len() > self.max_len {
+            let excess = self.messages.len() - self.max_len;
+            self.messages.drain(0..excess);
+        }
+    }
+
+    pub fn tail(&self) -> &[Message] {
+        &self.messages
+    }
+}

--- a/voice/src/lib.rs
+++ b/voice/src/lib.rs
@@ -16,3 +16,55 @@ pub fn placeholder() {
 
 pub mod model;
 pub mod context;
+pub mod conversation;
+use std::sync::Mutex;
+use conversation::{Conversation, Role};
+use model::ModelClient;
+use futures_util::StreamExt;
+
+pub struct ChatVoice<C: ModelClient> {
+    llm: C,
+    conversation: Mutex<Conversation>,
+    model: String,
+}
+
+impl<C: ModelClient> ChatVoice<C> {
+    pub fn new(llm: C, model: impl Into<String>, max_history: usize) -> Self {
+        Self { llm, conversation: Mutex::new(Conversation::new(max_history)), model: model.into() }
+    }
+
+    pub fn receive_user(&self, msg: impl Into<String>) {
+        let mut conv = self.conversation.lock().unwrap();
+        conv.push(Role::User, msg);
+    }
+}
+
+#[async_trait]
+impl<C: ModelClient + Send + Sync> VoiceAgent for ChatVoice<C> {
+    async fn narrate(&self, context: &str) -> String {
+        let prompt = {
+            let conv = self.conversation.lock().unwrap();
+            let mut prompt = format!("You are a storyteller narrating the life of Pete Daringsby. Narrate in the voice of Pete from the first person. Current thought: {context}\n");
+            for m in conv.tail() {
+                match m.role {
+                    Role::Assistant => prompt.push_str(&format!("Pete: {}\n", m.content)),
+                    Role::User => prompt.push_str(&format!("User: {}\n", m.content)),
+                }
+            }
+            prompt
+        };
+        let mut stream = match self.llm.stream_chat(&self.model, &prompt).await {
+            Ok(s) => s,
+            Err(_) => return String::new(),
+        };
+        let mut response = String::new();
+        while let Some(chunk) = stream.next().await {
+            if let Ok(text) = chunk {
+                response.push_str(&text);
+            }
+        }
+        let mut conv = self.conversation.lock().unwrap();
+        conv.push(Role::Assistant, response.clone());
+        response
+    }
+}

--- a/voice/tests/chat_voice.rs
+++ b/voice/tests/chat_voice.rs
@@ -1,0 +1,10 @@
+use voice::{ChatVoice, VoiceAgent, model::MockModelClient};
+
+#[tokio::test]
+async fn voice_updates_conversation() {
+    let llm = MockModelClient::new(vec!["hello".into()], vec![]);
+    let voice = ChatVoice::new(llm, "mock", 3);
+    voice.receive_user("hi");
+    let out = voice.narrate("test").await;
+    assert_eq!(out, "hello");
+}

--- a/voice/tests/conversation.rs
+++ b/voice/tests/conversation.rs
@@ -1,0 +1,11 @@
+use voice::conversation::{Conversation, Role};
+
+#[test]
+fn tail_truncates() {
+    let mut c = Conversation::new(2);
+    c.push(Role::User, "hi");
+    c.push(Role::Assistant, "yo");
+    c.push(Role::User, "bye");
+    assert_eq!(c.tail().len(), 2);
+    assert_eq!(c.tail()[0].content, "yo");
+}


### PR DESCRIPTION
## Summary
- add conversation type with Role enum
- implement ChatVoice that keeps conversation tail and streams chat
- test conversation tailing and ChatVoice
- document conversation tail guideline in AGENTS

## Testing
- `cargo check --workspace --all-targets`
- `cargo test --workspace --all-targets`

------
https://chatgpt.com/codex/tasks/task_e_6842929ecfd483209fabdd0f4b204d9d