### PR TITLE
Fix scheduler test runtime and auto-refresh

### DIFF
--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -584,8 +584,8 @@ mod tests {
         assert!(!heart.quick().unwrap().memory.all().is_empty());
     }
 
-    #[test]
-    fn processor_scheduler_runs_llm() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn processor_scheduler_runs_llm() {
         use async_stream::stream;
         use async_trait::async_trait;
         use futures::{StreamExt, stream::BoxStream};

--- a/psyche/static/index.html
+++ b/psyche/static/index.html
@@ -64,6 +64,7 @@ async function refresh() {
 }
 document.getElementById('refresh').addEventListener('click', refresh);
 refresh();
+setInterval(refresh, 2000);
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- fix `processor_scheduler_runs_llm` test by running it on a multi-thread Tokio runtime
- auto-refresh scheduler info on the dashboard every 2s

## Testing
- `cargo test -p psyche --quiet`
- `cargo test -p pete --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6846b2f4113c8320be38cfe022592064