### PR TITLE
Move default wits into psyche

### DIFF
--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -17,34 +17,11 @@ async fn main() -> Result<()> {
     let model = std::env::var("OLLAMA_MODEL").unwrap_or_else(|_| "gemma3".into());
     lingproc::ensure_model_available(&model).await?;
     info!("model {model} ready");
-    let heart = psyche::Heart::new(vec![
-        psyche::Wit::with_config(
-            psyche::ProcessorScheduler::new(lingproc::OllamaProcessor::new(&model)),
-            Some("fond".into()),
-            std::time::Duration::from_secs(1),
-            "fond",
-        ),
-        psyche::Wit::with_config(
-            psyche::ProcessorScheduler::new(lingproc::OllamaProcessor::new(&model)),
-            Some("wit2".into()),
-            std::time::Duration::from_secs(2),
-            "wit2",
-        ),
-        psyche::Wit::with_config(
-            psyche::ProcessorScheduler::new(lingproc::OllamaProcessor::new(&model)),
-            Some("wit3".into()),
-            std::time::Duration::from_secs(4),
-            "wit3",
-        ),
-        psyche::Wit::with_config(
-            psyche::ProcessorScheduler::new(lingproc::OllamaProcessor::new(&model)),
-            Some("quick".into()),
-            std::time::Duration::from_secs(8),
-            "quick",
-        ),
-    ]);
-
-    let psyche = Arc::new(Mutex::new(psyche::Psyche::new(heart, external_sensors)));
+    let make_sched = || psyche::ProcessorScheduler::new(lingproc::OllamaProcessor::new(&model));
+    let psyche = Arc::new(Mutex::new(psyche::Psyche::new(
+        make_sched,
+        external_sensors,
+    )));
 
     {
         let bus = bus.clone();

--- a/psyche/src/server.rs
+++ b/psyche/src/server.rs
@@ -273,7 +273,7 @@ mod tests {
     #[tokio::test]
     async fn wit_endpoint_returns_memory() {
         let heart = Heart::new(vec![Wit::new(JoinScheduler::default(), "test")]);
-        let psyche = Arc::new(Mutex::new(Psyche::new(heart, vec![])));
+        let psyche = Arc::new(Mutex::new(Psyche::with_heart(heart, vec![])));
 
         {
             let mut p = psyche.lock().await;
@@ -300,7 +300,7 @@ mod tests {
             std::time::Duration::from_secs(0),
             "test",
         )]);
-        let psyche = Arc::new(Mutex::new(Psyche::new(
+        let psyche = Arc::new(Mutex::new(Psyche::with_heart(
             heart,
             vec![Box::new(crate::sensors::ChatSensor::default())],
         )));
@@ -324,7 +324,7 @@ mod tests {
             std::time::Duration::from_secs(0),
             "test",
         )]);
-        let psyche = Arc::new(Mutex::new(Psyche::new(heart, vec![])));
+        let psyche = Arc::new(Mutex::new(Psyche::with_heart(heart, vec![])));
 
         let resp = scheduler_handler::<ProcessorScheduler<OllamaProcessor>>(psyche.clone())
             .await
@@ -344,7 +344,7 @@ mod tests {
             std::time::Duration::from_millis(100),
             "test",
         )]);
-        let psyche = Arc::new(Mutex::new(Psyche::new(heart, vec![])));
+        let psyche = Arc::new(Mutex::new(Psyche::with_heart(heart, vec![])));
 
         {
             let mut p = psyche.lock().await;
@@ -373,7 +373,7 @@ mod tests {
             std::time::Duration::from_secs(0),
             "test",
         )]);
-        let psyche = Arc::new(Mutex::new(Psyche::new(heart, vec![])));
+        let psyche = Arc::new(Mutex::new(Psyche::with_heart(heart, vec![])));
 
         {
             let mut p = psyche.lock().await;


### PR DESCRIPTION
## Summary
- construct Pete's wits inside `Psyche::new`
- add `Psyche::with_heart` helper for tests
- update docs and tests
- simplify binary startup logic

## Testing
- `cargo test -p psyche --doc`
- `cargo test --all`

------
https://chatgpt.com/codex/tasks/task_e_68490014ad1083209cf398409a91a42b