### PR TITLE
Fix profiler stream poll

### DIFF
--- a/lingproc/src/lib.rs
+++ b/lingproc/src/lib.rs
@@ -298,6 +298,7 @@ mod tests {
         });
         let mut stream = proc.process(task).await.unwrap();
         while let Some(_c) = stream.next().await {}
+        assert!(stream.next().await.is_none());
         let d = proc.durations();
         assert_eq!(d.len(), 1);
         assert!(d[0] > Duration::from_secs(0));


### PR DESCRIPTION
## Summary
- ensure `profiler_records_time` checks for stream completion

## Testing
- `cargo test -p lingproc`
- `cargo test --all`


------
https://chatgpt.com/codex/tasks/task_e_6845c354d4c88320a3ebb5dc9b38bcb7