### PR TITLE
Introduce think-silently tag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,9 @@ This design supports cognitive modularity, streamability, emotional realism, and
 * Witness and Voice are sibling subagents managed by `Psyche`.
 * Use symbolic abstractions like `Genie`, `FondDuCoeur`, and `HereAndNow` when naming narrative components.
 * Use `docker-compose.yml` to start the local Coqui TTS server.
+* Voice responses are direct speech; use `<think-silently>` tags for internal thoughts.
+* Keep spoken replies brief so listeners can interject.
+* Witness should relay `<think-silently>` content as Pete thinking to himself.
 * Configure `OLLAMA_URL` and `OLLAMA_MODEL` in your `.env` for LLM calls.
 * Memory is stored in Qdrant and Neo4j using a GraphRAG approach.
 * Sensors implement the `Sensor` trait and stream `Sensation` objects through an `mpsc` channel.

--- a/README.md
+++ b/README.md
@@ -16,3 +16,32 @@ This repository contains the initial Rust workspace layout for the Pete Daringsb
 
 Run `cargo check` in the repository root to verify that all crates compile.
 CI on GitHub automatically runs `cargo check` and `cargo test` for pushes and pull requests.
+
+## Setup
+
+1. Install Rust (stable) and Docker.
+2. Copy `.env.example` to `.env` and set `OLLAMA_URL`, `OLLAMA_MODEL`, `COQUI_URL` and `SPEAKER`.
+3. Start the Coqui TTS server with `docker-compose up -d tts`.
+4. Optional: run Whisper locally for ASR and configure its address in `.env`.
+
+## Running
+
+Start the WebSocket backend:
+
+```bash
+cargo run -p sensation-server
+```
+
+Use `sensation-tester` to send mock sensor input:
+
+```bash
+cargo run -p sensation-tester -- --help
+```
+
+## Testing
+
+Run the full test suite with:
+
+```bash
+cargo test
+```

--- a/voice/tests/chat_voice.rs
+++ b/voice/tests/chat_voice.rs
@@ -2,9 +2,20 @@ use voice::{ChatVoice, VoiceAgent, model::MockModelClient};
 
 #[tokio::test]
 async fn voice_updates_conversation() {
-    let llm = MockModelClient::new(vec!["<say>ok</say>".into()], vec![]);
+    let llm = MockModelClient::new(vec!["ok".into()], vec![]);
     let voice = ChatVoice::new(llm, "mock", 3);
     voice.receive_user("hi");
     let out = voice.narrate("test").await;
+    assert_eq!(out.think.content, "");
     assert_eq!(out.say.unwrap().content, "ok");
+}
+
+#[tokio::test]
+async fn parses_think_silently() {
+    let llm = MockModelClient::new(vec!["hi <think-silently>secret</think-silently>".into()], vec![]);
+    let voice = ChatVoice::new(llm, "mock", 3);
+    voice.receive_user("yo");
+    let out = voice.narrate("ctx").await;
+    assert_eq!(out.think.content, "secret");
+    assert_eq!(out.say.unwrap().content, "hi");
 }


### PR DESCRIPTION
## Summary
- invert speech logic in `ChatVoice` to use `<think-silently>` tags
- update unit tests for new tag behaviour
- document setup and run instructions
- clarify development notes on voice prompts

## Testing
- `cargo test`
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_684356deddd08320a53f654dad2ac59e