### PR TITLE
Improve docs and agent guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,3 +18,13 @@
   after the final item to trigger any cleanup logic.
 - When storing timestamped data, prefer field names `when` and `what` for
   clarity.
+
+## Project Overview
+Daringsby houses several Rust crates forming a toy cognitive system named Pete. Events flow through sensors into a `Heart` of `Wit`s which summarize and store experiences.
+
+### Layout
+- `lingproc/` – LLM processors, providers and scheduler
+- `modeldb/`  – catalog of available models
+- `psyche/`   – sensors, event bus, heart/wit logic and web server
+- `memory/`   – graph and vector memory abstractions
+- `pete/`     – binary launching the web interface

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Tests and formatting can be run for the entire workspace:
 
 ```bash
 cargo fmt --all
-cargo test --all
+cargo test --workspace --all-targets
 ```
 
 This repository includes a `.cargo/config.toml` file enabling incremental
@@ -100,11 +100,12 @@ Run `cargo check` in the repository root to verify that all crates compile. CI o
 ## Setup
 
 1. Install Rust (stable) and Docker.
-2. Copy `.env.example` to `.env` and set the environment variables described below.
-3. Start the required services with `docker-compose up -d tts qdrant neo4j`.
+2. Create a `.env` file and set the environment variables described below.
    If you lack a GPU, swap the image for `ghcr.io/coqui-ai/tts-cpu` and remove the `runtime: nvidia` line. See [Coqui TTS docs](https://tts.readthedocs.io/en/latest/docker_images.html) for details.
    Be sure to include `entrypoint: python3` in the `tts` service so the server script runs.
+3. Start the required services with `docker-compose up -d tts qdrant neo4j`.
 4. Optional: run Whisper locally for ASR and configure its address in `.env`.
+5. Run `cargo run -p pete` to start the local web interface.
 
 ### Environment variables
 
@@ -125,5 +126,5 @@ Run `cargo check` in the repository root to verify that all crates compile. CI o
 Run the full test suite with:
 
 ```bash
-cargo test
+cargo test --workspace --all-targets
 ```

--- a/lingproc/src/lib.rs
+++ b/lingproc/src/lib.rs
@@ -1,3 +1,7 @@
+//! Language processing primitives including processors, providers and schedulers.
+//! Processors implement chat completion, instruction following or embedding.
+//! Providers manage processor instances, while a [`scheduler::Scheduler`]
+//! distributes tasks across available providers.
 use async_trait::async_trait;
 use futures::stream::BoxStream;
 use modeldb::{AiModel, ModelRepository};

--- a/memory/src/lib.rs
+++ b/memory/src/lib.rs
@@ -1,3 +1,7 @@
+//! In-memory abstractions for graph and vector databases used to store
+//! embeddings of faces and sentences.
+//! Components implementing [`MemoryComponent`] process sensations and
+//! record them in a [`Memory`] instance.
 use async_trait::async_trait;
 use psyche::{Experience, Sensation};
 

--- a/modeldb/src/lib.rs
+++ b/modeldb/src/lib.rs
@@ -1,3 +1,5 @@
+//! Lightweight in-memory catalog describing available AI models.
+//! See [`ModelRepository`] for usage.
 use serde::{Deserialize, Serialize};
 
 /// Basic information about an AI model.

--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -1,3 +1,4 @@
+//! Launches the Pete web server exposing log and chat events over WebSockets.
 use anyhow::Result;
 use log::info;
 

--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -1,3 +1,6 @@
+//! Core types for Pete's cognitive loop including the event bus, sensors,
+//! schedulers and the `Heart`/`Wit` abstractions.
+//! The accompanying web server streams bus events over WebSockets.
 use std::time::SystemTime;
 
 pub mod bus;


### PR DESCRIPTION
## Summary
- add project overview and layout to AGENTS.md
- document crate purposes via doc comments
- clarify setup and test instructions in README

## Testing
- `cargo test --workspace --all-targets`

------
https://chatgpt.com/codex/tasks/task_e_6845e96042e48320b028f0bf63f8471a