### PR TITLE
Enable multi-host Ollama scheduling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,6 @@
 OLLAMA_URL=http://localhost:11434
+# Optional comma separated fallback hosts
+OLLAMA_URLS=http://localhost:11434
 OLLAMA_MODEL=gemma3:27b
 COQUI_URL=http://localhost:5002
 SPEAKER=Royston Min

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,7 @@ This design supports cognitive modularity, streamability, emotional realism, and
 * Keep spoken replies brief so listeners can interject.
 * Witness should relay `<think-silently>` content as Pete thinking to himself.
 * Configure `OLLAMA_URL` and `OLLAMA_MODEL` in your `.env` for LLM calls.
+* Use `OLLAMA_URLS` for a comma list of fallback hosts.
 * Memory is stored in Qdrant and Neo4j using a GraphRAG approach.
 * Sensors implement the `Sensor` trait and stream `Sensation` objects through an `mpsc` channel.
 * Conversation history should retain only a recent tail to keep prompts concise.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ CI on GitHub automatically runs `cargo check` and `cargo test` for pushes and pu
 
 | Name | Purpose |
 | --- | --- |
-| `OLLAMA_URL` | Base URL of the Ollama server |
+| `OLLAMA_URL` | Base URL of the primary Ollama server |
+| `OLLAMA_URLS` | Comma separated list of Ollama hosts for load balancing |
 | `OLLAMA_MODEL` | LLM model identifier |
 | `COQUI_URL` | Base URL of the Coqui TTS server |
 | `SPEAKER` | Coqui speaker name |

--- a/llm/src/lib.rs
+++ b/llm/src/lib.rs
@@ -15,6 +15,6 @@ pub use client::OllamaClient;
 pub use model::{LLMModel, LLMServer};
 pub use pool::LLMClientPool;
 pub use pool::LLMClientPool as LinguisticScheduler; // alias for narrative terminology
-pub use runner::{client_from_env, model_from_env, run_from_env, stream_first_sentence};
+pub use runner::{client_from_env, model_from_env, scheduler_from_env, run_from_env, stream_first_sentence};
 pub use task::LinguisticTask;
 pub use traits::{LLMAttribute, LLMCapability, LLMClient, LLMError};


### PR DESCRIPTION
## Summary
- add `add_ollama_host` helper and round-robin load balancing
- expose `scheduler_from_env` for parsing `OLLAMA_URLS`
- document `OLLAMA_URLS` in README and `.env.example`
- note new env variable in AGENTS
- test round robin scheduling

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6843e330b6248320ad78fa882593a34e