### PR TITLE
Refactor sensors to buffer events

### DIFF
--- a/psyche/src/server.rs
+++ b/psyche/src/server.rs
@@ -255,12 +255,18 @@ mod tests {
     use serde_json::Value;
     use warp::Reply;
 
-    struct Echo;
+    struct Echo {
+        last: Option<String>,
+    }
 
     impl crate::Sensor for Echo {
         type Input = String;
-        fn feel(&mut self, s: Sensation<Self::Input>) -> Option<Experience> {
-            Some(Experience::new(s.what))
+        fn feel(&mut self, s: Sensation<Self::Input>) {
+            self.last = Some(s.what);
+        }
+
+        fn experience(&mut self) -> Experience {
+            Experience::new(self.last.take().unwrap())
         }
     }
 


### PR DESCRIPTION
## Summary
- split Sensor::feel and Sensor::experience
- update ChatSensor and ConnectionSensor implementations
- adjust Psyche event flow and tests

## Testing
- `cargo test -p psyche --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6848ed4d678c83208809518c842609e3