### PR TITLE
Add basic runtime orchestrator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,3 +102,4 @@ This design supports cognitive modularity, streamability, emotional realism, and
 * The `WitnessAgent` should call the language processor directly to build the `HereAndNow`, not via `Voice`.
   * Use `max_perceptions` and `max_memories` to keep prompts short.
 * Use naturalistic language when describing agent roles (e.g., 'Witness feels sensory data to produce experience').
+* Prefer the `clap` crate for parsing CLI arguments in binaries.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,6 @@ members = [
   "vision",
   "sensation-server",
   "sensation-tester",
-  "llm"
+  "llm",
+  "runtime"
 ]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "runtime"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+core = { path = "../core" }
+voice = { path = "../voice" }
+llm = { path = "../llm" }
+clap = { version = "4", features = ["derive"] }
+env_logger = "0.10"
+dotenvy = "0.15"
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1,0 +1,33 @@
+//! Runtime orchestrator for Pete Daringsby.
+
+/// Determine the tick rate in seconds from CLI or `TICK_RATE` env.
+/// Falls back to `1.0` if unset or invalid.
+pub fn tick_rate(cli: Option<f32>) -> f32 {
+    cli.or_else(|| {
+        std::env::var("TICK_RATE").ok()?.parse::<f32>().ok()
+    }).unwrap_or(1.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env;
+
+    #[test]
+    fn cli_overrides_env() {
+        env::set_var("TICK_RATE", "2.0");
+        assert_eq!(tick_rate(Some(0.5)), 0.5);
+    }
+
+    #[test]
+    fn env_used_when_cli_none() {
+        env::set_var("TICK_RATE", "3.5");
+        assert_eq!(tick_rate(None), 3.5);
+    }
+
+    #[test]
+    fn default_when_missing() {
+        env::remove_var("TICK_RATE");
+        assert_eq!(tick_rate(None), 1.0);
+    }
+}

--- a/runtime/src/main.rs
+++ b/runtime/src/main.rs
@@ -1,0 +1,40 @@
+use clap::Parser;
+use dotenvy::dotenv;
+use std::{env, time::Duration};
+use core::{psyche::Psyche, witness::WitnessAgent};
+use voice::ChatVoice;
+use llm::model_from_env;
+use voice::model::OllamaClient;
+
+#[derive(Parser)]
+struct Args {
+    /// Tick rate in seconds
+    #[arg(long)]
+    tick_rate: Option<f32>,
+}
+
+#[tokio::main]
+async fn main() {
+    dotenv().ok();
+    env_logger::init();
+    let args = Args::parse();
+    let rate = runtime::tick_rate(args.tick_rate);
+
+    let ollama_url = env::var("OLLAMA_URL").unwrap_or_else(|_| "http://localhost:11434".into());
+    let llm = OllamaClient::new(&ollama_url);
+    let model = model_from_env();
+    let narrator = ChatVoice::new(llm, model, 10);
+
+    let witness = WitnessAgent::default();
+    let mut psyche = Psyche::new(witness, narrator);
+    psyche.agent.self_understanding = Some("I am Pete Daringsby.".into());
+    let delay = Duration::from_secs_f32(rate);
+
+    loop {
+        let output = psyche.tick().await;
+        if let Some(say) = output.say {
+            println!("Pete: {}", say.content);
+        }
+        tokio::time::sleep(delay).await;
+    }
+}


### PR DESCRIPTION
## Summary
- create `runtime` crate with tick loop
- parse `TICK_RATE` from CLI or environment
- update workspace members and AGENTS guidance

## Testing
- `cargo check`
- `cargo test` *(fails: Codex couldn't run certain commands due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6844a74d19a48320a6dfcab225c57b4d