### PR TITLE
Add mood emoji state and live log viewer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,3 +109,5 @@ This design supports cognitive modularity, streamability, emotional realism, and
 * Keep module declarations unique; avoid duplicate `pub mod` lines.
 * Run `cargo run -p runtime` and open `http://localhost:3000/see` to mirror your
   webcam in the browser and stream frames to the runtime.
+* `Psyche` tracks a `mood` emoji each tick via `MoodAgent`.
+* The web server exposes `/face` and `/logs` for mood and live log output.

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -31,6 +31,7 @@
 pub mod ethics;
 pub mod fond;
 pub mod genie;
+pub mod mood;
 pub mod prompt_builder;
 pub mod psyche;
 pub mod witness;

--- a/core/src/mood.rs
+++ b/core/src/mood.rs
@@ -1,0 +1,69 @@
+use llm::traits::{LLMClient, LLMError};
+use llm::runner::{stream_first_sentence, client_from_env, model_from_env};
+use llm::OllamaClient;
+
+/// Evaluate Pete's emotional state as an emoji string.
+pub struct MoodAgent<C: LLMClient> {
+    client: C,
+    model: String,
+}
+
+impl MoodAgent<OllamaClient> {
+    /// Create a new mood agent using environment configuration.
+    pub fn new() -> Self {
+        Self {
+            client: client_from_env(),
+            model: model_from_env(),
+        }
+    }
+}
+
+impl<C: LLMClient> MoodAgent<C> {
+    /// Use a custom LLM client and model name.
+    pub fn with(client: C, model: impl Into<String>) -> Self {
+        Self { client, model: model.into() }
+    }
+
+    /// Assess how Pete would feel about the provided context.
+    pub async fn assess(&self, context: &str) -> Result<String, LLMError> {
+        let prompt = format!(
+            "How would the character PETE feel about this situation? Return 1-2 emojis. Situation: {context}"
+        );
+        log::info!("Mood prompt: {prompt}");
+        let (_, resp) = stream_first_sentence(&self.client, &self.model, &prompt).await?;
+        log::info!("Mood response: {resp}");
+        Ok(resp.trim().to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use futures_util::stream;
+    use std::pin::Pin;
+
+    struct Mock;
+
+    #[async_trait]
+    impl LLMClient for Mock {
+        async fn stream_chat(
+            &self,
+            _model: &str,
+            _prompt: &str,
+        ) -> Result<Pin<Box<dyn futures_core::Stream<Item = Result<String, LLMError>> + Send>>, LLMError> {
+            Ok(Box::pin(stream::iter(vec![Ok("😀".to_string())])))
+        }
+
+        async fn embed(&self, _model: &str, _input: &str) -> Result<Vec<f32>, LLMError> {
+            Ok(Vec::new())
+        }
+    }
+
+    #[tokio::test]
+    async fn returns_emoji() {
+        let agent = MoodAgent::with(Mock, "mock");
+        let emoji = agent.assess("context").await.unwrap();
+        assert_eq!(emoji, "😀");
+    }
+}

--- a/runtime/src/face.html
+++ b/runtime/src/face.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>Pete's Face</title>
+<style>
+body { font-size: 5rem; text-align: center; }
+</style>
+<script>
+async function poll() {
+  const res = await fetch('/face/emoji');
+  const text = await res.text();
+  document.getElementById('mood').textContent = text;
+}
+setInterval(poll, 1000);
+window.onload = poll;
+</script>
+</head>
+<body>
+<div id="mood">🙂</div>
+</body>
+</html>

--- a/runtime/src/logger.rs
+++ b/runtime/src/logger.rs
@@ -1,0 +1,45 @@
+use log::{LevelFilter, Metadata, Record};
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone)]
+pub struct SimpleLogger {
+    buffer: Arc<Mutex<VecDeque<String>>>,
+    level: LevelFilter,
+}
+
+impl SimpleLogger {
+    pub fn init(level: LevelFilter) -> Arc<Self> {
+        let logger = Arc::new(Self {
+            buffer: Arc::new(Mutex::new(VecDeque::with_capacity(100))),
+            level,
+        });
+        log::set_boxed_logger(Box::new(logger.clone())).expect("set logger");
+        log::set_max_level(level);
+        logger
+    }
+
+    pub fn dump(&self) -> String {
+        let buf = self.buffer.lock().unwrap();
+        buf.iter().cloned().collect::<Vec<_>>().join("\n")
+    }
+}
+
+impl log::Log for SimpleLogger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        metadata.level() <= self.level
+    }
+
+    fn log(&self, record: &Record) {
+        if self.enabled(record.metadata()) {
+            println!("[{}] {}", record.level(), record.args());
+            let mut buf = self.buffer.lock().unwrap();
+            buf.push_back(format!("[{}] {}", record.level(), record.args()));
+            if buf.len() > 100 {
+                buf.pop_front();
+            }
+        }
+    }
+
+    fn flush(&self) {}
+}

--- a/runtime/src/server.rs
+++ b/runtime/src/server.rs
@@ -1,24 +1,43 @@
 use axum::{extract::{ws::{WebSocket, WebSocketUpgrade, Message}, State}, response::{Html, IntoResponse}, routing::get, Router};
 use serde::Deserialize;
-use tokio::sync::mpsc::Sender;
+use tokio::sync::{mpsc::Sender, Mutex as AsyncMutex};
 use sensor::Sensation;
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
+use std::sync::Arc;
+use crate::logger::SimpleLogger;
 
 #[derive(Clone)]
 pub struct AppState {
     pub tx: Sender<Sensation>,
+    pub mood: Arc<AsyncMutex<String>>,
+    pub logs: Arc<SimpleLogger>,
 }
 
-pub fn router(tx: Sender<Sensation>) -> Router {
+pub fn router(tx: Sender<Sensation>, mood: Arc<AsyncMutex<String>>, logs: Arc<SimpleLogger>) -> Router {
     Router::new()
         .route("/see", get(index))
         .route("/see/ws", get(ws_handler))
-        .with_state(AppState { tx })
+        .route("/face", get(face))
+        .route("/face/emoji", get(face_emoji))
+        .route("/logs", get(show_logs))
+        .with_state(AppState { tx, mood, logs })
 }
 
 async fn index() -> Html<&'static str> {
     Html(include_str!("see.html"))
+}
+
+async fn face() -> Html<&'static str> {
+    Html(include_str!("face.html"))
+}
+
+async fn face_emoji(State(state): State<AppState>) -> String {
+    state.mood.lock().await.clone()
+}
+
+async fn show_logs(State(state): State<AppState>) -> Html<String> {
+    Html(format!("<pre>{}</pre>", state.logs.dump()))
 }
 
 async fn ws_handler(ws: WebSocketUpgrade, State(state): State<AppState>) -> impl IntoResponse {

--- a/voice/src/lib.rs
+++ b/voice/src/lib.rs
@@ -87,6 +87,7 @@ impl<C: ModelClient + Send + Sync> VoiceAgent for ChatVoice<C> {
             }
             prompt
         };
+        log::info!("Voice prompt: {}", prompt);
         let mut stream = match self.llm.stream_chat(&self.model, &prompt).await {
             Ok(s) => s,
             Err(_) => {
@@ -103,6 +104,7 @@ impl<C: ModelClient + Send + Sync> VoiceAgent for ChatVoice<C> {
                 response.push_str(&text);
             }
         }
+        log::info!("Voice response: {}", response);
         let mut conv = self.conversation.lock().unwrap();
         conv.push(Role::Assistant, response.clone());
         let think_re = Regex::new(r"<think-silently>(.*?)</think-silently>").unwrap();


### PR DESCRIPTION
## Summary
- implement `MoodAgent` for emoji mood evaluation
- track mood in `Psyche` and expose `/face` route
- add `SimpleLogger` with `/logs` route
- log prompts and responses in `ChatVoice`
- update development notes about mood and logging

## Testing
- `cargo check` *(fails: whisper-rs-sys compile error)*
- `cargo test` *(failed during build)*

------
https://chatgpt.com/codex/tasks/task_e_6844d7b0410c8320a10e0aeab389c048