### PR TITLE
Expose wit memory via new HTTP endpoint

### DIFF
--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -1,12 +1,71 @@
 use anyhow::Result;
 use log::info;
 use std::sync::Arc;
+use tokio::sync::Mutex;
+
+struct Echo;
+
+impl psyche::Sensor for Echo {
+    type Input = String;
+    fn feel(&mut self, s: psyche::Sensation<Self::Input>) -> Option<psyche::Experience> {
+        Some(psyche::Experience::new(s.what))
+    }
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let bus = Arc::new(psyche::bus::EventBus::new());
     psyche::logging::init(bus.clone())?;
+
+    let sensors: Vec<Box<dyn psyche::Sensor<Input = psyche::bus::Event> + Send + Sync>> = vec![
+        Box::new(psyche::sensors::ChatSensor::default()),
+        Box::new(psyche::sensors::ConnectionSensor::default()),
+    ];
+
+    let heart = psyche::Heart::new(vec![
+        psyche::Wit::with_config(
+            psyche::JoinScheduler::default(),
+            Echo,
+            Some("fond".into()),
+            std::time::Duration::from_secs(1),
+        ),
+        psyche::Wit::with_config(
+            psyche::JoinScheduler::default(),
+            Echo,
+            Some("focus".into()),
+            std::time::Duration::from_secs(1),
+        ),
+    ]);
+
+    let psyche = Arc::new(Mutex::new(psyche::Psyche::new(heart, sensors)));
+
+    {
+        let bus = bus.clone();
+        let psyche = psyche.clone();
+        tokio::spawn(async move {
+            let mut rx = bus.subscribe();
+            while let Ok(evt) = rx.recv().await {
+                let mut p = psyche.lock().await;
+                p.process_event(evt);
+            }
+        });
+    }
+
+    {
+        let psyche = psyche.clone();
+        tokio::spawn(async move {
+            use tokio::time::{sleep, Duration};
+            loop {
+                {
+                    let mut p = psyche.lock().await;
+                    p.heart.tick();
+                }
+                sleep(Duration::from_secs(1)).await;
+            }
+        });
+    }
+
     info!("starting pete webserver");
-    psyche::server::run(bus, ([127, 0, 0, 1], 8080)).await;
+    psyche::server::run_with_psyche(bus, psyche, ([127, 0, 0, 1], 8080)).await;
     Ok(())
 }

--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -1,4 +1,5 @@
 use std::time::SystemTime;
+use serde::Serialize;
 
 pub mod bus;
 pub mod logging;
@@ -16,8 +17,9 @@ pub mod server;
 /// let s = Sensation::new(42);
 /// assert_eq!(s.what, 42);
 /// ```
-#[derive(Debug, Clone, PartialEq)]
-pub struct Sensation<T> {
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct Sensation<T>
+{
     /// Time when the data was perceived.
     pub when: SystemTime,
     /// Arbitrary data representing the perception.
@@ -52,7 +54,7 @@ impl<T> Sensation<T> {
 /// let e = Experience::new("I see a cat.");
 /// assert_eq!(e.sentence, "I see a cat.");
 /// ```
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct Experience {
     /// The explanatory sentence.
     pub sentence: String,
@@ -381,7 +383,7 @@ impl Experience {
 /// struct Echo;
 /// impl psyche::Sensor for Echo { type Input = String; fn feel(&mut self, s: psyche::Sensation<String>) -> Option<psyche::Experience> { Some(psyche::Experience::new(s.what)) } }
 /// let wit = Wit::new(JoinScheduler::default(), Echo);
-/// let sensors: Vec<Box<dyn Sensor<Input = Event>>> = vec![
+/// let sensors: Vec<Box<dyn Sensor<Input = Event> + Send + Sync>> = vec![
 ///     Box::new(ChatSensor::default()),
 ///     Box::new(ConnectionSensor::default()),
 /// ];
@@ -399,7 +401,7 @@ where
 {
     /// Internal heart managing wits.
     pub heart: Heart<Wit<Sched, Percept>>,
-    sensors: Vec<Box<dyn Sensor<Input = bus::Event>>>,
+    sensors: Vec<Box<dyn Sensor<Input = bus::Event> + Send + Sync>>,
 }
 
 impl<Sched, Percept> Psyche<Sched, Percept>
@@ -411,7 +413,7 @@ where
     /// Create a new psyche from a heart and sensors.
     pub fn new(
         heart: Heart<Wit<Sched, Percept>>,
-        sensors: Vec<Box<dyn Sensor<Input = bus::Event>>>,
+        sensors: Vec<Box<dyn Sensor<Input = bus::Event> + Send + Sync>>,
     ) -> Self {
         Self { heart, sensors }
     }

--- a/psyche/src/server.rs
+++ b/psyche/src/server.rs
@@ -1,4 +1,7 @@
 use crate::bus::{Event, EventBus};
+use crate::{Psyche, Sensor, Scheduler};
+use tokio::sync::Mutex;
+use serde::Serialize;
 use futures::{SinkExt, StreamExt};
 use log::info;
 use serde::Deserialize;
@@ -71,4 +74,95 @@ pub async fn run(bus: Arc<EventBus>, addr: impl Into<SocketAddr>) {
         });
 
     warp::serve(html.or(ws_route)).run(addr).await;
+}
+
+async fn wit_handler<S, P>(
+    name: String,
+    psyche: Arc<Mutex<Psyche<S, P>>>,
+) -> Result<impl warp::Reply, warp::Rejection>
+where
+    S: Scheduler + Send + Sync,
+    P: Sensor<Input = S::Output> + Send + Sync,
+    S::Output: Serialize + Clone,
+{
+    let psyche = psyche.lock().await;
+    let idx = name.parse::<usize>().ok();
+    let wit_opt = if let Some(i) = idx {
+        psyche.heart.wits.get(i)
+    } else {
+        psyche
+            .heart
+            .wits
+            .iter()
+            .find(|w| w.name.as_deref() == Some(&name))
+    };
+    if let Some(wit) = wit_opt {
+        return Ok(warp::reply::json(&wit.memory.all()));
+    }
+    Err(warp::reject::not_found())
+}
+
+/// Start the webserver with access to a [`Psyche`].
+pub async fn run_with_psyche<S, P>(
+    bus: Arc<EventBus>,
+    psyche: Arc<Mutex<Psyche<S, P>>>,
+    addr: impl Into<SocketAddr>,
+) where
+    S: Scheduler + Send + Sync + 'static,
+    P: Sensor<Input = S::Output> + Send + Sync + 'static,
+    S::Output: Serialize + Clone + Send + Sync + 'static,
+{
+
+    let html = warp::path::end().map(|| warp::reply::html(INDEX_HTML));
+    let ws_route = warp::path("ws")
+        .and(warp::ws())
+        .and(warp::addr::remote())
+        .map(move |ws: warp::ws::Ws, addr: Option<SocketAddr>| {
+            let bus = bus.clone();
+            ws.on_upgrade(move |socket| handle_ws(bus, socket, addr))
+        });
+
+    let psyche_filter = warp::any().map(move || psyche.clone());
+    let wit_route = warp::path!("wit" / String)
+        .and(psyche_filter)
+        .and_then(wit_handler::<S, P>);
+
+    warp::serve(html.or(ws_route).or(wit_route)).run(addr).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+    use warp::Reply;
+    use crate::{Experience, JoinScheduler, Sensation, Heart, Wit};
+
+    struct Echo;
+
+    impl crate::Sensor for Echo {
+        type Input = String;
+        fn feel(&mut self, s: Sensation<Self::Input>) -> Option<Experience> {
+            Some(Experience::new(s.what))
+        }
+    }
+
+    #[tokio::test]
+    async fn wit_endpoint_returns_memory() {
+        let heart = Heart::new(vec![Wit::new(JoinScheduler::default(), Echo)]);
+        let psyche = Arc::new(Mutex::new(Psyche::new(heart, vec![])));
+
+        {
+            let mut p = psyche.lock().await;
+            p.heart.wits[0].memory.remember(Sensation::new("hello".to_string()));
+        }
+
+        let resp = wit_handler::<JoinScheduler, Echo>("0".into(), psyche.clone())
+            .await
+            .unwrap();
+        let body = resp.into_response();
+        assert_eq!(body.status(), 200);
+        let bytes = warp::hyper::body::to_bytes(body.into_body()).await.unwrap();
+        let val: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(val.as_array().unwrap()[0]["what"], "hello");
+    }
 }


### PR DESCRIPTION
## Summary
- implement serialization for `Sensation` and `Experience`
- add `/wit/:name_or_index` endpoint with tests
- build a simple psyche in `pete` and wire it to the web server
- adjust `Psyche` to require `Send + Sync` sensors

## Testing
- `cargo test -p psyche`
- `cargo test -p psyche --doc`
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6845f14108a88320a583106ee2666ac8