### PR TITLE
Implement queued LLM scheduler

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,7 @@ This design supports cognitive modularity, streamability, emotional realism, and
 * Refer to the `llm` crate as the "language processor".
 * The `LinguisticScheduler` selects a model based on task capabilities.
 * The `LinguisticScheduler` profiles each server's latency and favors faster hosts.
+* Tasks are queued with one running per server; droppable tasks return `LLMError::QueueFull` when busy.
 * The `WitnessAgent` should call the language processor directly to build the `HereAndNow`, not via `Voice`.
   * Use `max_perceptions` and `max_memories` to keep prompts short.
 * Use naturalistic language when describing agent roles (e.g., 'Witness feels sensory data to produce experience').

--- a/llm/src/task.rs
+++ b/llm/src/task.rs
@@ -9,17 +9,25 @@ pub struct LinguisticTask {
     pub capabilities: Vec<LLMCapability>,
     /// Optional preferred processor attribute.
     pub prefer: Option<LLMAttribute>,
+    /// Whether this task can be dropped if all processors are busy.
+    pub droppable: bool,
 }
 
 impl LinguisticTask {
     /// Create a new task with the given prompt and capabilities.
     pub fn new(prompt: impl Into<String>, capabilities: Vec<LLMCapability>) -> Self {
-        Self { prompt: prompt.into(), capabilities, prefer: None }
+        Self { prompt: prompt.into(), capabilities, prefer: None, droppable: false }
     }
 
     /// Indicate a preferred attribute for scheduling.
     pub fn prefer_attribute(mut self, attr: LLMAttribute) -> Self {
         self.prefer = Some(attr);
+        self
+    }
+
+    /// Mark the task as droppable when the queue is full.
+    pub fn droppable(mut self, value: bool) -> Self {
+        self.droppable = value;
         self
     }
 }

--- a/llm/src/traits.rs
+++ b/llm/src/traits.rs
@@ -36,6 +36,8 @@ pub enum LLMError {
     InvalidResponse,
     #[error("model not found")]
     ModelNotFound,
+    #[error("queue full")]
+    QueueFull,
 }
 
 /// Interface for talking to a language model server.


### PR DESCRIPTION
## Summary
- add queue semantics to `LinguisticScheduler`
- allow tasks to be marked droppable
- new `QueueFull` error and semaphore-based locking
- update unit tests for dropping behaviour
- document scheduler queue behaviour in `AGENTS.md`

## Testing
- `cargo check`
- `cargo test -p llm`
- `cargo test -p tts`


------
https://chatgpt.com/codex/tasks/task_e_684512c5c61883208f00f8b69abaccd0