### PR TITLE
Add chat input and fix logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1307,6 +1307,8 @@ dependencies = [
  "lingproc",
  "log",
  "once_cell",
+ "serde",
+ "serde_json",
  "tokio",
  "warp",
 ]

--- a/pete/Cargo.toml
+++ b/pete/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2024"
 psyche = { path = "../psyche" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 anyhow = "1"
-log = "0.4.27"
+log = { version = "0.4.27", features = ["std"] }

--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -1,7 +1,10 @@
 use anyhow::Result;
+use log::info;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    psyche::logging::init()?;
+    info!("starting pete webserver");
     psyche::server::run(([127, 0, 0, 1], 8080)).await;
     Ok(())
 }

--- a/psyche/Cargo.toml
+++ b/psyche/Cargo.toml
@@ -8,8 +8,10 @@ lingproc = { path = "../lingproc" }
 futures = "0.3"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync"] }
 warp = { version = "0.3", features = ["websocket"] }
-log = "0.4"
+log = { version = "0.4", features = ["std"] }
 once_cell = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [dev-dependencies]
 async-trait = "0.1"

--- a/psyche/static/index.html
+++ b/psyche/static/index.html
@@ -6,12 +6,25 @@
 </head>
 <body>
 <pre id="log"></pre>
+<form id="chat-form">
+    <input id="chat-input" type="text" autocomplete="off" />
+    <button type="submit">Send</button>
+</form>
 <script>
 const ws = new WebSocket(`ws://${location.host}/ws`);
 ws.onmessage = (ev) => {
     const pre = document.getElementById('log');
     pre.textContent += ev.data + '\n';
 };
+document.getElementById('chat-form').addEventListener('submit', (ev) => {
+    ev.preventDefault();
+    const input = document.getElementById('chat-input');
+    const line = input.value;
+    if (line.trim() !== '') {
+        ws.send(JSON.stringify({ type: 'chat', line }));
+        input.value = '';
+    }
+});
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- enable the std feature for the `log` crate
- wire logging back into Pete
- add `Chat` events and tests for the bus
- extend the server to forward chat lines through the bus
- update the HTML page with a simple chat form

## Testing
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6845d34399348320a5e6c74f6f71d709