### PR TITLE
Add configurable Ollama servers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,8 @@
 - Use `how` for the descriptive text inside an `Experience`.
 - Each psyche should create its own `EventBus` and web server. Avoid globals.
 - Keep `README.md` in sync with `docker-compose.yml` whenever services change.
+- When mocking Ollama endpoints in tests, include all fields the client expects
+  (e.g. `modified_at`, `size`) to avoid parsing errors.
 
 ## Project Overview
 Daringsby houses several Rust crates forming a model cognitive system named Pete. Events flow through sensors into a `Heart` of `Wit`s which summarize and store experiences.

--- a/lingproc/src/lib.rs
+++ b/lingproc/src/lib.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 pub mod provider;
 pub use provider::{ModelRunnerProvider, OllamaProvider, OpenAIProvider, ProviderProfile};
 
+pub mod ollama_server;
 pub mod profiling;
 pub mod scheduler;
 /// Role of a chat participant.
@@ -93,9 +94,21 @@ pub struct OllamaProcessor {
 }
 
 impl OllamaProcessor {
+    /// Create a processor using the default Ollama client.
     pub fn new(model: &str) -> Self {
+        Self::with_client(ollama_rs::Ollama::default(), model)
+    }
+
+    /// Create a processor backed by a custom Ollama client.
+    ///
+    /// ```no_run
+    /// let client = ollama_rs::Ollama::new("http://localhost", 11434);
+    /// let proc = lingproc::OllamaProcessor::with_client(client, "gemma3");
+    /// assert_eq!(proc.model, "gemma3");
+    /// ```
+    pub fn with_client(client: ollama_rs::Ollama, model: &str) -> Self {
         Self {
-            client: ollama_rs::Ollama::default(),
+            client,
             model: model.to_string(),
         }
     }

--- a/lingproc/src/ollama_server.rs
+++ b/lingproc/src/ollama_server.rs
@@ -1,0 +1,74 @@
+use anyhow::Context;
+use modeldb::{AiModel, ModelRepository};
+
+/// Attributes describing an Ollama server.
+#[derive(Debug, Clone, Default)]
+pub struct OllamaServer {
+    pub client: ollama_rs::Ollama,
+    /// Whether the server runs on the local machine.
+    pub local: bool,
+    /// Whether the server is considered fast relative to others.
+    pub fast: bool,
+    /// Whether usage is free of charge.
+    pub free: bool,
+}
+
+impl OllamaServer {
+    /// Create a new server description.
+    pub fn new(client: ollama_rs::Ollama, local: bool, fast: bool, free: bool) -> Self {
+        Self {
+            client,
+            local,
+            fast,
+            free,
+        }
+    }
+
+    /// Retrieve the list of installed model names.
+    pub async fn list_models(&self) -> anyhow::Result<Vec<String>> {
+        let models = self
+            .client
+            .list_local_models()
+            .await
+            .context("failed to query models from server")?;
+        Ok(models.into_iter().map(|m| m.name).collect())
+    }
+
+    /// Ensure `model` is available on this server, pulling if necessary.
+    pub async fn pull_model(&self, model: &str) -> anyhow::Result<()> {
+        crate::ensure_model_with_client(&self.client, model).await
+    }
+
+    /// Convert the list of names from [`list_models`] into [`AiModel`]s using
+    /// `repo` for metadata lookup.
+    pub async fn models(&self, repo: &ModelRepository) -> anyhow::Result<Vec<AiModel>> {
+        let names = self.list_models().await?;
+        Ok(names
+            .into_iter()
+            .filter_map(|n| repo.find(&n).cloned())
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use warp::Filter;
+
+    #[tokio::test]
+    async fn lists_models() {
+        let tags = warp::path("api").and(warp::path("tags")).map(|| {
+            warp::reply::json(&serde_json::json!({
+                "models": [{"name": "gemma3", "modified_at":"0", "size":0}]
+            }))
+        });
+        let (addr, server) = warp::serve(tags).bind_ephemeral(([127, 0, 0, 1], 0));
+        tokio::task::spawn(server);
+
+        let client = ollama_rs::Ollama::new(format!("http://{}", addr.ip()), addr.port());
+        let server = OllamaServer::new(client, true, true, true);
+        let repo = modeldb::ollama_models();
+        let models = server.models(&repo).await.unwrap();
+        assert!(models.iter().any(|m| m.name == "gemma3"));
+    }
+}


### PR DESCRIPTION
## Summary
- make `OllamaProcessor` accept a custom client
- expose new `OllamaServer` helper with model listing and pulling
- update `OllamaProvider` to use servers
- document mocking advice in `AGENTS.md`
- add tests for the new server logic

## Testing
- `cargo test -p lingproc --lib --tests`
- `cargo check -p lingproc`

------
https://chatgpt.com/codex/tasks/task_e_6848dd20bf1483209577585c7de8ba12