### PR TITLE
Remove images from embedding task

### DIFF
--- a/lingproc/src/lib.rs
+++ b/lingproc/src/lib.rs
@@ -44,12 +44,11 @@ pub struct ChatCompletionTask {
     pub messages: Vec<Message>,
 }
 
-/// Produce embeddings for a single sentence.
+/// Produce embeddings for a single sentence. Images are currently only
+/// supported for [`InstructionFollowingTask`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SentenceEmbeddingTask {
     pub sentence: String,
-    #[serde(default)]
-    pub images: Vec<Vec<u8>>,
 }
 
 /// Follow a natural language instruction and return textual output.
@@ -369,7 +368,6 @@ mod tests {
         let proc = OllamaProcessor::new("nomic-embed-text");
         let task = Task::SentenceEmbedding(SentenceEmbeddingTask {
             sentence: "hello world".into(),
-            images: vec![],
         });
         let mut stream = proc.process(task).await.unwrap();
         let first = stream.next().await.unwrap().unwrap();


### PR DESCRIPTION
## Summary
- document that images are only supported for InstructionFollowingTask
- drop `images` field from `SentenceEmbeddingTask`
- update embedding test

## Testing
- `cargo test -p lingproc`

------
https://chatgpt.com/codex/tasks/task_e_6848daa220508320b74507fb86b33756