### PR TITLE
Fix scheduler details display

### DIFF
--- a/psyche/static/index.html
+++ b/psyche/static/index.html
@@ -51,6 +51,7 @@ async function refresh() {
     const pinfo = psyche.wits[i] || {};
     const pct = pinfo.interval_ms ? Math.min(100, Math.round(100 * (pinfo.interval_ms - w.due_ms) / pinfo.interval_ms)) : 0;
     const det = document.createElement('details');
+    det.open = true;
     const name = w.name ?? `Processor ${i}`;
     det.innerHTML = `<summary>${name}</summary>` +
       `<blockquote>${w.last ?? ''}</blockquote>` +


### PR DESCRIPTION
## Summary
- expand details elements in the scheduler dashboard by default

## Testing
- `cargo test -p psyche`

------
https://chatgpt.com/codex/tasks/task_e_68473253dfc48320a9674a17362e9519