### PR TITLE
Implement Heart system and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Daringsby
+
+This workspace contains several Rust crates forming a small experimental AI stack.
+
+- **lingproc** – interfaces with language models and provides processors for chat
+  completion, embeddings and instruction following.
+- **modeldb** – stores metadata about available AI models.
+- **psyche** – basic types representing sensations, experiences and sensors.
+- **memory** – abstractions and utilities for persisting information.
+
+Tests and formatting can be run for the entire workspace:
+
+```bash
+cargo fmt --all
+cargo test --all
+```
+
+The provided `docker-compose.yml` launches optional services such as text to
+speech (Coqui TTS), Qdrant and Neo4j which are useful during development but not
+required to run the unit tests.

--- a/lingproc/src/lib.rs
+++ b/lingproc/src/lib.rs
@@ -298,6 +298,7 @@ mod tests {
         });
         let mut stream = proc.process(task).await.unwrap();
         while let Some(_c) = stream.next().await {}
+        assert!(stream.next().await.is_none());
         let d = proc.durations();
         assert_eq!(d.len(), 1);
         assert!(d[0] > Duration::from_secs(0));

--- a/modeldb/src/lib.rs
+++ b/modeldb/src/lib.rs
@@ -1,13 +1,43 @@
 use serde::{Deserialize, Serialize};
 
+/// Metadata describing an available language model.
+///
+/// ```
+/// use modeldb::{AiModel, ModelRepository};
+/// let mut repo = ModelRepository::new();
+/// repo.add_model(AiModel {
+///     name: "gpt4".into(),
+///     supports_images: true,
+///     speed: Some(1.0),
+///     cost_per_token: Some(0.02),
+/// });
+/// assert!(repo.find("gpt4").is_some());
+/// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AiModel {
+    /// Unique name of the model.
     pub name: String,
+    /// Whether the model accepts image inputs.
     pub supports_images: bool,
+    /// Relative speed factor of the model.
     pub speed: Option<f32>,
+    /// Cost in dollars per generated token.
     pub cost_per_token: Option<f32>,
 }
 
+/// Simple in-memory collection of [`AiModel`]s.
+///
+/// ```
+/// use modeldb::{AiModel, ModelRepository};
+/// let mut repo = ModelRepository::new();
+/// repo.add_model(AiModel {
+///     name: "foo".into(),
+///     supports_images: false,
+///     speed: None,
+///     cost_per_token: None,
+/// });
+/// assert!(repo.find("foo").is_some());
+/// ```
 pub struct ModelRepository {
     models: Vec<AiModel>,
 }


### PR DESCRIPTION
## Summary
- add README with workspace overview
- document `AiModel` and `ModelRepository`
- ensure async stream cleanup in profiler test
- implement `Memory`, `Wit` and `Heart` in `psyche`
- add associated unit tests

## Testing
- `cargo test --all`

------
https://chatgpt.com/codex/tasks/task_e_6845c1c906e083208eb82f727555b4d4