### PR TITLE
Implement wit-owned prompt styles

### DIFF
--- a/psyche/AGENTS.md
+++ b/psyche/AGENTS.md
@@ -6,3 +6,5 @@
 - Display queue lengths and timing progress on the scheduler dashboard.
 - Prefer `Heart::run_serial` for background loops instead of timer sleeps.
 - Log processor errors instead of dropping them.
+- Distinguish wit prompts via `PromptStyle` (Objective, Reflective, Identity).
+  Each `Wit` owns its style and configures its scheduler before running.


### PR DESCRIPTION
## Summary
- move PromptStyle management into `Wit`
- add `Styleable` trait for schedulers
- update server and binary for new APIs
- document wit-owned styles in `psyche/AGENTS.md`

## Testing
- `cargo test -p psyche`
- `cargo test -p pete`


------
https://chatgpt.com/codex/tasks/task_e_68486b4aec188320bb6d30af6955badb