### PR TITLE
fix capability advertisement

### DIFF
--- a/lingproc/src/scheduler.rs
+++ b/lingproc/src/scheduler.rs
@@ -23,7 +23,13 @@ use futures::stream::BoxStream;
 /// #[async_trait]
 /// impl ModelRunnerProvider for EchoProvider {
 ///     async fn models(&self) -> anyhow::Result<Vec<modeldb::AiModel>> {
-///         Ok(vec![modeldb::AiModel { name: "echo".into(), supports_images: false, speed: None, cost_per_token: None }])
+///         Ok(vec![modeldb::AiModel {
+///             name: "echo".into(),
+///             supports_images: false,
+///             speed: None,
+///             cost_per_token: None,
+///             capabilities: vec![modeldb::Capability::InstructionFollowing],
+///         }])
 ///     }
 ///     async fn processor_for(&self, _model: &str) -> anyhow::Result<Box<dyn Processor + Send + Sync>> {
 ///         struct Echo;
@@ -137,6 +143,7 @@ mod tests {
                 supports_images: false,
                 speed: None,
                 cost_per_token: None,
+                capabilities: vec![modeldb::Capability::InstructionFollowing],
             }])
         }
 

--- a/modeldb/src/lib.rs
+++ b/modeldb/src/lib.rs
@@ -105,21 +105,21 @@ pub fn ollama_models() -> ModelRepository {
         supports_images: false,
         speed: None,
         cost_per_token: None,
-        capabilities: vec![Capability::ChatCompletion],
+        capabilities: vec![Capability::ChatCompletion, Capability::InstructionFollowing],
     });
     repo.add_model(AiModel {
         name: "llama3:70b".into(),
         supports_images: false,
         speed: None,
         cost_per_token: None,
-        capabilities: vec![Capability::ChatCompletion],
+        capabilities: vec![Capability::ChatCompletion, Capability::InstructionFollowing],
     });
     repo.add_model(AiModel {
         name: "phi3:mini".into(),
         supports_images: false,
         speed: None,
         cost_per_token: None,
-        capabilities: vec![Capability::ChatCompletion],
+        capabilities: vec![Capability::ChatCompletion, Capability::InstructionFollowing],
     });
     repo.add_model(AiModel {
         name: "codellama:34b".into(),

--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -147,6 +147,14 @@ impl<P> ProcessorScheduler<P> {
     pub fn new(processor: P) -> Self {
         Self { processor }
     }
+
+    /// Capabilities advertised by the underlying processor.
+    pub fn capabilities(&self) -> Vec<lingproc::TaskKind>
+    where
+        P: lingproc::Processor,
+    {
+        self.processor.capabilities()
+    }
 }
 
 impl<P> Scheduler for ProcessorScheduler<P>


### PR DESCRIPTION
## Summary
- advertise both chat and instruction modes for Ollama models
- show processor capabilities in the scheduler dashboard

## Testing
- `cargo test -p lingproc`
- `cargo test -p modeldb`
- `cargo test -p psyche`

------
https://chatgpt.com/codex/tasks/task_e_6846ff9cd76c83208292977b37554769