### PR TITLE
Improve processor error handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@
 - Follow BDD/TDD principles; add tests alongside new features.
 - Use concise commit messages.
 - Prefer doc tests and examples for public APIs to aid understanding.
+- Log errors instead of silently discarding them.
 - When testing streams created with `async_stream`, ensure you poll once more
   after the final item to trigger any cleanup logic.
 - When storing timestamped data, prefer field names `when` and `what` for

--- a/psyche/AGENTS.md
+++ b/psyche/AGENTS.md
@@ -5,3 +5,4 @@
 - Use Foundation for any dashboard styling; avoid Bootstrap.
 - Display queue lengths and timing progress on the scheduler dashboard.
 - Prefer `Heart::run_serial` for background loops instead of timer sleeps.
+- Log processor errors instead of dropping them.


### PR DESCRIPTION
## Summary
- log processor errors instead of discarding them
- test graceful scheduler failure
- document the new rule about logging errors in `AGENTS.md`

## Testing
- `cargo test -p psyche --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6846b74cec088320b7e88fcb31e8a375