### PR TITLE
Add structured connection events

### DIFF
--- a/psyche/src/bus.rs
+++ b/psyche/src/bus.rs
@@ -8,6 +8,10 @@ pub enum Event {
     Log(String),
     /// Chat line submitted from a user.
     Chat(String),
+    /// WebSocket client connected from an address.
+    Connected(std::net::SocketAddr),
+    /// WebSocket client disconnected.
+    Disconnected(std::net::SocketAddr),
 }
 
 /// Simple broadcast bus for sending [`Event`]s to multiple listeners.
@@ -50,6 +54,19 @@ mod tests {
         bus.send(Event::Chat("hi".into()));
         match rx.recv().await {
             Ok(Event::Chat(line)) => assert_eq!(line, "hi"),
+            other => panic!("unexpected event: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn send_and_receive_connection() {
+        use std::net::SocketAddr;
+        let bus = global_bus();
+        let mut rx = bus.subscribe();
+        let addr: SocketAddr = "127.0.0.1:8080".parse().unwrap();
+        bus.send(Event::Connected(addr));
+        match rx.recv().await {
+            Ok(Event::Connected(a)) => assert_eq!(a, addr),
             other => panic!("unexpected event: {:?}", other),
         }
     }

--- a/psyche/src/sensors.rs
+++ b/psyche/src/sensors.rs
@@ -1,0 +1,79 @@
+use crate::{Experience, Sensor, Sensation, bus::Event};
+
+/// Sensor interpreting chat events from the bus.
+///
+/// # Examples
+/// ```
+/// use psyche::{bus::Event, sensors::ChatSensor, Sensation, Sensor};
+/// let mut sensor = ChatSensor::default();
+/// let exp = sensor.feel(Sensation::new(Event::Chat("hi".into()))).unwrap();
+/// assert_eq!(exp.sentence, "I heard someone say: hi");
+/// ```
+#[derive(Default)]
+pub struct ChatSensor;
+
+impl Sensor for ChatSensor {
+    type Input = Event;
+    fn feel(&mut self, s: Sensation<Self::Input>) -> Option<Experience> {
+        match s.what {
+            Event::Chat(line) => Some(Experience::new(format!(
+                "I heard someone say: {line}"))),
+            _ => None,
+        }
+    }
+}
+
+/// Sensor interpreting connection events from the bus.
+///
+/// # Examples
+/// ```
+/// use std::net::SocketAddr;
+/// use psyche::{bus::Event, sensors::ConnectionSensor, Sensation, Sensor};
+/// let mut sensor = ConnectionSensor::default();
+/// let addr: SocketAddr = "127.0.0.1:80".parse().unwrap();
+/// let exp = sensor.feel(Sensation::new(Event::Connected(addr))).unwrap();
+/// assert!(exp.sentence.contains("127.0.0.1"));
+/// ```
+#[derive(Default)]
+pub struct ConnectionSensor;
+
+impl Sensor for ConnectionSensor {
+    type Input = Event;
+    fn feel(&mut self, s: Sensation<Self::Input>) -> Option<Experience> {
+        match s.what {
+            Event::Connected(addr) => Some(Experience::new(format!(
+                "Someone at {addr} connected."))),
+            Event::Disconnected(addr) => Some(Experience::new(format!(
+                "Connection from {addr} closed."))),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chat_event_to_experience() {
+        let mut sensor = ChatSensor::default();
+        let exp = sensor
+            .feel(Sensation::new(Event::Chat("hello".into())))
+            .unwrap();
+        assert_eq!(exp.sentence, "I heard someone say: hello");
+    }
+
+    #[test]
+    fn connection_events_to_experience() {
+        let addr: std::net::SocketAddr = "127.0.0.1:80".parse().unwrap();
+        let mut sensor = ConnectionSensor::default();
+        let exp = sensor
+            .feel(Sensation::new(Event::Connected(addr)))
+            .unwrap();
+        assert_eq!(exp.sentence, "Someone at 127.0.0.1:80 connected.");
+        let exp = sensor
+            .feel(Sensation::new(Event::Disconnected(addr)))
+            .unwrap();
+        assert_eq!(exp.sentence, "Connection from 127.0.0.1:80 closed.");
+    }
+}


### PR DESCRIPTION
## Summary
- include socket address in connection events
- split bus sensors into ChatSensor and ConnectionSensor
- allow heterogeneous sensors on Psyche
- forward connection information through web server

## Testing
- `cargo test -p psyche`


------
https://chatgpt.com/codex/tasks/task_e_6845deb8ac048320b1568d8a556bb62b