### PR TITLE
Add custom prompts and multi-experience sensors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@
 - Prefer doc tests and examples for public APIs to aid understanding.
 - Log errors instead of silently discarding them.
 - Include tests that verify the heart passes experiences across multiple wits.
+- Sensors should return a vector of experiences.
 - When testing streams created with `async_stream`, ensure you poll once more
   after the final item to trigger any cleanup logic.
 - When storing timestamped data, prefer field names `when` and `what` for

--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -9,7 +9,7 @@ async fn main() -> Result<()> {
     let bus = Arc::new(psyche::bus::EventBus::new());
     psyche::logging::init(bus.clone())?;
 
-    let sensors: Vec<Box<dyn psyche::Sensor<Input = psyche::bus::Event> + Send + Sync>> = vec![
+    let external_sensors: Vec<Box<dyn psyche::Sensor<Input = psyche::bus::Event> + Send + Sync>> = vec![
         Box::new(psyche::sensors::ChatSensor::default()),
         Box::new(psyche::sensors::ConnectionSensor::default()),
     ];
@@ -22,25 +22,29 @@ async fn main() -> Result<()> {
             psyche::ProcessorScheduler::new(lingproc::OllamaProcessor::new(&model)),
             Some("fond".into()),
             std::time::Duration::from_secs(1),
+            "fond",
         ),
         psyche::Wit::with_config(
             psyche::ProcessorScheduler::new(lingproc::OllamaProcessor::new(&model)),
             Some("wit2".into()),
             std::time::Duration::from_secs(2),
+            "wit2",
         ),
         psyche::Wit::with_config(
             psyche::ProcessorScheduler::new(lingproc::OllamaProcessor::new(&model)),
             Some("wit3".into()),
             std::time::Duration::from_secs(4),
+            "wit3",
         ),
         psyche::Wit::with_config(
             psyche::ProcessorScheduler::new(lingproc::OllamaProcessor::new(&model)),
             Some("quick".into()),
             std::time::Duration::from_secs(8),
+            "quick",
         ),
     ]);
 
-    let psyche = Arc::new(Mutex::new(psyche::Psyche::new(heart, sensors)));
+    let psyche = Arc::new(Mutex::new(psyche::Psyche::new(heart, external_sensors)));
 
     {
         let bus = bus.clone();

--- a/psyche/src/sensors.rs
+++ b/psyche/src/sensors.rs
@@ -7,8 +7,8 @@ use crate::{Experience, Sensation, Sensor, bus::Event};
 /// use psyche::{bus::Event, sensors::ChatSensor, Sensation, Sensor};
 /// let mut sensor = ChatSensor::default();
 /// sensor.feel(Sensation::new(Event::Chat("hi".into())));
-/// let exp = sensor.experience();
-/// assert_eq!(exp.how, "I heard someone say: hi");
+/// let exps = sensor.experience();
+/// assert_eq!(exps[0].how, "I heard someone say: hi");
 /// ```
 #[derive(Default)]
 pub struct ChatSensor {
@@ -23,10 +23,10 @@ impl Sensor for ChatSensor {
         }
     }
 
-    fn experience(&mut self) -> Experience {
+    fn experience(&mut self) -> Vec<Experience> {
         match self.last.take() {
-            Some(line) => Experience::new(format!("I heard someone say: {line}")),
-            None => Experience::new("I heard nothing."),
+            Some(line) => vec![Experience::new(format!("I heard someone say: {line}"))],
+            None => vec![Experience::new("I heard nothing.")],
         }
     }
 }
@@ -40,8 +40,8 @@ impl Sensor for ChatSensor {
 /// let mut sensor = ConnectionSensor::default();
 /// let addr: SocketAddr = "127.0.0.1:80".parse().unwrap();
 /// sensor.feel(Sensation::new(Event::Connected(addr)));
-/// let exp = sensor.experience();
-/// assert!(exp.how.contains("127.0.0.1"));
+/// let exps = sensor.experience();
+/// assert!(exps[0].how.contains("127.0.0.1"));
 /// ```
 #[derive(Default)]
 pub struct ConnectionSensor {
@@ -57,15 +57,15 @@ impl Sensor for ConnectionSensor {
         }
     }
 
-    fn experience(&mut self) -> Experience {
+    fn experience(&mut self) -> Vec<Experience> {
         match self.last.take() {
             Some(Event::Connected(addr)) => {
-                Experience::new(format!("Someone at {addr} connected."))
+                vec![Experience::new(format!("Someone at {addr} connected."))]
             }
             Some(Event::Disconnected(addr)) => {
-                Experience::new(format!("Connection from {addr} closed."))
+                vec![Experience::new(format!("Connection from {addr} closed."))]
             }
-            _ => Experience::new("No connection events."),
+            _ => vec![Experience::new("No connection events.")],
         }
     }
 }
@@ -78,8 +78,8 @@ mod tests {
     fn chat_event_to_experience() {
         let mut sensor = ChatSensor::default();
         sensor.feel(Sensation::new(Event::Chat("hello".into())));
-        let exp = sensor.experience();
-        assert_eq!(exp.how, "I heard someone say: hello");
+        let exps = sensor.experience();
+        assert_eq!(exps[0].how, "I heard someone say: hello");
     }
 
     #[test]
@@ -87,10 +87,10 @@ mod tests {
         let addr: std::net::SocketAddr = "127.0.0.1:80".parse().unwrap();
         let mut sensor = ConnectionSensor::default();
         sensor.feel(Sensation::new(Event::Connected(addr)));
-        let exp = sensor.experience();
-        assert_eq!(exp.how, "Someone at 127.0.0.1:80 connected.");
+        let exps = sensor.experience();
+        assert_eq!(exps[0].how, "Someone at 127.0.0.1:80 connected.");
         sensor.feel(Sensation::new(Event::Disconnected(addr)));
-        let exp = sensor.experience();
-        assert_eq!(exp.how, "Connection from 127.0.0.1:80 closed.");
+        let exps = sensor.experience();
+        assert_eq!(exps[0].how, "Connection from 127.0.0.1:80 closed.");
     }
 }

--- a/psyche/src/server.rs
+++ b/psyche/src/server.rs
@@ -130,7 +130,7 @@ where
         })
         .collect();
     let sensors = psyche
-        .sensors
+        .external_sensors
         .iter()
         .map(|s| type_name_of_val(&**s).to_string())
         .collect();
@@ -265,14 +265,14 @@ mod tests {
             self.last = Some(s.what);
         }
 
-        fn experience(&mut self) -> Experience {
-            Experience::new(self.last.take().unwrap())
+        fn experience(&mut self) -> Vec<Experience> {
+            vec![Experience::new(self.last.take().unwrap())]
         }
     }
 
     #[tokio::test]
     async fn wit_endpoint_returns_memory() {
-        let heart = Heart::new(vec![Wit::new(JoinScheduler::default())]);
+        let heart = Heart::new(vec![Wit::new(JoinScheduler::default(), "test")]);
         let psyche = Arc::new(Mutex::new(Psyche::new(heart, vec![])));
 
         {
@@ -298,6 +298,7 @@ mod tests {
             ProcessorScheduler::new(OllamaProcessor::new("model")),
             Some("w1".into()),
             std::time::Duration::from_secs(0),
+            "test",
         )]);
         let psyche = Arc::new(Mutex::new(Psyche::new(
             heart,
@@ -321,6 +322,7 @@ mod tests {
             ProcessorScheduler::new(OllamaProcessor::new("llama-test")),
             None,
             std::time::Duration::from_secs(0),
+            "test",
         )]);
         let psyche = Arc::new(Mutex::new(Psyche::new(heart, vec![])));
 
@@ -340,6 +342,7 @@ mod tests {
             JoinScheduler::default(),
             Some("q".into()),
             std::time::Duration::from_millis(100),
+            "test",
         )]);
         let psyche = Arc::new(Mutex::new(Psyche::new(heart, vec![])));
 
@@ -368,6 +371,7 @@ mod tests {
             JoinScheduler::default(),
             None,
             std::time::Duration::from_secs(0),
+            "test",
         )]);
         let psyche = Arc::new(Mutex::new(Psyche::new(heart, vec![])));
 


### PR DESCRIPTION
## Summary
- allow sensors to yield multiple experiences
- track a custom prompt on each `Wit`
- rename sensors vector in `Psyche` to `external_sensors`
- adjust server and binary to use the new names
- document the new behavior in examples
- add development note about sensor outputs

## Testing
- `cargo test -p psyche`
- `cargo test -p pete`

------
https://chatgpt.com/codex/tasks/task_e_6848f681cbec8320b3d4bda42f1d92f1