### PR TITLE
Add web dashboard for Pete

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,3 +111,4 @@ This design supports cognitive modularity, streamability, emotional realism, and
   webcam in the browser and stream frames to the runtime.
 * `Psyche` tracks a `mood` emoji each tick via `MoodAgent`.
 * The web server exposes `/face` and `/logs` for mood and live log output.
+* `/` hosts an interactive dashboard for sending text, audio and location to Pete.

--- a/core/src/mood.rs
+++ b/core/src/mood.rs
@@ -51,7 +51,7 @@ mod tests {
             &self,
             _model: &str,
             _prompt: &str,
-        ) -> Result<Pin<Box<dyn futures_core::Stream<Item = Result<String, LLMError>> + Send>>, LLMError> {
+        ) -> Result<Pin<Box<dyn futures_util::Stream<Item = Result<String, LLMError>> + Send>>, LLMError> {
             Ok(Box::pin(stream::iter(vec![Ok("😀".to_string())])))
         }
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -10,6 +10,7 @@ llm = { path = "../llm" }
 sensor = { path = "../sensor" }
 clap = { version = "4", features = ["derive"] }
 env_logger = "0.10"
+log = "0.4"
 dotenvy = "0.15"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 axum = { version = "0.7", features = ["ws", "json"] }
@@ -19,4 +20,6 @@ base64 = "0.21"
 
 [dev-dependencies]
 tower = "0.4"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+log = "0.4"
 

--- a/runtime/src/index.html
+++ b/runtime/src/index.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>Pete Interface</title>
+<style>
+body { font-family: sans-serif; margin:0; padding:0; }
+#main { display:flex; gap:1rem; padding:1rem; }
+#left { flex:3; }
+#right { flex:1; }
+pre { background:#000; color:#0f0; padding:0.5rem; height:150px; overflow-y:auto; }
+canvas { width:100%; height:60px; border:1px solid #ccc; }
+</style>
+</head>
+<body>
+<p>Hello Pete. Treat these inputs as your own organs. Narrate them in first person.</p>
+<div id="main">
+  <div id="left">
+    <input id="text" type="text" placeholder="Type to Pete" />
+    <button id="send">Send</button>
+    <button id="record">Record</button>
+    <label><input type="checkbox" id="mute"/>Mute</label>
+    <canvas id="osc"></canvas>
+    <pre id="history"></pre>
+    <pre id="thoughts"></pre>
+  </div>
+  <div id="right">
+    <iframe id="face" src="/face" style="border:none;width:100%;height:150px"></iframe>
+    <div id="location"></div>
+  </div>
+</div>
+<script>
+const ws = new WebSocket(`ws://${location.host}/ws`);
+const textEl = document.getElementById('text');
+document.getElementById('send').onclick = () => {
+  ws.send(JSON.stringify({type:'text', value:textEl.value}));
+  textEl.value='';
+};
+ws.onmessage = ev => {
+  const m = JSON.parse(ev.data);
+  if(m.kind==='say') append('history', m.content);
+  if(m.kind==='think') append('thoughts', m.content);
+};
+function append(id, msg){
+  const pre = document.getElementById(id);
+  const atBottom = pre.scrollTop + pre.clientHeight >= pre.scrollHeight - 5;
+  pre.textContent += msg + '\n';
+  if(atBottom) pre.scrollTop = pre.scrollHeight;
+}
+navigator.geolocation.getCurrentPosition(pos=>{
+  document.getElementById('location').textContent =
+    `Location: ${pos.coords.latitude.toFixed(4)}, ${pos.coords.longitude.toFixed(4)}`;
+  ws.send(JSON.stringify({type:'geo', lat:pos.coords.latitude, lon:pos.coords.longitude}));
+});
+let ctx, analyser, dataArray, mediaRecorder, recording=false;
+const canvas = document.getElementById('osc');
+const mute = document.getElementById('mute');
+const recordBtn = document.getElementById('record');
+recordBtn.onclick = async () => {
+  if(recording){
+    mediaRecorder.stop();
+    recordBtn.textContent='Record';
+    recording=false;
+  } else {
+    const stream = await navigator.mediaDevices.getUserMedia({audio:true});
+    ctx = new AudioContext();
+    analyser = ctx.createAnalyser();
+    const source = ctx.createMediaStreamSource(stream);
+    source.connect(analyser);
+    analyser.fftSize=2048;
+    dataArray = new Uint8Array(analyser.fftSize);
+    draw();
+    mediaRecorder = new MediaRecorder(stream);
+    let chunks=[];
+    mediaRecorder.ondataavailable=e=>chunks.push(e.data);
+    mediaRecorder.onstop=()=>{
+      const blob=new Blob(chunks,{type:'audio/webm'}); chunks=[];
+      blob.arrayBuffer().then(buf=>{
+        if(!mute.checked){
+          const bin=new Uint8Array(buf);
+          const b64=btoa(String.fromCharCode(...bin));
+          ws.send(JSON.stringify({type:'audio', base64:b64}));
+        }
+      });
+    };
+    mediaRecorder.start();
+    recordBtn.textContent='Stop';
+    recording=true;
+  }
+};
+function draw(){
+  if(!recording){return;}
+  requestAnimationFrame(draw);
+  analyser.getByteTimeDomainData(dataArray);
+  const c=canvas.getContext('2d');
+  c.clearRect(0,0,canvas.width,canvas.height);
+  c.beginPath();
+  for(let i=0;i<dataArray.length;i++){
+    const v=dataArray[i]/128.0; const y=v*canvas.height/2;
+    if(i===0) c.moveTo(i,y); else c.lineTo(i,y);
+  }
+  c.stroke();
+}
+</script>
+</body>
+</html>

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -7,6 +7,9 @@ pub fn tick_rate(cli: Option<f32>) -> f32 {
         .unwrap_or(1.0)
 }
 
+pub mod server;
+pub mod logger;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/runtime/src/main.rs
+++ b/runtime/src/main.rs
@@ -1,14 +1,14 @@
 use clap::Parser;
-use dotenvy::dotenv;
-use std::{env, sync::Arc, time::Duration};
 use core::{psyche::Psyche, witness::WitnessAgent};
-use voice::ChatVoice;
+use dotenvy::dotenv;
 use llm::model_from_env;
-use voice::model::OllamaClient;
-use tokio::sync::{mpsc, Mutex};
 use log::LevelFilter;
-mod server;
+use std::{env, sync::Arc, time::Duration};
+use tokio::sync::{mpsc, Mutex};
+use voice::model::OllamaClient;
+use voice::ChatVoice;
 mod logger;
+mod server;
 
 #[derive(Parser)]
 struct Args {
@@ -52,8 +52,11 @@ async fn main() {
             let mut m = mood.lock().await;
             *m = psyche.mood.clone();
         }
+        if !output.think.content.is_empty() {
+            log::info!("Think: {}", output.think.content);
+        }
         if let Some(say) = output.say {
-            println!("Pete: {}", say.content);
+            log::info!("Pete: {}", say.content);
         }
         tokio::time::sleep(delay).await;
     }

--- a/runtime/src/server.rs
+++ b/runtime/src/server.rs
@@ -1,11 +1,19 @@
-use axum::{extract::{ws::{WebSocket, WebSocketUpgrade, Message}, State}, response::{Html, IntoResponse}, routing::get, Router};
-use serde::Deserialize;
-use tokio::sync::{mpsc::Sender, Mutex as AsyncMutex};
-use sensor::Sensation;
-use base64::Engine;
-use base64::engine::general_purpose::STANDARD as BASE64;
-use std::sync::Arc;
 use crate::logger::SimpleLogger;
+use axum::{
+    extract::{
+        ws::{Message, WebSocket, WebSocketUpgrade},
+        State,
+    },
+    response::{Html, IntoResponse},
+    routing::get,
+    Router,
+};
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine;
+use sensor::Sensation;
+use serde::Deserialize;
+use std::sync::Arc;
+use tokio::sync::{mpsc::Sender, Mutex as AsyncMutex};
 
 #[derive(Clone)]
 pub struct AppState {
@@ -14,17 +22,27 @@ pub struct AppState {
     pub logs: Arc<SimpleLogger>,
 }
 
-pub fn router(tx: Sender<Sensation>, mood: Arc<AsyncMutex<String>>, logs: Arc<SimpleLogger>) -> Router {
+pub fn router(
+    tx: Sender<Sensation>,
+    mood: Arc<AsyncMutex<String>>,
+    logs: Arc<SimpleLogger>,
+) -> Router {
     Router::new()
-        .route("/see", get(index))
-        .route("/see/ws", get(ws_handler))
+        .route("/", get(home))
+        .route("/see", get(see))
+        .route("/ws", get(ws_handler))
+        .route("/see/ws", get(ws_frames))
         .route("/face", get(face))
         .route("/face/emoji", get(face_emoji))
         .route("/logs", get(show_logs))
         .with_state(AppState { tx, mood, logs })
 }
 
-async fn index() -> Html<&'static str> {
+async fn home() -> Html<&'static str> {
+    Html(include_str!("index.html"))
+}
+
+async fn see() -> Html<&'static str> {
     Html(include_str!("see.html"))
 }
 
@@ -41,13 +59,63 @@ async fn show_logs(State(state): State<AppState>) -> Html<String> {
 }
 
 async fn ws_handler(ws: WebSocketUpgrade, State(state): State<AppState>) -> impl IntoResponse {
-    ws.on_upgrade(move |socket| handle_ws(socket, state))
+    ws.on_upgrade(move |socket| handle_socket(socket, state))
 }
 
 #[derive(Deserialize)]
-struct Frame { base64: String }
+#[serde(tag = "type", rename_all = "lowercase")]
+enum Input {
+    Text { value: String },
+    Audio { base64: String },
+    Geo { lat: f64, lon: f64 },
+    Frame { base64: String },
+}
 
-async fn handle_ws(mut socket: WebSocket, state: AppState) {
+#[derive(Deserialize)]
+struct Frame {
+    base64: String,
+}
+
+async fn handle_socket(mut socket: WebSocket, state: AppState) {
+    while let Some(Ok(Message::Text(text))) = socket.recv().await {
+        if let Ok(input) = serde_json::from_str::<Input>(&text) {
+            match input {
+                Input::Text { value } => {
+                    let _ = state.tx.send(Sensation::new("keyboard", Some(value))).await;
+                }
+                Input::Audio { base64 } => {
+                    if let Ok(bytes) = BASE64.decode(base64) {
+                        // placeholder for ASR processing
+                        let _ = state
+                            .tx
+                            .send(Sensation::new(
+                                "audio",
+                                Some(format!("{} bytes", bytes.len())),
+                            ))
+                            .await;
+                    }
+                }
+                Input::Geo { lat, lon } => {
+                    let _ = state
+                        .tx
+                        .send(Sensation::new("geo", Some(format!("{lat},{lon}"))))
+                        .await;
+                }
+                Input::Frame { base64 } => {
+                    if let Ok(bytes) = BASE64.decode(base64) {
+                        let _ = state.tx.send(Sensation::saw(bytes)).await;
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn ws_frames(ws: WebSocketUpgrade, State(state): State<AppState>) -> impl IntoResponse {
+    ws.on_upgrade(move |socket| handle_frames(socket, state))
+}
+
+async fn handle_frames(mut socket: WebSocket, state: AppState) {
     while let Some(Ok(Message::Text(text))) = socket.recv().await {
         if let Ok(frame) = serde_json::from_str::<Frame>(&text) {
             if let Ok(bytes) = BASE64.decode(frame.base64) {
@@ -56,4 +124,3 @@ async fn handle_ws(mut socket: WebSocket, state: AppState) {
         }
     }
 }
-

--- a/runtime/tests/server.rs
+++ b/runtime/tests/server.rs
@@ -1,0 +1,21 @@
+use runtime::server::router;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+use tokio::{runtime::Runtime, sync::{mpsc, Mutex}};
+use std::sync::Arc;
+use runtime::logger::SimpleLogger;
+
+#[test]
+fn root_serves_page() {
+    let (tx, _rx) = mpsc::channel(1);
+    let mood = Arc::new(Mutex::new(String::new()));
+    let logger = SimpleLogger::init(log::LevelFilter::Info);
+    let app = router(tx, mood, logger);
+    Runtime::new().unwrap().block_on(async {
+        let res = app
+            .oneshot(Request::builder().uri("/").body(axum::body::Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+    });
+}


### PR DESCRIPTION
## Summary
- serve a new interactive `index.html` at `/`
- accept keyboard, audio, and location events via `/ws`
- log Pete's thoughts and speech to the logger
- expose server/router modules from the runtime crate
- document dashboard in AGENTS notes
- test root route of the server

## Testing
- `cargo check --workspace --all-targets`
- `cargo test --workspace --all-targets`


------
https://chatgpt.com/codex/tasks/task_e_6844db6ee4a08320a7910d3228e25a5f