### PR TITLE
Add Ollama model presets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@ OLLAMA_URL=http://localhost:11434
 # Optional comma separated hosts for load balancing
 OLLAMA_URLS=http://localhost:11434
 # Default model for completions
-OLLAMA_MODEL=llama2
+OLLAMA_MODEL=gemma3:27b
 
 # Text-to-speech service
 COQUI_URL=http://localhost:5002

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Run `cargo check` in the repository root to verify that all crates compile. CI o
 | --- | --- |
 | `OLLAMA_URL` | Base URL of the primary Ollama server |
 | `OLLAMA_URLS` | Comma separated list of Ollama hosts for load balancing |
-| `OLLAMA_MODEL` | LLM model identifier |
+| `OLLAMA_MODEL` | LLM model identifier (default `gemma3:27b`) |
 | `COQUI_URL` | Base URL of the Coqui TTS server |
 | `SPEAKER` | Coqui speaker name |
 | `QDRANT_URL` | Address of the Qdrant vector database |

--- a/lingproc/Cargo.toml
+++ b/lingproc/Cargo.toml
@@ -16,3 +16,5 @@ serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
 tokio-test = "0.4"
+warp = "0.3"
+serde_json = "1"

--- a/lingproc/src/provider.rs
+++ b/lingproc/src/provider.rs
@@ -124,6 +124,7 @@ impl ModelRunnerProvider for OllamaProvider {
     }
 
     async fn processor_for(&self, model: &str) -> anyhow::Result<Box<dyn Processor + Send + Sync>> {
+        crate::ensure_model_available(model).await?;
         let proc = crate::OllamaProcessor::new(model);
         let proc = ProfilingProcessor::new(proc);
         Ok(Box::new(ManagedProcessor::new(

--- a/modeldb/src/lib.rs
+++ b/modeldb/src/lib.rs
@@ -68,6 +68,53 @@ impl ModelRepository {
     }
 }
 
+/// Return a [`ModelRepository`] preloaded with common models from the
+/// [Ollama library](https://ollama.com).
+///
+/// The repository includes several freely available models with their basic
+/// capabilities.
+///
+/// # Examples
+///
+/// ```
+/// let repo = modeldb::ollama_models();
+/// assert!(repo.find("gemma3:27b").is_some());
+/// ```
+pub fn ollama_models() -> ModelRepository {
+    let mut repo = ModelRepository::new();
+    repo.add_model(AiModel {
+        name: "gemma3:27b".into(),
+        supports_images: false,
+        speed: None,
+        cost_per_token: None,
+    });
+    repo.add_model(AiModel {
+        name: "llama3:70b".into(),
+        supports_images: false,
+        speed: None,
+        cost_per_token: None,
+    });
+    repo.add_model(AiModel {
+        name: "phi3:mini".into(),
+        supports_images: false,
+        speed: None,
+        cost_per_token: None,
+    });
+    repo.add_model(AiModel {
+        name: "codellama:34b".into(),
+        supports_images: false,
+        speed: None,
+        cost_per_token: None,
+    });
+    repo.add_model(AiModel {
+        name: "llava:34b".into(),
+        supports_images: true,
+        speed: None,
+        cost_per_token: None,
+    });
+    repo
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -82,5 +129,11 @@ mod tests {
             cost_per_token: Some(0.01),
         });
         assert!(repo.find("gpt4").is_some());
+    }
+
+    #[test]
+    fn default_ollama_models_present() {
+        let repo = ollama_models();
+        assert!(repo.find("gemma3:27b").is_some());
     }
 }

--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -23,27 +23,28 @@ async fn main() -> Result<()> {
         Box::new(psyche::sensors::ConnectionSensor::default()),
     ];
 
+    let model = std::env::var("OLLAMA_MODEL").unwrap_or_else(|_| "gemma3:27b".into());
     let heart = psyche::Heart::new(vec![
         psyche::Wit::with_config(
-            psyche::ProcessorScheduler::new(lingproc::OllamaProcessor::new("llama2")),
+            psyche::ProcessorScheduler::new(lingproc::OllamaProcessor::new(&model)),
             Echo,
             Some("fond".into()),
             std::time::Duration::from_secs(1),
         ),
         psyche::Wit::with_config(
-            psyche::ProcessorScheduler::new(lingproc::OllamaProcessor::new("llama2")),
+            psyche::ProcessorScheduler::new(lingproc::OllamaProcessor::new(&model)),
             Echo,
             Some("wit2".into()),
             std::time::Duration::from_secs(2),
         ),
         psyche::Wit::with_config(
-            psyche::ProcessorScheduler::new(lingproc::OllamaProcessor::new("llama2")),
+            psyche::ProcessorScheduler::new(lingproc::OllamaProcessor::new(&model)),
             Echo,
             Some("wit3".into()),
             std::time::Duration::from_secs(4),
         ),
         psyche::Wit::with_config(
-            psyche::ProcessorScheduler::new(lingproc::OllamaProcessor::new("llama2")),
+            psyche::ProcessorScheduler::new(lingproc::OllamaProcessor::new(&model)),
             Echo,
             Some("quick".into()),
             std::time::Duration::from_secs(8),


### PR DESCRIPTION
## Summary
- include a list of common Ollama models in `modeldb`
- pull missing models on demand in `lingproc`
- default model is now `gemma3:27b`
- allow configuring the model via `OLLAMA_MODEL`

## Testing
- `cargo test -p modeldb`
- `cargo test -p lingproc`
- `cargo test -p pete`

------
https://chatgpt.com/codex/tasks/task_e_6846a29d51048320a024d5ab96ae13cf