### PR TITLE
Fix voice compile error and update guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,3 +106,4 @@ This design supports cognitive modularity, streamability, emotional realism, and
 * Use naturalistic language when describing agent roles (e.g., 'Witness feels sensory data to produce experience').
 * Prefer the `clap` crate for parsing CLI arguments in binaries.
 * Eye sensor emits `Sensation::saw` objects from JPEG snapshots.
+* Keep module declarations unique; avoid duplicate `pub mod` lines.

--- a/voice/src/lib.rs
+++ b/voice/src/lib.rs
@@ -5,8 +5,6 @@
 
 use async_trait::async_trait;
 
-pub mod stream;
-
 #[derive(Debug, PartialEq, Eq)]
 pub struct ThinkMessage {
     pub content: String,


### PR DESCRIPTION
## Summary
- remove duplicate `stream` module declaration
- clarify AGENTS guidelines about unique module declarations

## Testing
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6844b69cc80c8320bc781ceeedc8f4c9