### PR TITLE
Improve workspace docs

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,8 +1,8 @@
 //! Core abstractions for Pete Daringsby's mind.
 //!
-//! This crate wires together the [`WitnessAgent`] which perceives incoming
-//! [`Sensation`](sensor::Sensation)s with the [`Psyche`] that summarizes them
-//! using a [`Genie`] implementation such as [`FondDuCoeur`].
+//! This crate wires together the [`witness::WitnessAgent`] which perceives
+//! [`sensor::Sensation`] values with the [`psyche::Psyche`] that summarizes them
+//! using a [`fond::FondDuCoeur`] or other [`genie::Genie`] implementation.
 //!
 //! ```
 //! use core::{psyche::Psyche, witness::WitnessAgent};
@@ -28,12 +28,12 @@
 //! ```
 #![doc(test(no_crate_inject))]
 
+pub mod ethics;
 pub mod fond;
 pub mod genie;
+pub mod prompt_builder;
 pub mod psyche;
 pub mod witness;
-pub mod prompt_builder;
-pub mod ethics;
 
 /// Emit a simple initialization message.
 ///
@@ -57,9 +57,15 @@ mod tests {
     impl VoiceAgent for MockNarrator {
         async fn narrate(&self, context: &str) -> VoiceOutput {
             VoiceOutput {
-                think: ThinkMessage { content: format!("echo: {context}") },
-                say: Some(SayMessage { content: context.into() }),
-                emote: Some(EmoteMessage { emoji: "😊".into() }),
+                think: ThinkMessage {
+                    content: format!("echo: {context}"),
+                },
+                say: Some(SayMessage {
+                    content: context.into(),
+                }),
+                emote: Some(EmoteMessage {
+                    emoji: "😊".into()
+                }),
             }
         }
     }
@@ -74,8 +80,18 @@ mod tests {
         let msg = psyche.tick().await;
         assert_eq!(psyche.here_and_now, "hello");
         assert_eq!(msg.think.content, "echo: hello");
-        assert_eq!(msg.say, Some(SayMessage { content: "hello".into() }));
-        assert_eq!(msg.emote, Some(EmoteMessage { emoji: "😊".into() }));
+        assert_eq!(
+            msg.say,
+            Some(SayMessage {
+                content: "hello".into()
+            })
+        );
+        assert_eq!(
+            msg.emote,
+            Some(EmoteMessage {
+                emoji: "😊".into()
+            })
+        );
     }
 
     struct FixedGenie {

--- a/llm/src/model.rs
+++ b/llm/src/model.rs
@@ -1,3 +1,10 @@
+//! Data structures describing available language models and servers.
+//!
+//! A [`LLMServer`] wraps a concrete [`LLMClient`]
+//! implementation and the set of [`LLMModel`]s it exposes. These types are used
+//! by the scheduler in [`crate::pool`] to select an appropriate model for a
+//! [`crate::task::LinguisticTask`].
+
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -18,7 +25,11 @@ pub struct LLMServer {
 
 impl LLMServer {
     pub fn new(client: Arc<dyn LLMClient>) -> Self {
-        Self { client, models: HashMap::new(), attributes: Vec::new() }
+        Self {
+            client,
+            models: HashMap::new(),
+            attributes: Vec::new(),
+        }
     }
 
     pub fn with_attribute(mut self, attr: LLMAttribute) -> Self {
@@ -34,6 +45,9 @@ impl LLMServer {
 
 impl LLMModel {
     pub fn new(name: impl Into<String>, capabilities: Vec<LLMCapability>) -> Self {
-        Self { name: name.into(), capabilities }
+        Self {
+            name: name.into(),
+            capabilities,
+        }
     }
 }

--- a/llm/src/runner.rs
+++ b/llm/src/runner.rs
@@ -1,8 +1,8 @@
 use crate::traits::{LLMClient, LLMError};
-use crate::{OllamaClient, LLMClientPool, LLMServer, LLMModel, LLMCapability};
+use crate::{LLMCapability, LLMClientPool, LLMModel, LLMServer, OllamaClient};
+use regex::Regex;
 use std::sync::Arc;
 use tokio_stream::StreamExt;
-use regex::Regex;
 
 /// Stream a prompt and capture each token and the first complete sentence.
 pub async fn stream_first_sentence<C: LLMClient>(
@@ -40,7 +40,7 @@ pub fn model_from_env() -> String {
     std::env::var("OLLAMA_MODEL").unwrap_or_else(|_| "gemma3:27b".into())
 }
 
-/// Create a [`LinguisticScheduler`] from the `OLLAMA_URLS` environment variable.
+/// Create a [`crate::LinguisticScheduler`] from the `OLLAMA_URLS` environment variable.
 /// The variable should contain a comma separated list of base URLs. If not set,
 /// `OLLAMA_URL` is used instead.
 pub fn scheduler_from_env() -> LLMClientPool {
@@ -51,10 +51,8 @@ pub fn scheduler_from_env() -> LLMClientPool {
     let mut pool = LLMClientPool::new();
     for url in urls.split(',') {
         let client = Arc::new(OllamaClient::new(url.trim()));
-        let server = LLMServer::new(client).with_model(LLMModel::new(
-            model.clone(),
-            vec![LLMCapability::Chat],
-        ));
+        let server = LLMServer::new(client)
+            .with_model(LLMModel::new(model.clone(), vec![LLMCapability::Chat]));
         pool.add_server(server);
     }
     pool

--- a/llm/src/traits.rs
+++ b/llm/src/traits.rs
@@ -1,8 +1,14 @@
+//! Core traits and enums describing language model capabilities.
+//!
+//! Other crates use these abstractions to remain agnostic over the specific LLM
+//! backend being used.
+
 use async_trait::async_trait;
 use futures_core::Stream;
 use std::pin::Pin;
 use thiserror::Error;
 
+/// Features that a model can support.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum LLMCapability {
     Chat,
@@ -11,6 +17,7 @@ pub enum LLMCapability {
     Code,
 }
 
+/// Qualitative attributes describing a server or model.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum LLMAttribute {
     Fast,
@@ -20,6 +27,7 @@ pub enum LLMAttribute {
     Remote,
 }
 
+/// Errors produced by an [`LLMClient`].
 #[derive(Debug, Error)]
 pub enum LLMError {
     #[error("network error: {0}")]
@@ -30,6 +38,7 @@ pub enum LLMError {
     ModelNotFound,
 }
 
+/// Interface for talking to a language model server.
 #[async_trait]
 pub trait LLMClient: Send + Sync {
     async fn stream_chat(

--- a/tts/src/lib.rs
+++ b/tts/src/lib.rs
@@ -19,6 +19,7 @@ pub enum TTSError {
 /// Convenience result type used throughout this crate.
 pub type Result<T> = std::result::Result<T, TTSError>;
 
+/// Remove emoji characters from `input` while returning them separately.
 fn strip_emojis(input: &str) -> (String, Vec<String>) {
     let found = find_emoji(input);
     let mut cleaned = input.to_string();

--- a/voice/src/context.rs
+++ b/voice/src/context.rs
@@ -1,6 +1,9 @@
-/// Utilities to compose prompts for the language model in Pete's first-person voice.
+//! Helper functions for building first-person prompts.
+//!
+//! These utilities keep the voice of Pete consistent across calls to the
+//! language model.
+
+/// Compose a simple prompt referencing current context and user input.
 pub fn compose_prompt(here_and_now: &str, identity: &str, input: &str) -> String {
-    format!(
-        "Pete Daringsby muses: {identity}\nCurrent thought: {here_and_now}\nUser said: {input}"
-    )
+    format!("Pete Daringsby muses: {identity}\nCurrent thought: {here_and_now}\nUser said: {input}")
 }

--- a/voice/src/conversation.rs
+++ b/voice/src/conversation.rs
@@ -1,35 +1,53 @@
-use serde::{Serialize, Deserialize};
+//! Lightweight conversation history tracker.
+//!
+//! The [`Conversation`] struct stores a bounded list of [`Message`]s exchanged
+//! between Pete (the assistant) and the user. This context is used by
+//! [`ChatVoice`](crate::ChatVoice) when crafting prompts.
 
+use serde::{Deserialize, Serialize};
+
+/// Speaker role of a [`Message`].
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Role {
     Assistant,
     User,
 }
 
+/// Single utterance in a conversation.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Message {
     pub role: Role,
     pub content: String,
 }
 
+/// Rolling window of recent [`Message`]s.
 pub struct Conversation {
     messages: Vec<Message>,
     max_len: usize,
 }
 
 impl Conversation {
+    /// Create an empty conversation with a maximum length.
     pub fn new(max_len: usize) -> Self {
-        Self { messages: Vec::new(), max_len }
+        Self {
+            messages: Vec::new(),
+            max_len,
+        }
     }
 
+    /// Append a new message and drop oldest if capacity is exceeded.
     pub fn push(&mut self, role: Role, content: impl Into<String>) {
-        self.messages.push(Message { role, content: content.into() });
+        self.messages.push(Message {
+            role,
+            content: content.into(),
+        });
         if self.messages.len() > self.max_len {
             let excess = self.messages.len() - self.max_len;
             self.messages.drain(0..excess);
         }
     }
 
+    /// Return the slice of currently stored messages.
     pub fn tail(&self) -> &[Message] {
         &self.messages
     }

--- a/voice/src/model/registry.rs
+++ b/voice/src/model/registry.rs
@@ -1,7 +1,13 @@
+//! Registry of available language model servers.
+//!
+//! The [`ModelRegistry`] type tracks [`ServerInfo`] entries which list the
+//! supported models and attributes for each host.
+
 use std::collections::HashMap;
 
 use super::{Attribute, Capability};
 
+/// Metadata describing a single model.
 #[derive(Clone)]
 pub struct ModelInfo {
     pub name: String,
@@ -9,6 +15,7 @@ pub struct ModelInfo {
     pub attributes: Vec<Attribute>,
 }
 
+/// Configuration for a running server and the models it provides.
 #[derive(Clone)]
 pub struct ServerInfo {
     pub address: String,
@@ -16,23 +23,41 @@ pub struct ServerInfo {
     pub attributes: Vec<Attribute>,
 }
 
+/// Collection of known LLM servers.
 pub struct ModelRegistry {
     servers: Vec<ServerInfo>,
 }
 
 impl ModelRegistry {
-    pub fn new() -> Self { Self { servers: Vec::new() } }
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self {
+            servers: Vec::new(),
+        }
+    }
 
-    pub fn add_server(&mut self, server: ServerInfo) { self.servers.push(server); }
+    /// Add a server definition.
+    pub fn add_server(&mut self, server: ServerInfo) {
+        self.servers.push(server);
+    }
 
-    pub fn servers(&self) -> &[ServerInfo] { &self.servers }
+    /// Return all registered servers.
+    pub fn servers(&self) -> &[ServerInfo] {
+        &self.servers
+    }
 }
 
 impl ServerInfo {
+    /// Create a server entry with no models.
     pub fn new(address: impl Into<String>) -> Self {
-        Self { address: address.into(), models: HashMap::new(), attributes: Vec::new() }
+        Self {
+            address: address.into(),
+            models: HashMap::new(),
+            attributes: Vec::new(),
+        }
     }
 
+    /// Associate a model definition with this server.
     pub fn with_model(mut self, info: ModelInfo) -> Self {
         self.models.insert(info.name.clone(), info);
         self
@@ -40,7 +65,15 @@ impl ServerInfo {
 }
 
 impl ModelInfo {
-    pub fn new(name: impl Into<String>, capabilities: Vec<Capability>, attributes: Vec<Attribute>) -> Self {
-        Self { name: name.into(), capabilities, attributes }
+    pub fn new(
+        name: impl Into<String>,
+        capabilities: Vec<Capability>,
+        attributes: Vec<Attribute>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            capabilities,
+            attributes,
+        }
     }
 }

--- a/voice/src/model/scheduler.rs
+++ b/voice/src/model/scheduler.rs
@@ -1,15 +1,27 @@
-use super::{registry::{ModelRegistry, ServerInfo}, Capability, Attribute};
+//! Simple scheduler that selects a server by capability and optional attribute.
 
+use super::{
+    registry::{ModelRegistry, ServerInfo},
+    Attribute, Capability,
+};
+
+/// Chooses which server to use for a given request.
 pub struct ModelScheduler {
     registry: ModelRegistry,
 }
 
 impl ModelScheduler {
-    pub fn new(registry: ModelRegistry) -> Self { Self { registry } }
+    /// Wrap an existing [`ModelRegistry`].
+    pub fn new(registry: ModelRegistry) -> Self {
+        Self { registry }
+    }
 
+    /// Find a server that supports the requested capability.
     pub fn select(&self, capability: Capability, prefer: Option<Attribute>) -> Option<&ServerInfo> {
         self.registry.servers().iter().find(|s| {
-            s.models.values().any(|m| m.capabilities.contains(&capability))
+            s.models
+                .values()
+                .any(|m| m.capabilities.contains(&capability))
                 && prefer.map_or(true, |attr| s.attributes.contains(&attr))
         })
     }


### PR DESCRIPTION
## Summary
- add detailed module docs across llm and voice crates
- document helper functions for composing prompts
- expand crate docs for core
- add small clarifications in TTS

## Testing
- `cargo check`
- `cargo doc --no-deps`


------
https://chatgpt.com/codex/tasks/task_e_68448965caa48320b24efaf99c094382