### PR TITLE
Introduce quick wit and Ollama

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1226,6 +1226,7 @@ name = "pete"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "lingproc",
  "log",
  "psyche",
  "tokio",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,3 +38,10 @@ services:
       - NEO4J_AUTH=neo4j/password
     volumes:
       - ./neo4j_data:/data
+
+  ollama:
+    image: ollama/ollama:latest
+    ports:
+      - "11434:11434"
+    volumes:
+      - ./ollama:/root/.ollama

--- a/pete/Cargo.toml
+++ b/pete/Cargo.toml
@@ -8,3 +8,4 @@ psyche = { path = "../psyche" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 anyhow = "1"
 log = { version = "0.4.27", features = ["std"] }
+lingproc = { path = "../lingproc" }

--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -25,16 +25,28 @@ async fn main() -> Result<()> {
 
     let heart = psyche::Heart::new(vec![
         psyche::Wit::with_config(
-            psyche::JoinScheduler::default(),
+            psyche::ProcessorScheduler::new(lingproc::OllamaProcessor::new("llama2")),
             Echo,
             Some("fond".into()),
             std::time::Duration::from_secs(1),
         ),
         psyche::Wit::with_config(
-            psyche::JoinScheduler::default(),
+            psyche::ProcessorScheduler::new(lingproc::OllamaProcessor::new("llama2")),
             Echo,
-            Some("focus".into()),
-            std::time::Duration::from_secs(1),
+            Some("wit2".into()),
+            std::time::Duration::from_secs(2),
+        ),
+        psyche::Wit::with_config(
+            psyche::ProcessorScheduler::new(lingproc::OllamaProcessor::new("llama2")),
+            Echo,
+            Some("wit3".into()),
+            std::time::Duration::from_secs(4),
+        ),
+        psyche::Wit::with_config(
+            psyche::ProcessorScheduler::new(lingproc::OllamaProcessor::new("llama2")),
+            Echo,
+            Some("quick".into()),
+            std::time::Duration::from_secs(8),
         ),
     ]);
 


### PR DESCRIPTION
## Summary
- rename `focus` wit to `quick`
- add default `ollama` service to docker compose
- log prompts and chunks when scheduling with LLM
- create multiple recursive wits and wire them up to Ollama
- adjust ticks to respect intervals
- update tests for new behaviour

## Testing
- `cargo test -p psyche`
- `cargo test -p psyche --doc`
- `cargo test --all`
- `cargo check -p pete`


------
https://chatgpt.com/codex/tasks/task_e_68463c8bc85883209e293cdff2fbabca