### PR TITLE
Add websocket sensor server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,8 @@ members = [
   "voice",
   "tts",
   "sensor",
-  "vision"
-, "llm"]
+  "vision",
+  "sensation-server",
+  "sensation-tester",
+  "llm"
+]

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This repository contains the initial Rust workspace layout for the Pete Daringsb
 - **tts** – text-to-speech integration
 - **sensor** – audio, geolocation and filesystem listeners
 - **vision** – webcam and face recognition helpers
+- **sensation-server** – WebSocket backend with a simple dev panel
+- **sensation-tester** – CLI tool for sending mock sensor input
 
 Run `cargo check` in the repository root to verify that all crates compile.
 CI on GitHub automatically runs `cargo check` and `cargo test` for pushes and pull requests.

--- a/docs/package_overview.md
+++ b/docs/package_overview.md
@@ -17,3 +17,5 @@ This document lists each crate in the Pete Daringsby workspace with a short desc
 - **llm** – language model client and routing utilities.
 - **net** – networking helpers.
 - **vision** – stubs for future computer vision work.
+- **sensation-server** – axum based WebSocket server exposing `/ws` and `/devpanel`.
+- **sensation-tester** – CLI utility to send mock sensor events.

--- a/docs/task6_sensor_ws_pipeline.md
+++ b/docs/task6_sensor_ws_pipeline.md
@@ -1,0 +1,14 @@
+# Task 6: Sensor to Sensation WebSocket Pipeline
+
+This task introduces a simple WebSocket server that converts browser sensor events into `Sensation` structs. A small dev panel is served from `/devpanel` and streams geolocation and text input to the backend.
+
+Run the server:
+```bash
+cargo run -p sensation-server
+```
+Then open [http://localhost:8000/devpanel](http://localhost:8000/devpanel).
+
+A CLI tester is also available:
+```bash
+cargo run -p sensation-tester -- --geo 45.0 122.0
+```

--- a/sensation-server/Cargo.toml
+++ b/sensation-server/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "sensation-server"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+axum = { version = "0.7", features = ["ws", "json"] }
+tokio = { version = "1", features = ["full"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
+chrono = { version = "0.4", features = ["serde"] }
+
+# for tests
+tokio-tungstenite = { version = "0.20", optional = true }
+
+[lib]
+name = "sensation_server"
+path = "src/lib.rs"
+
+[[bin]]
+name = "sensation-server"
+path = "src/main.rs"
+
+[dev-dependencies]
+futures-util = "0.3"
+tokio-tungstenite = "0.20"

--- a/sensation-server/src/devpanel.html
+++ b/sensation-server/src/devpanel.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head><title>Dev Panel</title></head>
+<body>
+<h1>Sensor Tester</h1>
+<textarea id='text' rows='2' cols='30'></textarea>
+<button onclick='sendText()'>Send Text</button>
+<pre id='log'></pre>
+<script>
+const ws = new WebSocket('ws://localhost:8000/ws');
+ws.onmessage = ev => {
+  const log = document.getElementById('log');
+  log.textContent += ev.data + "\n";
+};
+function sendText() {
+  const val = document.getElementById('text').value;
+  ws.send(JSON.stringify({sensor_type:'text', value: val}));
+}
+setInterval(()=>{
+  navigator.geolocation.getCurrentPosition(pos=>{
+    ws.send(JSON.stringify({sensor_type:'geolocation', lat:pos.coords.latitude, lon:pos.coords.longitude}));
+  });
+},5000);
+</script>
+</body>
+</html>

--- a/sensation-server/src/lib.rs
+++ b/sensation-server/src/lib.rs
@@ -1,0 +1,55 @@
+use axum::{extract::ws::{WebSocket, WebSocketUpgrade, Message}, routing::get, Router};
+use axum::response::IntoResponse;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use tracing::info;
+
+#[derive(Debug, Deserialize)]
+#[serde(tag="sensor_type", rename_all="lowercase")]
+pub enum SensorInput {
+    Geolocation { lat: f64, lon: f64 },
+    Audio { transcript: String },
+    Image { base64: String },
+    Text { value: String },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Sensation {
+    pub how: String,
+    pub when: DateTime<Utc>,
+}
+
+pub async fn ws_handler(ws: WebSocketUpgrade) -> impl IntoResponse {
+    ws.on_upgrade(handle_socket)
+}
+
+async fn handle_socket(mut socket: WebSocket) {
+    while let Some(Ok(msg)) = socket.recv().await {
+        if let Message::Text(text) = msg {
+            if let Ok(input) = serde_json::from_str::<SensorInput>(&text) {
+                let how = match input {
+                    SensorInput::Geolocation { lat, lon } => format!("geo {lat},{lon}"),
+                    SensorInput::Audio { transcript } => format!("audio {transcript}"),
+                    SensorInput::Image { .. } => "image".to_string(),
+                    SensorInput::Text { value } => value,
+                };
+                let sensation = Sensation { how, when: Utc::now() };
+                let _ = socket
+                    .send(Message::Text(serde_json::to_string(&sensation).unwrap()))
+                    .await;
+                info!(?sensation, "received");
+            }
+        }
+    }
+}
+
+async fn dev_panel() -> impl IntoResponse {
+    const HTML: &str = include_str!("devpanel.html");
+    HTML
+}
+
+pub fn router() -> Router {
+    Router::new()
+        .route("/ws", get(ws_handler))
+        .route("/devpanel", get(dev_panel))
+}

--- a/sensation-server/src/main.rs
+++ b/sensation-server/src/main.rs
@@ -1,0 +1,13 @@
+use sensation_server::router;
+use std::net::SocketAddr;
+use tracing::info;
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt::init();
+    let app = router();
+    let addr = SocketAddr::from(([127, 0, 0, 1], 8000));
+    info!("listening on {}", addr);
+    let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
+    axum::serve(listener, app).await.unwrap();
+}

--- a/sensation-server/tests/ws_test.rs
+++ b/sensation-server/tests/ws_test.rs
@@ -1,0 +1,23 @@
+use tokio_tungstenite::connect_async;
+use tokio::net::TcpListener;
+use axum::{routing::get, Router};
+use futures_util::{SinkExt, StreamExt};
+use tokio::time::{timeout, Duration};
+use sensation_server::ws_handler;
+
+#[tokio::test]
+async fn websocket_echo_sensation() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let app = Router::new().route("/ws", get(ws_handler));
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let url = format!("ws://{}/ws", addr);
+    let (mut ws, _) = connect_async(url).await.unwrap();
+    let msg = r#"{\"sensor_type\":\"geolocation\",\"lat\":1.0,\"lon\":2.0}"#;
+    ws.send(tokio_tungstenite::tungstenite::Message::Text(msg.into())).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    ws.close(None).await.unwrap();
+}

--- a/sensation-tester/Cargo.toml
+++ b/sensation-tester/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "sensation-tester"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "1", features = ["full"] }
+clap = { version = "4", features = ["derive"] }
+tokio-tungstenite = "0.20"
+serde_json = "1"
+futures-util = "0.3"

--- a/sensation-tester/src/main.rs
+++ b/sensation-tester/src/main.rs
@@ -1,0 +1,30 @@
+use clap::Parser;
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::Message;
+use futures_util::SinkExt;
+
+#[derive(Parser)]
+struct Args {
+    #[arg(long)]
+    geo: Option<Vec<f64>>,
+    #[arg(long)]
+    text: Option<String>,
+    #[arg(default_value = "ws://localhost:8000/ws")]
+    url: String,
+}
+
+#[tokio::main]
+async fn main() {
+    let args = Args::parse();
+    let (mut ws, _) = connect_async(&args.url).await.expect("connect");
+    if let Some(v) = args.geo {
+        if v.len() == 2 {
+            let msg = serde_json::json!({"sensor_type":"geolocation","lat":v[0],"lon":v[1]});
+            ws.send(Message::Text(msg.to_string())).await.unwrap();
+        }
+    }
+    if let Some(t) = args.text {
+        let msg = serde_json::json!({"sensor_type":"text","value":t});
+        ws.send(Message::Text(msg.to_string())).await.unwrap();
+    }
+}


### PR DESCRIPTION
## Summary
- add new `sensation-server` with a dev panel and WebSocket endpoint
- introduce CLI utility `sensation-tester`
- document sensor pipeline and list new crates

## Testing
- `cargo check`
- `cargo test -p sensation-server --test ws_test -- --nocapture`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6842df741b148320af3a4ceca2e3736e