### PR TITLE
Fix experience how field

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@
   after the final item to trigger any cleanup logic.
 - When storing timestamped data, prefer field names `when` and `what` for
   clarity.
+- Use `how` for the descriptive text inside an `Experience`.
 - Each psyche should create its own `EventBus` and web server. Avoid globals.
 
 ## Project Overview

--- a/memory/src/lib.rs
+++ b/memory/src/lib.rs
@@ -82,7 +82,7 @@ where
     ) -> anyhow::Result<()> {
         let vector = Self::encode_face(&sensation.what).await;
         let face_id = memory.faces.insert(vector);
-        memory.graph.link_face(&experience.sentence, face_id);
+        memory.graph.link_face(&experience.how, face_id);
         Ok(())
     }
 }
@@ -133,6 +133,6 @@ mod tests {
             .unwrap();
 
         assert_eq!(memory.faces.vectors.len(), 1);
-        assert_eq!(memory.graph.links, vec![(exp.sentence, 0)]);
+        assert_eq!(memory.graph.links, vec![(exp.how, 0)]);
     }
 }

--- a/psyche/src/sensors.rs
+++ b/psyche/src/sensors.rs
@@ -1,4 +1,4 @@
-use crate::{Experience, Sensor, Sensation, bus::Event};
+use crate::{Experience, Sensation, Sensor, bus::Event};
 
 /// Sensor interpreting chat events from the bus.
 ///
@@ -7,7 +7,7 @@ use crate::{Experience, Sensor, Sensation, bus::Event};
 /// use psyche::{bus::Event, sensors::ChatSensor, Sensation, Sensor};
 /// let mut sensor = ChatSensor::default();
 /// let exp = sensor.feel(Sensation::new(Event::Chat("hi".into()))).unwrap();
-/// assert_eq!(exp.sentence, "I heard someone say: hi");
+/// assert_eq!(exp.how, "I heard someone say: hi");
 /// ```
 #[derive(Default)]
 pub struct ChatSensor;
@@ -16,8 +16,7 @@ impl Sensor for ChatSensor {
     type Input = Event;
     fn feel(&mut self, s: Sensation<Self::Input>) -> Option<Experience> {
         match s.what {
-            Event::Chat(line) => Some(Experience::new(format!(
-                "I heard someone say: {line}"))),
+            Event::Chat(line) => Some(Experience::new(format!("I heard someone say: {line}"))),
             _ => None,
         }
     }
@@ -32,7 +31,7 @@ impl Sensor for ChatSensor {
 /// let mut sensor = ConnectionSensor::default();
 /// let addr: SocketAddr = "127.0.0.1:80".parse().unwrap();
 /// let exp = sensor.feel(Sensation::new(Event::Connected(addr))).unwrap();
-/// assert!(exp.sentence.contains("127.0.0.1"));
+/// assert!(exp.how.contains("127.0.0.1"));
 /// ```
 #[derive(Default)]
 pub struct ConnectionSensor;
@@ -41,10 +40,12 @@ impl Sensor for ConnectionSensor {
     type Input = Event;
     fn feel(&mut self, s: Sensation<Self::Input>) -> Option<Experience> {
         match s.what {
-            Event::Connected(addr) => Some(Experience::new(format!(
-                "Someone at {addr} connected."))),
-            Event::Disconnected(addr) => Some(Experience::new(format!(
-                "Connection from {addr} closed."))),
+            Event::Connected(addr) => {
+                Some(Experience::new(format!("Someone at {addr} connected.")))
+            }
+            Event::Disconnected(addr) => {
+                Some(Experience::new(format!("Connection from {addr} closed.")))
+            }
             _ => None,
         }
     }
@@ -60,20 +61,18 @@ mod tests {
         let exp = sensor
             .feel(Sensation::new(Event::Chat("hello".into())))
             .unwrap();
-        assert_eq!(exp.sentence, "I heard someone say: hello");
+        assert_eq!(exp.how, "I heard someone say: hello");
     }
 
     #[test]
     fn connection_events_to_experience() {
         let addr: std::net::SocketAddr = "127.0.0.1:80".parse().unwrap();
         let mut sensor = ConnectionSensor::default();
-        let exp = sensor
-            .feel(Sensation::new(Event::Connected(addr)))
-            .unwrap();
-        assert_eq!(exp.sentence, "Someone at 127.0.0.1:80 connected.");
+        let exp = sensor.feel(Sensation::new(Event::Connected(addr))).unwrap();
+        assert_eq!(exp.how, "Someone at 127.0.0.1:80 connected.");
         let exp = sensor
             .feel(Sensation::new(Event::Disconnected(addr)))
             .unwrap();
-        assert_eq!(exp.sentence, "Connection from 127.0.0.1:80 closed.");
+        assert_eq!(exp.how, "Connection from 127.0.0.1:80 closed.");
     }
 }


### PR DESCRIPTION
## Summary
- rename `Experience.sentence` to `how`
- update docs and tests for `how`
- adjust memory component to use the new field
- document `how` usage in `AGENTS.md`

## Testing
- `cargo test --all`

------
https://chatgpt.com/codex/tasks/task_e_68467a80428c8320aee947b6f68a264e