### PR TITLE
Refactor event bus per psyche

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,4 +17,5 @@
 - When testing streams created with `async_stream`, ensure you poll once more
   after the final item to trigger any cleanup logic.
 - When storing timestamped data, prefer field names `when` and `what` for
-  clarity.
+    clarity.
+- Each psyche should create its own `EventBus` and web server. Avoid globals.

--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -1,10 +1,12 @@
 use anyhow::Result;
 use log::info;
+use std::sync::Arc;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    psyche::logging::init()?;
+    let bus = Arc::new(psyche::bus::EventBus::new());
+    psyche::logging::init(bus.clone())?;
     info!("starting pete webserver");
-    psyche::server::run(([127, 0, 0, 1], 8080)).await;
+    psyche::server::run(bus, ([127, 0, 0, 1], 8080)).await;
     Ok(())
 }

--- a/psyche/src/bus.rs
+++ b/psyche/src/bus.rs
@@ -1,4 +1,3 @@
-use once_cell::sync::OnceCell;
 use tokio::sync::broadcast;
 
 /// Events emitted by the system.
@@ -20,7 +19,8 @@ pub struct EventBus {
 }
 
 impl EventBus {
-    fn new() -> Self {
+    /// Create a new event bus.
+    pub fn new() -> Self {
         let (sender, _) = broadcast::channel(100);
         Self { sender }
     }
@@ -36,20 +36,13 @@ impl EventBus {
     }
 }
 
-static BUS: OnceCell<EventBus> = OnceCell::new();
-
-/// Access the global event bus used for logging.
-pub fn global_bus() -> &'static EventBus {
-    BUS.get_or_init(EventBus::new)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[tokio::test]
     async fn send_and_receive_chat() {
-        let bus = global_bus();
+        let bus = EventBus::new();
         let mut rx = bus.subscribe();
         bus.send(Event::Chat("hi".into()));
         match rx.recv().await {
@@ -61,7 +54,7 @@ mod tests {
     #[tokio::test]
     async fn send_and_receive_connection() {
         use std::net::SocketAddr;
-        let bus = global_bus();
+        let bus = EventBus::new();
         let mut rx = bus.subscribe();
         let addr: SocketAddr = "127.0.0.1:8080".parse().unwrap();
         bus.send(Event::Connected(addr));


### PR DESCRIPTION
## Summary
- remove global event bus
- pass an `EventBus` to the logger and web server
- start Pete with its own event bus
- document new guideline in `AGENTS.md`

## Testing
- `cargo check`
- `cargo test -p psyche`

------
https://chatgpt.com/codex/tasks/task_e_6845ed2da9ec8320835cb0bdf5f65497