### PR TITLE
Add crate-level AGENTS guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@
 - During day‑to‑day coding, prefer targeted tests (e.g. `cargo test -p <crate>`)
   to avoid long waits. Save the full `--all` runs for just before a commit.
 - Keep dependency caches around between runs to reduce network activity.
+- Each crate folder has its own terse `AGENTS.md` with more tips.
 
 ## Development
 - Follow BDD/TDD principles; add tests alongside new features.

--- a/lingproc/AGENTS.md
+++ b/lingproc/AGENTS.md
@@ -1,0 +1,4 @@
+# Lingproc Guidelines
+- Mirror root repo rules.
+- `cargo test -p lingproc` before pushing.
+- Document processors with examples.

--- a/memory/AGENTS.md
+++ b/memory/AGENTS.md
@@ -1,0 +1,4 @@
+# Memory Guidelines
+- Use `when`/`what` names for timestamps.
+- Provide tokio tests for components.
+- Traits must stay generic and lean.

--- a/modeldb/AGENTS.md
+++ b/modeldb/AGENTS.md
@@ -1,0 +1,4 @@
+# ModelDB Notes
+- Every public fn needs a doc example.
+- Tests stay inline with code.
+- Use `cargo test -p modeldb` for speed.

--- a/pete/AGENTS.md
+++ b/pete/AGENTS.md
@@ -1,0 +1,4 @@
+# Pete Binary Notes
+- Keep `main.rs` small; move logic to libs.
+- Add integration tests under `tests/`.
+- `cargo test -p pete` before commit.

--- a/psyche/AGENTS.md
+++ b/psyche/AGENTS.md
@@ -1,0 +1,4 @@
+# Psyche Guidelines
+- Every psyche has its own `EventBus`.
+- Poll once more after streams finish.
+- Keep sensors modular with examples.


### PR DESCRIPTION
## Summary
- mention crate-specific AGENTS files in the root guidelines
- add terse AGENTS guidance for each crate directory

## Testing
- `cargo test --all`

------
https://chatgpt.com/codex/tasks/task_e_684677f7dd908320a4ea97408bdd6ac8