### PR TITLE
Add multi-wit flow test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@
 - Use concise commit messages.
 - Prefer doc tests and examples for public APIs to aid understanding.
 - Log errors instead of silently discarding them.
+- Include tests that verify the heart passes experiences across multiple wits.
 - When testing streams created with `async_stream`, ensure you poll once more
   after the final item to trigger any cleanup logic.
 - When storing timestamped data, prefer field names `when` and `what` for

--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -643,6 +643,20 @@ mod tests {
         assert!(!heart.wits[1].memory.all().is_empty());
     }
 
+    #[test]
+    fn heart_flows_across_three_wits() {
+        use std::time::Duration;
+        let w1 = Wit::with_config(JoinScheduler::default(), Echo, None, Duration::from_secs(0));
+        let w2 = Wit::with_config(JoinScheduler::default(), Echo, None, Duration::from_secs(0));
+        let w3 = Wit::with_config(JoinScheduler::default(), Echo, None, Duration::from_secs(0));
+        let mut heart = Heart::new(vec![w1, w2, w3]);
+        heart.push(Experience::new("a"));
+        heart.push(Experience::new("b"));
+        heart.run_serial();
+        assert_eq!(heart.wits[0].memory.all()[0].what, "a b");
+        assert_eq!(heart.wits[2].memory.all()[0].what, "a b");
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn processor_scheduler_runs_llm() {
         use async_stream::stream;


### PR DESCRIPTION
## Summary
- test heart pushes across three wits
- document verifying multi-wit flow in AGENTS

## Testing
- `cargo test -p psyche --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684738a03c1883208daf56194173e54d