### PR TITLE
Implement Heart Sensor interface

### DIFF
--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -42,7 +42,7 @@ async fn main() -> Result<()> {
             loop {
                 {
                     let mut p = psyche.lock().await;
-                    let _ = p.heart.tick();
+                    let _ = p.heart.experience();
                 }
                 tokio::task::yield_now().await;
             }

--- a/psyche/AGENTS.md
+++ b/psyche/AGENTS.md
@@ -6,3 +6,5 @@
 - Display queue lengths and timing progress on the scheduler dashboard.
 - Prefer `Heart::run_serial` for background loops instead of timer sleeps.
 - Log processor errors instead of dropping them.
+- `Heart` implements `Sensor`; use `feel` and `experience` in place of
+  `push` and `tick`.


### PR DESCRIPTION
## Summary
- implement `Sensor` for `Heart`
- update `pete` main loop for new API
- document new `Heart` interface in psyche guidelines

## Testing
- `cargo test -p psyche`

------
https://chatgpt.com/codex/tasks/task_e_68493e9bc2ac83208e73a218b411901f