### PR TITLE
Add memory pipeline hookup

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -8,6 +8,9 @@ This document defines the event types used when streaming data between Pete Dari
 - `asr_final` – finalized transcript for a sentence.
 - `llm_thought_fragment` – partial LLM reflection text.
 - `llm_final_response` – complete LLM response for a sentence.
+- `llm_begin_say` – the voice has started speaking.
+- `llm_say_fragment` – partial text of the current utterance.
+- `llm_end_say` – end of the utterance with a completion flag.
 - `tts_chunk_ready` – identifier for an audio chunk ready to play.
 - `perception_log` – log message from Witness or other sensors.
 - `memory_update` – summary of an Experience stored in memory.

--- a/net/src/stream_bus.rs
+++ b/net/src/stream_bus.rs
@@ -9,6 +9,12 @@ pub enum StreamEvent {
     AsrFinal { transcript: String },
     LlmThoughtFragment { content: String },
     LlmFinalResponse { content: String },
+    /// Notification that a spoken response has begun.
+    LlmBeginSay,
+    /// Fragment of a spoken response as it streams.
+    LlmSayFragment { content: String },
+    /// Indicates the utterance is complete or was interrupted.
+    LlmEndSay { complete: bool },
     TtsChunkReady { id: usize },
     PerceptionLog { text: String },
     MemoryUpdate { summary: String },

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -8,6 +8,8 @@ core = { path = "../core" }
 voice = { path = "../voice" }
 llm = { path = "../llm" }
 sensor = { path = "../sensor" }
+memory = { path = "../memory" }
+net = { path = "../net" }
 clap = { version = "4", features = ["derive"] }
 env_logger = "0.10"
 log = "0.4"

--- a/runtime/src/main.rs
+++ b/runtime/src/main.rs
@@ -2,11 +2,14 @@ use clap::Parser;
 use core::{psyche::Psyche, witness::WitnessAgent};
 use dotenvy::dotenv;
 use llm::model_from_env;
+use memory::{GraphRag, Memory};
+use net::stream_bus::{StreamBus, StreamEvent};
 use log::LevelFilter;
 use std::{env, sync::Arc, time::Duration};
 use tokio::sync::{mpsc, Mutex};
 use voice::model::OllamaClient;
 use voice::ChatVoice;
+use llm::OllamaClient as LlmClient;
 mod logger;
 mod server;
 
@@ -29,6 +32,14 @@ async fn main() {
     let model = model_from_env();
     let narrator = ChatVoice::new(llm, model, 10);
 
+    let memory_llm = LlmClient::new(&ollama_url);
+    let qdrant_url = env::var("QDRANT_URL").unwrap_or_else(|_| "http://localhost:6333".into());
+    let neo_uri = env::var("NEO4J_URI").unwrap_or_else(|_| "bolt://localhost:7687".into());
+    let neo_user = env::var("NEO4J_USER").unwrap_or_else(|_| "neo4j".into());
+    let neo_pass = env::var("NEO4J_PASS").unwrap_or_else(|_| "neo4j".into());
+    let memory = GraphRag::new(&qdrant_url, &neo_uri, &neo_user, &neo_pass).expect("connect memory");
+    let bus = StreamBus::new(16);
+
     let witness = WitnessAgent::default();
     let mut psyche = Psyche::new(witness, narrator);
     psyche.agent.self_understanding = Some("I am Pete Daringsby.".into());
@@ -45,7 +56,13 @@ async fn main() {
     let delay = Duration::from_secs_f32(rate);
     loop {
         while let Ok(s) = rx.try_recv() {
-            psyche.witness.ingest(s);
+            match psyche.witness.feel(s, &memory_llm).await {
+                Ok(exp) => {
+                    let _ = memory.store(exp.clone()).await;
+                    let _ = bus.send(StreamEvent::MemoryUpdate { summary: exp.explanation.clone() });
+                }
+                Err(e) => log::error!("feel error: {:?}", e),
+            }
         }
         let output = psyche.tick().await;
         {


### PR DESCRIPTION
## Summary
- extend StreamEvent for voice streaming stages
- document new events in protocol
- wire up GraphRag storage in runtime

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6844f597742883209b45ecf0e2e8c7f4