### PR TITLE
Implement latency-aware scheduling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,5 +96,6 @@ This design supports cognitive modularity, streamability, emotional realism, and
   * It allows setting the reflection format (natural, JSON, or hybrid).
 * Refer to the `llm` crate as the "language processor".
 * The `LinguisticScheduler` selects a model based on task capabilities.
+* The `LinguisticScheduler` profiles each server's latency and favors faster hosts.
 * The `WitnessAgent` should call the language processor directly to build the `HereAndNow`, not via `Voice`.
   * Use `max_perceptions` and `max_memories` to keep prompts short.

--- a/llm/Cargo.toml
+++ b/llm/Cargo.toml
@@ -11,6 +11,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio-stream = "0.1"
 futures-core = "0.3"
+futures-util = "0.3"
 ollama-rs = { version = "0.3", features = ["stream"] }
 regex = "1"
 

--- a/llm/src/pool.rs
+++ b/llm/src/pool.rs
@@ -1,27 +1,46 @@
-use std::{pin::Pin, collections::HashMap};
+use std::{pin::Pin, time::Instant, sync::{Arc, Mutex}};
 use futures_core::Stream;
+use futures_util::ready;
+use std::task::{Context, Poll};
 
 use crate::model::{LLMServer, LLMModel};
 use crate::client::OllamaClient;
-use std::sync::Arc;
 use crate::traits::{LLMAttribute, LLMCapability, LLMError};
 use crate::task::LinguisticTask;
 
 pub struct LLMClientPool {
     servers: Vec<LLMServer>,
-    next: HashMap<String, usize>,
+    profiles: Vec<Arc<Mutex<ServerProfile>>>,
+}
+
+#[derive(Default)]
+struct ServerProfile {
+    latency_ms: f64,
+    samples: u32,
+}
+
+impl ServerProfile {
+    fn record(&mut self, sample: f64) {
+        self.samples += 1;
+        if self.samples == 1 {
+            self.latency_ms = sample;
+        } else {
+            let n = self.samples as f64;
+            self.latency_ms = ((n - 1.0) / n) * self.latency_ms + (sample / n);
+        }
+    }
 }
 
 impl LLMClientPool {
     pub fn new() -> Self {
-        Self { servers: Vec::new(), next: HashMap::new() }
+        Self { servers: Vec::new(), profiles: Vec::new() }
     }
 
     pub fn add_server(&mut self, server: LLMServer) {
         self.servers.push(server);
+        self.profiles.push(Arc::new(Mutex::new(ServerProfile::default())));
     }
 
-    /// Add an Ollama host with the provided models and attributes.
     pub fn add_ollama_host(
         &mut self,
         url: impl AsRef<str>,
@@ -39,8 +58,12 @@ impl LLMClientPool {
         self.add_server(server);
     }
 
-    fn find_server(&mut self, model: &str, attr: Option<LLMAttribute>) -> Option<&LLMServer> {
-        let matching: Vec<_> = self
+    fn find_server(
+        &mut self,
+        model: &str,
+        attr: Option<LLMAttribute>,
+    ) -> Option<(usize, &LLMServer)> {
+        let mut matching: Vec<_> = self
             .servers
             .iter()
             .enumerate()
@@ -51,10 +74,13 @@ impl LLMClientPool {
         if matching.is_empty() {
             return None;
         }
-        let idx = self.next.entry(model.to_string()).or_insert(0);
-        let server = &self.servers[matching[*idx % matching.len()].0];
-        *idx += 1;
-        Some(server)
+        matching.sort_by(|a, b| {
+            let la = self.profiles[a.0].lock().unwrap().latency_ms;
+            let lb = self.profiles[b.0].lock().unwrap().latency_ms;
+            la.partial_cmp(&lb).unwrap_or(std::cmp::Ordering::Equal)
+        });
+        let idx = matching[0].0;
+        Some((idx, &self.servers[idx]))
     }
 
     pub fn model_capabilities(&self, model: &str) -> Option<Vec<LLMCapability>> {
@@ -70,7 +96,6 @@ impl LLMClientPool {
         self.find_server(model, Some(attr)).is_some()
     }
 
-    /// Choose a model that satisfies all required capabilities and optional attribute.
     pub fn choose_model(
         &self,
         caps: &[LLMCapability],
@@ -88,7 +113,6 @@ impl LLMClientPool {
         None
     }
 
-    /// Execute a [`LinguisticTask`] by selecting an appropriate model.
     pub async fn run_task(
         &mut self,
         task: &LinguisticTask,
@@ -104,7 +128,45 @@ impl LLMClientPool {
         model: &str,
         prompt: &str,
     ) -> Result<Pin<Box<dyn Stream<Item = Result<String, LLMError>> + Send>>, LLMError> {
-        let server = self.find_server(model, None).ok_or(LLMError::ModelNotFound)?;
-        server.client.stream_chat(model, prompt).await
+        let (idx, server) = self
+            .find_server(model, None)
+            .ok_or(LLMError::ModelNotFound)?;
+        let start = Instant::now();
+        let stream = server.client.stream_chat(model, prompt).await?;
+        let profile = Arc::clone(&self.profiles[idx]);
+        let timed = ProfilingStream {
+            inner: stream,
+            start,
+            recorded: false,
+            profile,
+        };
+        Ok(Box::pin(timed))
+    }
+}
+
+struct ProfilingStream<S> {
+    inner: S,
+    start: Instant,
+    recorded: bool,
+    profile: Arc<Mutex<ServerProfile>>,
+}
+
+impl<S: Stream<Item = Result<String, LLMError>> + Unpin> Stream for ProfilingStream<S> {
+    type Item = Result<String, LLMError>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let item = ready!(Pin::new(&mut self.inner).poll_next(cx));
+        if let Some(res) = item {
+            if !self.recorded {
+                let elapsed = self.start.elapsed().as_millis() as f64;
+                if let Ok(mut p) = self.profile.lock() {
+                    p.record(elapsed);
+                }
+                self.recorded = true;
+            }
+            Poll::Ready(Some(res))
+        } else {
+            Poll::Ready(None)
+        }
     }
 }

--- a/llm/tests/test_pool.rs
+++ b/llm/tests/test_pool.rs
@@ -81,3 +81,38 @@ async fn round_robin_across_hosts() {
     let _ = shutdown1.send(()).await;
     let _ = shutdown2.send(()).await;
 }
+use mock_server::spawn_delayed_mock_server;
+
+#[tokio::test]
+async fn prefers_fast_server_after_profiling() {
+    let (fast_url, shutdown_fast) = spawn_delayed_mock_server(vec!["fast", "fast"], 10).await;
+    let (slow_url, shutdown_slow) = spawn_delayed_mock_server(vec!["slow", "slow"], 100).await;
+    let client1 = Arc::new(OllamaClient::new(&fast_url));
+    let client2 = Arc::new(OllamaClient::new(&slow_url));
+    let server1 = LLMServer::new(client1)
+        .with_attribute(LLMAttribute::Fast)
+        .with_model(LLMModel::new("gemma3:27b", vec![LLMCapability::Chat]));
+    let server2 = LLMServer::new(client2)
+        .with_attribute(LLMAttribute::Slow)
+        .with_model(LLMModel::new("gemma3:27b", vec![LLMCapability::Chat]));
+    let mut pool = LLMClientPool::new();
+    pool.add_server(server1);
+    pool.add_server(server2);
+
+    let mut s1 = pool
+        .run_task(&LinguisticTask::new("hi", vec![LLMCapability::Chat]).prefer_attribute(LLMAttribute::Fast))
+        .await
+        .unwrap();
+    let _ = s1.next().await;
+    let mut s2 = pool
+        .run_task(&LinguisticTask::new("hi", vec![LLMCapability::Chat]).prefer_attribute(LLMAttribute::Slow))
+        .await
+        .unwrap();
+    let _ = s2.next().await;
+
+    let mut result = pool.stream_chat("gemma3:27b", "hello").await.unwrap();
+    let token = result.next().await.unwrap().unwrap();
+    assert_eq!(token, "fast".to_string());
+    let _ = shutdown_fast.send(()).await;
+    let _ = shutdown_slow.send(()).await;
+}


### PR DESCRIPTION
## Summary
- profile each LLM server's latency in `LinguisticScheduler`
- prefer the fastest server when routing requests
- add delayed mock server helpers for tests
- test fast server preference logic
- document latency profiling in `AGENTS.md`

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6843e5ae65488320940f4c66e1a33fc0