### PR TITLE
Enforce terse narrator prompts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,8 @@ This design supports cognitive modularity, streamability, emotional realism, and
 * Qdrant and Neo4j services are defined there for the memory backends.
 * Voice responses are direct speech; use `<think-silently>` tags for internal thoughts.
 * Keep spoken replies brief so listeners can interject.
+* Narrator responses should stay terse and only draw from current sensations and memories. Avoid fabricating details unless explicitly required.
+* Include key guidelines like this directly in prompts because subagents don't read `AGENTS.md`.
 * Witness should relay `<think-silently>` content as Pete thinking to himself.
 * Configure `OLLAMA_URL` and `OLLAMA_MODEL` in your `.env` for LLM calls.
 * Use `OLLAMA_URLS` for a comma list of fallback hosts.

--- a/voice/src/lib.rs
+++ b/voice/src/lib.rs
@@ -78,7 +78,12 @@ impl<C: ModelClient + Send + Sync> VoiceAgent for ChatVoice<C> {
     async fn narrate(&self, context: &str) -> VoiceOutput {
         let prompt = {
             let conv = self.conversation.lock().unwrap();
-            let mut prompt = format!("You are a storyteller narrating the life of Pete Daringsby. Narrate in the voice of Pete from the first person. Current thought: {context}\n");
+            let mut prompt = format!(
+                "You are a storyteller narrating the life of Pete Daringsby. \
+                 Narrate in the voice of Pete from the first person. \
+                 Keep your responses brief and grounded in the provided sensations and memories. \
+                 Current thought: {context}\n"
+            );
             for m in conv.tail() {
                 match m.role {
                     Role::Assistant => prompt.push_str(&format!("Pete: {}\n", m.content)),
@@ -92,7 +97,9 @@ impl<C: ModelClient + Send + Sync> VoiceAgent for ChatVoice<C> {
             Ok(s) => s,
             Err(_) => {
                 return VoiceOutput {
-                    think: ThinkMessage { content: String::new() },
+                    think: ThinkMessage {
+                        content: String::new(),
+                    },
                     say: None,
                     emote: None,
                 }
@@ -117,15 +124,21 @@ impl<C: ModelClient + Send + Sync> VoiceAgent for ChatVoice<C> {
             think_content.push_str(&cap[1]);
         }
         let mut said = think_re.replace_all(&response, "").into_owned();
-        let emote_msg = emote_re.captures(&said).map(|c| EmoteMessage { emoji: c[1].to_string() });
+        let emote_msg = emote_re.captures(&said).map(|c| EmoteMessage {
+            emoji: c[1].to_string(),
+        });
         said = emote_re.replace_all(&said, "").into_owned();
         let say_msg = if said.trim().is_empty() {
             None
         } else {
-            Some(SayMessage { content: said.trim().to_string() })
+            Some(SayMessage {
+                content: said.trim().to_string(),
+            })
         };
         VoiceOutput {
-            think: ThinkMessage { content: think_content },
+            think: ThinkMessage {
+                content: think_content,
+            },
             say: say_msg,
             emote: emote_msg,
         }

--- a/voice/tests/chat_voice.rs
+++ b/voice/tests/chat_voice.rs
@@ -1,4 +1,4 @@
-use voice::{ChatVoice, VoiceAgent, model::MockModelClient};
+use voice::{model::MockModelClient, ChatVoice, VoiceAgent};
 
 #[tokio::test]
 async fn voice_updates_conversation() {
@@ -12,10 +12,58 @@ async fn voice_updates_conversation() {
 
 #[tokio::test]
 async fn parses_think_silently() {
-    let llm = MockModelClient::new(vec!["hi <think-silently>secret</think-silently>".into()], vec![]);
+    let llm = MockModelClient::new(
+        vec!["hi <think-silently>secret</think-silently>".into()],
+        vec![],
+    );
     let voice = ChatVoice::new(llm, "mock", 3);
     voice.receive_user("yo");
     let out = voice.narrate("ctx").await;
     assert_eq!(out.think.content, "secret");
     assert_eq!(out.say.unwrap().content, "hi");
+}
+
+use async_trait::async_trait;
+use futures_core::Stream;
+use std::{
+    pin::Pin,
+    sync::{Arc, Mutex},
+};
+use tokio_stream::iter;
+use voice::model::{ModelClient, ModelError};
+
+struct RecordingClient {
+    prompt: Arc<Mutex<Option<String>>>,
+}
+
+impl RecordingClient {
+    fn new(prompt: Arc<Mutex<Option<String>>>) -> Self {
+        Self { prompt }
+    }
+}
+
+#[async_trait]
+impl ModelClient for RecordingClient {
+    async fn stream_chat(
+        &self,
+        _model: &str,
+        prompt: &str,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<String, ModelError>> + Send>>, ModelError> {
+        *self.prompt.lock().unwrap() = Some(prompt.to_string());
+        Ok(Box::pin(iter(vec![Ok("ok".to_string())])))
+    }
+
+    async fn embed(&self, _model: &str, _input: &str) -> Result<Vec<f32>, ModelError> {
+        Ok(vec![])
+    }
+}
+
+#[tokio::test]
+async fn prompt_mentions_terse_rule() {
+    let captured = Arc::new(Mutex::new(None));
+    let llm = RecordingClient::new(captured.clone());
+    let voice = ChatVoice::new(llm, "mock", 1);
+    let _ = voice.narrate("context").await;
+    let prompt = captured.lock().unwrap().clone().unwrap();
+    assert!(prompt.contains("Keep your responses brief"));
 }


### PR DESCRIPTION
## Summary
- add note that subagents don't read AGENTS.md
- keep narrator prompt short and sensory-based
- test prompt includes terse rule

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6844e92af20c832093de6e5449e04bc1