### PR TITLE
Add mirror viewer to runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,3 +107,5 @@ This design supports cognitive modularity, streamability, emotional realism, and
 * Prefer the `clap` crate for parsing CLI arguments in binaries.
 * Eye sensor emits `Sensation::saw` objects from JPEG snapshots.
 * Keep module declarations unique; avoid duplicate `pub mod` lines.
+* Run `cargo run -p runtime` and open `http://localhost:3000/see` to mirror your
+  webcam in the browser and stream frames to the runtime.

--- a/README.md
+++ b/README.md
@@ -112,6 +112,15 @@ Start the WebSocket backend:
 cargo run -p sensation-server
 ```
 
+Run the main runtime alongside a simple viewer:
+
+```bash
+cargo run -p runtime
+```
+
+Then open [http://localhost:3000/see](http://localhost:3000/see) in a browser to
+mirror your webcam and stream frames to Pete.
+
 Use `sensation-tester` to send mock sensor input:
 
 ```bash

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -7,8 +7,16 @@ edition = "2021"
 core = { path = "../core" }
 voice = { path = "../voice" }
 llm = { path = "../llm" }
+sensor = { path = "../sensor" }
 clap = { version = "4", features = ["derive"] }
 env_logger = "0.10"
 dotenvy = "0.15"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+axum = { version = "0.7", features = ["ws", "json"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+base64 = "0.21"
+
+[dev-dependencies]
+tower = "0.4"
 

--- a/runtime/src/see.html
+++ b/runtime/src/see.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>See Yourself</title>
+<style>
+video { transform: scaleX(-1); }
+</style>
+</head>
+<body>
+<video id="v" autoplay playsinline></video>
+<script>
+const ws = new WebSocket(`ws://${location.host}/see/ws`);
+const video = document.getElementById('v');
+
+navigator.mediaDevices.getUserMedia({ video: true }).then(stream => {
+  video.srcObject = stream;
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d');
+  function sendFrame() {
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+    ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+    const data = canvas.toDataURL('image/jpeg');
+    ws.send(JSON.stringify({ base64: data.split(',')[1] }));
+    requestAnimationFrame(sendFrame);
+  }
+  requestAnimationFrame(sendFrame);
+});
+</script>
+</body>
+</html>

--- a/runtime/src/server.rs
+++ b/runtime/src/server.rs
@@ -1,0 +1,40 @@
+use axum::{extract::{ws::{WebSocket, WebSocketUpgrade, Message}, State}, response::{Html, IntoResponse}, routing::get, Router};
+use serde::Deserialize;
+use tokio::sync::mpsc::Sender;
+use sensor::Sensation;
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
+
+#[derive(Clone)]
+pub struct AppState {
+    pub tx: Sender<Sensation>,
+}
+
+pub fn router(tx: Sender<Sensation>) -> Router {
+    Router::new()
+        .route("/see", get(index))
+        .route("/see/ws", get(ws_handler))
+        .with_state(AppState { tx })
+}
+
+async fn index() -> Html<&'static str> {
+    Html(include_str!("see.html"))
+}
+
+async fn ws_handler(ws: WebSocketUpgrade, State(state): State<AppState>) -> impl IntoResponse {
+    ws.on_upgrade(move |socket| handle_ws(socket, state))
+}
+
+#[derive(Deserialize)]
+struct Frame { base64: String }
+
+async fn handle_ws(mut socket: WebSocket, state: AppState) {
+    while let Some(Ok(Message::Text(text))) = socket.recv().await {
+        if let Ok(frame) = serde_json::from_str::<Frame>(&text) {
+            if let Ok(bytes) = BASE64.decode(frame.base64) {
+                let _ = state.tx.send(Sensation::saw(bytes)).await;
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- serve /see to display mirrored webcam video
- connect browser via WebSocket and forward JPEG frames as sensations
- run the web server alongside the Psyche runtime
- document how to launch the runtime viewer

## Testing
- `cargo check --workspace --all-targets`
- `cargo test --workspace --all-targets`


------
https://chatgpt.com/codex/tasks/task_e_6844b96b26188320a6ae948267c5053b