### PR TITLE
Fix TTS compose entrypoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,8 @@ This design supports cognitive modularity, streamability, emotional realism, and
 * Witness and Voice are sibling subagents managed by `Psyche`.
 * Use symbolic abstractions like `Genie`, `FondDuCoeur`, and `HereAndNow` when naming narrative components.
 * Use `docker-compose.yml` to start the local Coqui TTS server.
+* `tts` can run on CPU by using `ghcr.io/coqui-ai/tts-cpu` and removing `runtime: nvidia`.
+* Add `entrypoint: python3` so the server script executes properly.
 * Qdrant and Neo4j services are defined there for the memory backends.
 * Voice responses are direct speech; use `<think-silently>` tags for internal thoughts.
 * Keep spoken replies brief so listeners can interject.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ Run `cargo check` in the repository root to verify that all crates compile. CI o
 1. Install Rust (stable) and Docker.
 2. Copy `.env.example` to `.env` and set the environment variables described below.
 3. Start the required services with `docker-compose up -d tts qdrant neo4j`.
+If you lack a GPU, swap the image for `ghcr.io/coqui-ai/tts-cpu` and remove the `runtime: nvidia` line. See [Coqui TTS docs](https://tts.readthedocs.io/en/latest/docker_images.html) for details.
+Be sure to include `entrypoint: python3` in the `tts` service so the server script runs.
 4. Optional: run Whisper locally for ASR and configure its address in `.env`.
 
 ### Environment variables

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     image: ghcr.io/coqui-ai/tts
     ports:
       - "5002:5002"
+    entrypoint: python3
     environment:
       - NVIDIA_VISIBLE_DEVICES=all
       - COQUI_TOS_AGREED=1

--- a/docs/task5_tts_sentence_streamer.md
+++ b/docs/task5_tts_sentence_streamer.md
@@ -18,6 +18,7 @@ tts:
   image: ghcr.io/coqui-ai/tts
   ports:
     - "5002:5002"
+  entrypoint: python3
   environment:
     - NVIDIA_VISIBLE_DEVICES=all
     - COQUI_TOS_AGREED=1
@@ -35,6 +36,11 @@ tts:
           - count: all
             capabilities: [gpu]
 ```
+For CPU-only systems, use the Coqui `tts-cpu` image:
+```bash
+docker run --rm -it -p 5002:5002 ghcr.io/coqui-ai/tts-cpu python3 TTS/server/server.py --model_name tts_models/en/vctk/vits
+```
+
 
 Set the following environment variables in `.env` or your configuration:
 


### PR DESCRIPTION
## Summary
- update AGENTS with docker-compose reminder
- clarify tts service entrypoint in README
- add entrypoint line to docker-compose.yml
- document entrypoint in TTS sentence streamer doc

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6844deaae90883208e078877e65770f6