### PR TITLE
Fix heart tick output

### DIFF
--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -73,7 +73,7 @@ async fn main() -> Result<()> {
             loop {
                 {
                     let mut p = psyche.lock().await;
-                    p.heart.tick();
+                    let _ = p.heart.tick();
                 }
                 tokio::task::yield_now().await;
             }

--- a/psyche/src/server.rs
+++ b/psyche/src/server.rs
@@ -376,7 +376,7 @@ mod tests {
         {
             let mut p = psyche.lock().await;
             p.heart.wits[0].push(Experience::new("hello"));
-            p.heart.tick();
+            let _ = p.heart.tick();
         }
 
         let resp = scheduler_handler::<JoinScheduler, Echo>(psyche.clone())


### PR DESCRIPTION
## Summary
- return final experience from Heart and loops
- adjust tick callers to ignore Option
- add regression test for Wit queue clearing

## Testing
- `cargo test -p psyche`

------
https://chatgpt.com/codex/tasks/task_e_6847444254a48320af1fedddb393ab33