### PR TITLE
Add memory services

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,7 @@ This design supports cognitive modularity, streamability, emotional realism, and
 * Witness and Voice are sibling subagents managed by `Psyche`.
 * Use symbolic abstractions like `Genie`, `FondDuCoeur`, and `HereAndNow` when naming narrative components.
 * Use `docker-compose.yml` to start the local Coqui TTS server.
+* Qdrant and Neo4j services are defined there for the memory backends.
 * Voice responses are direct speech; use `<think-silently>` tags for internal thoughts.
 * Keep spoken replies brief so listeners can interject.
 * Witness should relay `<think-silently>` content as Pete thinking to himself.

--- a/README.md
+++ b/README.md
@@ -87,9 +87,8 @@ Run `cargo check` in the repository root to verify that all crates compile. CI o
 
 1. Install Rust (stable) and Docker.
 2. Copy `.env.example` to `.env` and set the environment variables described below.
-3. Start the Coqui TTS server with `docker-compose up -d tts`.
+3. Start the required services with `docker-compose up -d tts qdrant neo4j`.
 4. Optional: run Whisper locally for ASR and configure its address in `.env`.
-5. Run `docker-compose up -d qdrant neo4j` if you want the memory backends.
 
 ### Environment variables
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,3 +20,21 @@ services:
           devices:
             - count: all
               capabilities: [gpu]
+
+  qdrant:
+    image: qdrant/qdrant:latest
+    ports:
+      - "6333:6333"
+      - "6334:6334"
+    volumes:
+      - ./qdrant_data:/qdrant/storage
+
+  neo4j:
+    image: neo4j:5
+    ports:
+      - "7687:7687"
+      - "7474:7474"
+    environment:
+      - NEO4J_AUTH=neo4j/password
+    volumes:
+      - ./neo4j_data:/data

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,3 +1,6 @@
 # Architecture
 
 This document outlines the overall system design for Pete Daringsby.
+
+Qdrant and Neo4j provide the vector and graph memory stores. Both services are
+included in `docker-compose.yml`.

--- a/voice/src/lib.rs
+++ b/voice/src/lib.rs
@@ -5,6 +5,8 @@
 
 use async_trait::async_trait;
 
+pub mod stream;
+
 #[derive(Debug, PartialEq, Eq)]
 pub struct ThinkMessage {
     pub content: String,


### PR DESCRIPTION
## Summary
- include qdrant and Neo4j in docker-compose
- document required services in the README and architecture docs
- re-export the `stream` module from the voice crate
- note memory services in AGENTS notes

## Testing
- `cargo check --workspace --all-targets`
- `cargo test --workspace --all-targets`


------
https://chatgpt.com/codex/tasks/task_e_6844b03546b483209be9889f7dc8820d