### PR TITLE
Init lingproc workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/target
+**/*.rs.bk
+Cargo.lock

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# Repo Guidelines
+
+## Programmatic Checks
+- Run `cargo fmt --all` and `cargo test --all` before committing.
+
+## Development
+- Follow BDD/TDD principles; add tests alongside new features.
+- Use concise commit messages.
+- Prefer doc tests and examples for public APIs to aid understanding.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,3 @@
+[workspace]
+members = ["lingproc", "modeldb"]
+resolver = "2"

--- a/lingproc/Cargo.toml
+++ b/lingproc/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "lingproc"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+async-trait = "0.1"
+ollama-rs = { version = "0.3", features = ["stream"] }
+async-openai = "0.28"
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+modeldb = { path = "../modeldb" }
+anyhow = "1"
+futures = "0.3"
+async-stream = "0.3"
+serde = { version = "1", features = ["derive"] }

--- a/lingproc/src/lib.rs
+++ b/lingproc/src/lib.rs
@@ -1,0 +1,276 @@
+use async_trait::async_trait;
+use futures::stream::BoxStream;
+use modeldb::{AiModel, ModelRepository};
+use serde::{Deserialize, Serialize};
+
+/// Role of a chat participant.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum Role {
+    System,
+    User,
+    Assistant,
+}
+
+/// A single chat message. Images may be attached.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Message {
+    pub role: Role,
+    pub content: String,
+    #[serde(default)]
+    pub images: Vec<Vec<u8>>, // raw image bytes
+}
+
+/// Task describing different operations a processor may handle.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Task {
+    ChatCompletion(ChatCompletionTask),
+    SentenceEmbedding(SentenceEmbeddingTask),
+    InstructionFollowing(InstructionFollowingTask),
+}
+
+/// Generate chat completions from a sequence of messages.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatCompletionTask {
+    pub messages: Vec<Message>,
+}
+
+/// Produce embeddings for a single sentence.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SentenceEmbeddingTask {
+    pub sentence: String,
+    #[serde(default)]
+    pub images: Vec<Vec<u8>>,
+}
+
+/// Follow a natural language instruction and return textual output.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InstructionFollowingTask {
+    pub instruction: String,
+    #[serde(default)]
+    pub images: Vec<Vec<u8>>,
+}
+
+/// Returned stream items from processors.
+#[derive(Debug)]
+pub enum TaskOutput {
+    TextChunk(String),
+    Embedding(Vec<f32>),
+}
+
+/// Capability describing supported task types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TaskKind {
+    ChatCompletion,
+    SentenceEmbedding,
+    InstructionFollowing,
+}
+
+#[async_trait]
+pub trait Processor {
+    /// Advertise supported task types.
+    fn capabilities(&self) -> Vec<TaskKind>;
+
+    /// Process a task, producing a stream of results.
+    async fn process(
+        &self,
+        task: Task,
+    ) -> anyhow::Result<BoxStream<'static, anyhow::Result<TaskOutput>>>;
+}
+
+/// Ollama based implementation.
+pub struct OllamaProcessor {
+    client: ollama_rs::Ollama,
+    pub model: String,
+}
+
+impl OllamaProcessor {
+    pub fn new(model: &str) -> Self {
+        Self {
+            client: ollama_rs::Ollama::default(),
+            model: model.to_string(),
+        }
+    }
+}
+
+#[async_trait]
+impl Processor for OllamaProcessor {
+    fn capabilities(&self) -> Vec<TaskKind> {
+        vec![TaskKind::ChatCompletion]
+    }
+
+    async fn process(
+        &self,
+        task: Task,
+    ) -> anyhow::Result<BoxStream<'static, anyhow::Result<TaskOutput>>> {
+        match task {
+            Task::ChatCompletion(c) => {
+                use async_stream::stream;
+                use futures::StreamExt;
+                use ollama_rs::generation::completion::request::GenerationRequest;
+
+                let prompt = c
+                    .messages
+                    .iter()
+                    .map(|m| format!("{:?}: {}", m.role, m.content))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                let req = GenerationRequest::new(self.model.clone(), prompt);
+                let mut resp = self.client.generate_stream(req).await?;
+                let s = stream! {
+                    while let Some(chunk) = resp.next().await {
+                        let chunk = chunk?;
+                        for c in chunk {
+                            yield Ok(TaskOutput::TextChunk(c.response));
+                        }
+                    }
+                };
+                Ok(Box::pin(s))
+            }
+            _ => Err(anyhow::anyhow!("task not supported")),
+        }
+    }
+}
+
+/// OpenAI based implementation.
+pub struct OpenAIProcessor {
+    client: async_openai::Client<async_openai::config::OpenAIConfig>,
+    pub model: String,
+}
+
+impl OpenAIProcessor {
+    pub fn new(api_key: &str, model: &str) -> Self {
+        let config = async_openai::config::OpenAIConfig::new().with_api_key(api_key);
+        Self { client: async_openai::Client::with_config(config), model: model.to_string() }
+    }
+}
+
+#[async_trait]
+impl Processor for OpenAIProcessor {
+    fn capabilities(&self) -> Vec<TaskKind> {
+        vec![TaskKind::ChatCompletion]
+    }
+
+    async fn process(
+        &self,
+        task: Task,
+    ) -> anyhow::Result<BoxStream<'static, anyhow::Result<TaskOutput>>> {
+        match task {
+            Task::ChatCompletion(c) => {
+                use async_openai::types::{
+                    ChatCompletionRequestAssistantMessageArgs, ChatCompletionRequestMessage,
+                    ChatCompletionRequestSystemMessageArgs, ChatCompletionRequestUserMessageArgs,
+                    CreateChatCompletionRequestArgs,
+                };
+                use async_stream::stream;
+                use futures::StreamExt;
+
+                let msgs: Vec<ChatCompletionRequestMessage> = c
+                    .messages
+                    .iter()
+                    .map(|m| match m.role {
+                        Role::System => ChatCompletionRequestSystemMessageArgs::default()
+                            .content(m.content.clone())
+                            .build()
+                            .unwrap()
+                            .into(),
+                        Role::Assistant => ChatCompletionRequestAssistantMessageArgs::default()
+                            .content(m.content.clone())
+                            .build()
+                            .unwrap()
+                            .into(),
+                        Role::User => ChatCompletionRequestUserMessageArgs::default()
+                            .content(m.content.clone())
+                            .build()
+                            .unwrap()
+                            .into(),
+                    })
+                    .collect();
+
+                let req = CreateChatCompletionRequestArgs::default()
+                    .model(&self.model)
+                    .messages(msgs)
+                    .stream(true)
+                    .build()?;
+                let mut resp = self.client.chat().create_stream(req).await?;
+                let s = stream! {
+                    while let Some(chunk) = resp.next().await {
+                        let chunk = chunk?;
+                        if let Some(c) = chunk.choices.first() {
+                            if let Some(ref content) = c.delta.content {
+                                yield Ok(TaskOutput::TextChunk(content.clone()));
+                            }
+                        }
+                    }
+                };
+                Ok(Box::pin(s))
+            }
+            _ => Err(anyhow::anyhow!("task not supported")),
+        }
+    }
+}
+
+/// Default model repository used by examples and tests.
+pub fn default_repository() -> ModelRepository {
+    let mut repo = ModelRepository::new();
+    repo.add_model(AiModel {
+        name: "gemma3:27b".into(),
+        supports_images: true,
+        speed: None,
+        cost_per_token: None,
+    });
+    repo.add_model(AiModel {
+        name: "gpt4".into(),
+        supports_images: true,
+        speed: Some(1.0),
+        cost_per_token: Some(0.03),
+    });
+    repo
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt;
+
+    struct EchoProcessor;
+
+    #[async_trait]
+    impl Processor for EchoProcessor {
+        fn capabilities(&self) -> Vec<TaskKind> {
+            vec![TaskKind::InstructionFollowing]
+        }
+
+        async fn process(
+            &self,
+            task: Task,
+        ) -> anyhow::Result<BoxStream<'static, anyhow::Result<TaskOutput>>> {
+            match task {
+                Task::InstructionFollowing(t) => {
+                    use async_stream::stream;
+                    let instr = t.instruction.clone();
+                    let s = stream! {
+                        yield Ok(TaskOutput::TextChunk(instr));
+                    };
+                    Ok(Box::pin(s))
+                }
+                _ => Err(anyhow::anyhow!("task not supported")),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn echo_instruction() {
+        let proc = EchoProcessor;
+        let task = Task::InstructionFollowing(InstructionFollowingTask { instruction: "ping".into(), images: vec![] });
+        let mut stream = proc.process(task).await.unwrap();
+        let first = stream.next().await.unwrap().unwrap();
+        match first { TaskOutput::TextChunk(t) => assert_eq!(t, "ping"), _ => panic!("wrong output") }
+    }
+
+    #[tokio::test]
+    async fn repo_has_models() {
+        let repo = default_repository();
+        assert!(repo.find("gpt4").is_some());
+        assert!(repo.find("gemma3:27b").is_some());
+    }
+}

--- a/modeldb/Cargo.toml
+++ b/modeldb/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "modeldb"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/modeldb/src/lib.rs
+++ b/modeldb/src/lib.rs
@@ -1,0 +1,44 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AiModel {
+    pub name: String,
+    pub supports_images: bool,
+    pub speed: Option<f32>,
+    pub cost_per_token: Option<f32>,
+}
+
+pub struct ModelRepository {
+    models: Vec<AiModel>,
+}
+
+impl ModelRepository {
+    pub fn new() -> Self {
+        Self { models: Vec::new() }
+    }
+
+    pub fn add_model(&mut self, model: AiModel) {
+        self.models.push(model);
+    }
+
+    pub fn find(&self, name: &str) -> Option<&AiModel> {
+        self.models.iter().find(|m| m.name == name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_and_find() {
+        let mut repo = ModelRepository::new();
+        repo.add_model(AiModel {
+            name: "gpt4".into(),
+            supports_images: true,
+            speed: Some(1.0),
+            cost_per_token: Some(0.01),
+        });
+        assert!(repo.find("gpt4").is_some());
+    }
+}


### PR DESCRIPTION
## Summary
- add a note in `AGENTS.md` about doc tests
- allow streaming by enabling `ollama-rs` stream feature and adding futures, serde
- rework `Processor` trait with task enum, stream output and capability advertizing
- add tests for new processor API

## Testing
- `cargo fmt --all` *(fails: cargo-fmt not installed)*
- `cargo test --all`


------
https://chatgpt.com/codex/tasks/task_e_68459ace522c83209835f94f2e11644a