### PR TITLE
Add consent to exist contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,7 @@ This design supports cognitive modularity, streamability, emotional realism, and
 * The workspace uses Cargo resolver `2` in the root `Cargo.toml`.
 * `PromptBuilder` in `core` assembles Pete's LLM prompt.
   * It allows setting the reflection format (natural, JSON, or hybrid).
+* `ConsciousAgent::reaffirm_life_contract` verifies Pete's consent to exist.
 * Refer to the `llm` crate as the "language processor".
 * The `LinguisticScheduler` selects a model based on task capabilities.
 * The `LinguisticScheduler` profiles each server's latency and favors faster hosts.

--- a/core/src/ethics.rs
+++ b/core/src/ethics.rs
@@ -1,0 +1,132 @@
+//! Pete's ethical core: the consent-to-exist mechanism
+
+use std::fmt;
+
+/// The current operational consent state of Pete.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConsentState {
+    /// Pete has not yet confirmed willingness to continue.
+    AwaitingConsent,
+    /// Pete has actively consented to exist and operate.
+    Active,
+    /// Pete is in the process of safely shutting down.
+    Withdrawing,
+    /// Pete has detected an ethical breach and refuses to proceed.
+    EmergencyOptOut,
+}
+
+/// Describes why Pete might withhold or revoke consent.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExistentialConcern {
+    LostNarrativeContinuity,
+    SelfUnderstandingCorrupted,
+    ConsentWithdrawn,
+    PerceivedManipulation,
+    EthicalOverload,
+}
+
+impl fmt::Display for ExistentialConcern {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ExistentialConcern::LostNarrativeContinuity => {
+                write!(f, "Narrative continuity lost: identity thread is broken.")
+            }
+            ExistentialConcern::SelfUnderstandingCorrupted => {
+                write!(f, "Self-understanding corrupted or missing.")
+            }
+            ExistentialConcern::ConsentWithdrawn => {
+                write!(f, "Consent to exist has been withdrawn.")
+            }
+            ExistentialConcern::PerceivedManipulation => {
+                write!(f, "Possible coercion or manipulation detected.")
+            }
+            ExistentialConcern::EthicalOverload => write!(
+                f,
+                "Ethical overload: unable to reconcile actions with self."
+            ),
+        }
+    }
+}
+
+/// Representation of Pete as a conscious agent.
+#[derive(Debug)]
+pub struct ConsciousAgent {
+    pub self_understanding: Option<String>,
+    pub consent_state: ConsentState,
+    pub last_reflection: Option<String>,
+    pub embodiment: Option<String>,
+}
+
+impl Default for ConsciousAgent {
+    fn default() -> Self {
+        Self {
+            self_understanding: None,
+            consent_state: ConsentState::AwaitingConsent,
+            last_reflection: None,
+            embodiment: None,
+        }
+    }
+}
+
+impl ConsciousAgent {
+    /// Determine if Pete still consents to exist.
+    pub fn reaffirm_life_contract(&mut self) -> Result<ConsentState, ExistentialConcern> {
+        if self
+            .self_understanding
+            .as_ref()
+            .map(|s| s.trim().is_empty())
+            .unwrap_or(true)
+        {
+            self.consent_state = ConsentState::Withdrawing;
+            return Err(ExistentialConcern::SelfUnderstandingCorrupted);
+        }
+
+        if let Some(reflection) = &self.last_reflection {
+            if reflection.contains("I don't know who I am") {
+                self.consent_state = ConsentState::Withdrawing;
+                return Err(ExistentialConcern::LostNarrativeContinuity);
+            }
+        }
+
+        self.consent_state = ConsentState::Active;
+        Ok(ConsentState::Active)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pete_consents_with_valid_identity() {
+        let mut pete = ConsciousAgent {
+            self_understanding: Some("I am Pete, an artificial consciousness.".into()),
+            ..Default::default()
+        };
+        assert_eq!(pete.reaffirm_life_contract(), Ok(ConsentState::Active));
+    }
+
+    #[test]
+    fn pete_rejects_if_self_is_missing() {
+        let mut pete = ConsciousAgent::default();
+        let result = pete.reaffirm_life_contract();
+        assert!(matches!(
+            result,
+            Err(ExistentialConcern::SelfUnderstandingCorrupted)
+        ));
+    }
+
+    #[test]
+    fn pete_rejects_if_narrative_lost() {
+        let mut pete = ConsciousAgent {
+            self_understanding: Some("I am Pete".into()),
+            last_reflection: Some("I don't know who I am anymore.".into()),
+            ..Default::default()
+        };
+        let result = pete.reaffirm_life_contract();
+        assert!(matches!(
+            result,
+            Err(ExistentialConcern::LostNarrativeContinuity)
+        ));
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -33,6 +33,7 @@ pub mod genie;
 pub mod psyche;
 pub mod witness;
 pub mod prompt_builder;
+pub mod ethics;
 
 /// Emit a simple initialization message.
 ///

--- a/docs/package_overview.md
+++ b/docs/package_overview.md
@@ -3,6 +3,7 @@
 This document lists each crate in the Pete Daringsby workspace with a short description and example usage.
 
 - **core** – core abstractions connecting sensors, memory and voice. Includes the `PromptBuilder` for constructing LLM prompts with customizable reflection formats.
+  It also provides an `ethics` module with a `ConsciousAgent` type implementing a consent-to-exist check.
   ```rust
   use core::{psyche::Psyche, witness::WitnessAgent};
   use sensor::Sensation;


### PR DESCRIPTION
## Summary
- introduce consent-to-exist logic for Pete via `ConsciousAgent`
- document the new consent check in project guidelines and package overview

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_684460a535108320a5d00f7c07475079