### PR TITLE
Add processor scheduler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1059,6 +1059,14 @@ dependencies = [
 [[package]]
 name = "psyche"
 version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-stream",
+ "async-trait",
+ "futures",
+ "lingproc",
+ "tokio",
+]
 
 [[package]]
 name = "quinn"

--- a/psyche/Cargo.toml
+++ b/psyche/Cargo.toml
@@ -4,3 +4,11 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+lingproc = { path = "../lingproc" }
+futures = "0.3"
+tokio = { version = "1", features = ["rt"] }
+
+[dev-dependencies]
+async-trait = "0.1"
+async-stream = "0.3"
+anyhow = "1"


### PR DESCRIPTION
## Summary
- use an LLM processor from psyche via `ProcessorScheduler`
- support futures, tokio and lingproc in `psyche`
- test that a mock processor drives `Wit`

## Testing
- `cargo test -p psyche`
- `cargo test --all`


------
https://chatgpt.com/codex/tasks/task_e_6845c9881b3c8320a6d81fb6a726b7dd