### PR TITLE
Implement streaming prompt runner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 OLLAMA_URL=http://localhost:11434
+OLLAMA_MODEL=gemma3:27b
 COQUI_URL=http://localhost:5002
 SPEAKER=Royston Min
 QDRANT_URL=http://localhost:6333

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,7 @@ This design supports cognitive modularity, streamability, emotional realism, and
 * Remember "ants across the bridge" when connecting modules.
 * Use symbolic abstractions like `Genie`, `FondDuCoeur`, and `HereAndNow` when naming narrative components.
 * Use `docker-compose.yml` to start the local Coqui TTS server.
+* Configure `OLLAMA_URL` and `OLLAMA_MODEL` in your `.env` for LLM calls.
 * Memory is stored in Qdrant and Neo4j using a GraphRAG approach.
 * Sensors implement the `Sensor` trait and stream `Sensation` objects through an `mpsc` channel.
 * Conversation history should retain only a recent tail to keep prompts concise.

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -132,7 +132,10 @@ mod tests {
             llm::traits::LLMError,
         > {
             use futures_util::stream;
-            Ok(Box::pin(stream::iter(vec![Ok("summary".to_string())])))
+            Ok(Box::pin(stream::iter(vec![
+                Ok("summary one. ".to_string()),
+                Ok("summary two".to_string()),
+            ])))
         }
 
         async fn embed(
@@ -155,6 +158,7 @@ mod tests {
             .feel(Sensation::new("beat", None::<String>), &llm)
             .await
             .unwrap();
+        assert_eq!(exp.explanation, "summary one.");
         witness.witness(exp, &mem).await.unwrap();
         assert_eq!(mem.inner.lock().unwrap().len(), 1);
     }

--- a/llm/Cargo.toml
+++ b/llm/Cargo.toml
@@ -12,6 +12,7 @@ serde_json = "1"
 tokio-stream = "0.1"
 futures-core = "0.3"
 ollama-rs = { version = "0.3", features = ["stream"] }
+regex = "1"
 
 
 [dev-dependencies]

--- a/llm/src/lib.rs
+++ b/llm/src/lib.rs
@@ -1,9 +1,11 @@
 pub mod client;
 pub mod model;
 pub mod pool;
+pub mod runner;
 pub mod traits;
 
 pub use client::OllamaClient;
 pub use model::{LLMModel, LLMServer};
 pub use pool::LLMClientPool;
+pub use runner::{client_from_env, model_from_env, run_from_env, stream_first_sentence};
 pub use traits::{LLMAttribute, LLMCapability, LLMClient, LLMError};

--- a/llm/src/runner.rs
+++ b/llm/src/runner.rs
@@ -1,0 +1,47 @@
+use crate::traits::{LLMClient, LLMError};
+use crate::OllamaClient;
+use tokio_stream::StreamExt;
+use regex::Regex;
+
+/// Stream a prompt and capture each token and the first complete sentence.
+pub async fn stream_first_sentence<C: LLMClient>(
+    client: &C,
+    model: &str,
+    prompt: &str,
+) -> Result<(Vec<String>, String), LLMError> {
+    let mut stream = client.stream_chat(model, prompt).await?;
+    let re = Regex::new(r"[.!?]\s").unwrap();
+    let mut tokens = Vec::new();
+    let mut buffer = String::new();
+    let mut sentence = None;
+    while let Some(chunk) = stream.next().await {
+        let token = chunk?;
+        buffer.push_str(&token);
+        tokens.push(token);
+        if sentence.is_none() {
+            if let Some(m) = re.find(&buffer) {
+                sentence = Some(buffer[..m.end()].to_string());
+            }
+        }
+    }
+    let sentence = sentence.unwrap_or_else(|| buffer.clone());
+    Ok((tokens, sentence))
+}
+
+/// Create an [`OllamaClient`] using the `OLLAMA_URL` environment variable.
+pub fn client_from_env() -> OllamaClient {
+    let url = std::env::var("OLLAMA_URL").unwrap_or_else(|_| "http://localhost:11434".into());
+    OllamaClient::new(&url)
+}
+
+/// Read the chat model name from the `OLLAMA_MODEL` environment variable.
+pub fn model_from_env() -> String {
+    std::env::var("OLLAMA_MODEL").unwrap_or_else(|_| "gemma3:27b".into())
+}
+
+/// Convenience helper to stream a prompt using environment configuration.
+pub async fn run_from_env(prompt: &str) -> Result<(Vec<String>, String), LLMError> {
+    let client = client_from_env();
+    let model = model_from_env();
+    stream_first_sentence(&client, &model, prompt).await
+}

--- a/llm/tests/test_runner.rs
+++ b/llm/tests/test_runner.rs
@@ -1,0 +1,24 @@
+use llm::{runner::stream_first_sentence, OllamaClient};
+use tokio_stream::StreamExt;
+
+mod mock_server;
+use mock_server::spawn_mock_server;
+
+#[tokio::test]
+async fn capture_first_sentence() {
+    let (url, shutdown) = spawn_mock_server(vec!["Hello ", "world.", " More."]).await;
+    let client = OllamaClient::new(&url);
+    let (tokens, sentence) = stream_first_sentence(&client, "gemma3:27b", "test")
+        .await
+        .unwrap();
+    assert_eq!(
+        tokens,
+        vec![
+            "Hello ".to_string(),
+            "world.".to_string(),
+            " More.".to_string()
+        ]
+    );
+    assert_eq!(sentence, "Hello world.");
+    let _ = shutdown.send(()).await;
+}


### PR DESCRIPTION
## Summary
- add Ollama prompt runner for streaming responses
- expose environment helpers for model and server URL
- use runner to get first sentence in memory
- tweak witness test to check sentence output
- document new OLLAMA_MODEL variable

## Testing
- `cargo check`
- `cargo test -p llm -p memory -p core --no-run`

------
https://chatgpt.com/codex/tasks/task_e_6842e8a78e38832098ee2f41a97f7ad3