### PR TITLE
Simplify heart to single quick wit

### DIFF
--- a/psyche/AGENTS.md
+++ b/psyche/AGENTS.md
@@ -4,7 +4,7 @@
 - Sensor trait only; add sensors in binary crates.
 - Use Foundation for any dashboard styling; avoid Bootstrap.
 - Display queue lengths and timing progress on the scheduler dashboard.
-- Prefer `Heart::run_serial` for background loops instead of timer sleeps.
+- Prefer `Heart::beat` for background loops instead of timer sleeps.
 - Log processor errors instead of dropping them.
 - `Heart` implements `Sensor`; use `feel` and `experience` in place of
   `push` and `tick`.

--- a/psyche/src/heart.rs
+++ b/psyche/src/heart.rs
@@ -1,38 +1,34 @@
 use crate::{Experience, Scheduler, Sensation, Sensor, Wit};
 
-/// Stack of wits from fond (index 0) to quick (last index).
+/// A single layer heart containing just the "quick" [`Wit`].
 ///
-/// `Heart` implements [`Sensor`] so experiences can be fed into the fond wit
-/// via [`Sensor::feel`] and processed through each wit using
-/// [`Sensor::experience`].
+/// `Heart` implements [`Sensor`], forwarding sensations directly to the quick
+/// wit. Call [`Heart::beat`] to process queued sensations and store the
+/// resulting experiences.
 pub struct Heart<W> {
-    pub wits: Vec<W>,
+    /// The sole wit handling all reflection.
+    pub quick: W,
+    /// Buffer of experiences returned from the last [`beat`](Self::beat) call.
+    pub buffer: Vec<Experience>,
 }
 
 impl<W> Heart<W> {
-    /// Create a heart from a set of wits.
-    pub fn new(wits: Vec<W>) -> Self {
-        Self { wits }
+    /// Create a heart from a single quick wit.
+    pub fn new(quick: W) -> Self {
+        Self {
+            quick,
+            buffer: Vec::new(),
+        }
     }
 
-    /// Reference to the fond (first wit).
-    pub fn fond(&self) -> Option<&W> {
-        self.wits.first()
-    }
-
-    /// Mutable reference to the fond (first wit).
-    pub fn fond_mut(&mut self) -> Option<&mut W> {
-        self.wits.first_mut()
-    }
-
-    /// Reference to the quick (last wit).
+    /// Reference to the quick wit.
     pub fn quick(&self) -> Option<&W> {
-        self.wits.last()
+        Some(&self.quick)
     }
 
-    /// Mutable reference to the quick (last wit).
+    /// Mutable reference to the quick wit.
     pub fn quick_mut(&mut self) -> Option<&mut W> {
-        self.wits.last_mut()
+        Some(&mut self.quick)
     }
 }
 
@@ -41,74 +37,18 @@ where
     S: Scheduler,
     S::Output: Clone + Into<String>,
 {
-    /// Run ticks in serial until no wit produces output.
-    pub fn run_serial(&mut self) -> Option<Experience> {
-        loop {
-            let mut progressed = false;
-            let mut last_output = None;
-            for i in 0..self.wits.len() {
-                let outputs = self.wits[i].experience();
-                if !outputs.is_empty() {
-                    progressed = true;
-                }
-                for exp in outputs {
-                    if let Some(next) = self.wits.get_mut(i + 1) {
-                        next.feel(Sensation::new(exp));
-                    } else {
-                        last_output = Some(exp);
-                    }
-                }
-            }
-            if !progressed {
-                return last_output;
-            }
-        }
-    }
-
-    /// Continuously run ticks respecting each wit's interval.
-    pub fn run_scheduled(&mut self, cycles: usize) -> Option<Experience> {
-        use std::{
-            thread,
-            time::{Duration, Instant},
-        };
-        log::info!("running scheduled for {cycles} cycles");
-        let mut completed = 0usize;
-        let mut last_output = None;
-        while completed < cycles {
-            let now = Instant::now();
-            let mut next_wait: Option<Duration> = None;
-            for i in 0..self.wits.len() {
-                let elapsed = now.duration_since(self.wits[i].last_tick);
-                if elapsed >= self.wits[i].interval {
-                    self.wits[i].last_tick = now;
-                    let outputs = self.wits[i].experience();
-                    for exp in outputs {
-                        if let Some(next) = self.wits.get_mut(i + 1) {
-                            next.feel(Sensation::new(exp));
-                        } else {
-                            last_output = Some(exp);
-                        }
-                    }
-                    completed += 1;
-                }
-                let remaining = self.wits[i]
-                    .interval
-                    .checked_sub(elapsed)
-                    .unwrap_or_default();
-                next_wait = Some(match next_wait {
-                    Some(d) => d.min(remaining),
-                    None => remaining,
-                });
-            }
-            if let Some(wait) = next_wait {
-                if !wait.is_zero() {
-                    thread::sleep(wait);
-                }
-            } else {
-                return last_output;
-            }
-        }
-        last_output
+    /// Process queued sensations and store produced experiences.
+    ///
+    /// ```
+    /// use psyche::{Heart, JoinScheduler, Wit, Sensation, Sensor, Experience};
+    /// let mut heart = Heart::new(Wit::new(JoinScheduler::default(), "q"));
+    /// heart.feel(Sensation::new(Experience::new("hi")));
+    /// heart.beat();
+    /// assert!(!heart.buffer.is_empty());
+    /// ```
+    pub fn beat(&mut self) {
+        let outputs = self.quick.experience();
+        self.buffer.extend(outputs);
     }
 }
 
@@ -120,37 +60,13 @@ where
     type Input = Experience;
 
     fn feel(&mut self, sensation: Sensation<Self::Input>) {
-        let msg = sensation.what.how.clone();
-        log::info!("heart feel to fond: {}", msg);
-        if let Some(first) = self.wits.first_mut() {
-            first.feel(sensation);
-        }
+        log::info!("heart feel: {}", sensation.what.how);
+        self.quick.feel(sensation);
     }
 
     fn experience(&mut self) -> Vec<Experience> {
-        use std::time::Instant;
-        let mut outputs = Vec::new();
-        for i in 0..self.wits.len() {
-            let now = Instant::now();
-            let elapsed = now.duration_since(self.wits[i].last_tick);
-            if elapsed < self.wits[i].interval {
-                continue;
-            }
-            self.wits[i].last_tick = now;
-            let wit_outputs = {
-                let wit = &mut self.wits[i];
-                log::trace!("wit {i} experience");
-                wit.experience()
-            };
-            for exp in wit_outputs {
-                if let Some(next) = self.wits.get_mut(i + 1) {
-                    next.feel(Sensation::new(exp));
-                } else {
-                    outputs.push(exp);
-                }
-            }
-        }
-        outputs
+        self.beat();
+        std::mem::take(&mut self.buffer)
     }
 }
 
@@ -160,84 +76,30 @@ mod tests {
     use crate::{JoinScheduler, Sensation, Sensor, Wit};
 
     #[test]
-    fn heart_flows_between_wits() {
-        let w1 = Wit::with_config(
+    fn beat_stores_output() {
+        let mut heart = Heart::new(Wit::with_config(
             JoinScheduler::default(),
-            None,
+            Some("quick".into()),
             std::time::Duration::from_secs(0),
-            "p1",
-        );
-        let w2 = Wit::with_config(
-            JoinScheduler::default(),
-            None,
-            std::time::Duration::from_secs(0),
-            "p2",
-        );
-        let mut heart = Heart::new(vec![w1, w2]);
-        heart.feel(Sensation::new(Experience::new("hello")));
-        heart.feel(Sensation::new(Experience::new("world")));
-        let _ = heart.experience();
-        let _ = heart.experience();
-        assert_eq!(heart.wits[0].memory.all().len(), 1);
-        assert_eq!(heart.wits[1].memory.all()[0].what, "hello world");
-    }
-
-    #[test]
-    fn heart_helpers_and_scheduled() {
-        use std::time::Duration;
-        let w1 = Wit::with_config(
-            JoinScheduler::default(),
-            Some("fond".to_string()),
-            Duration::from_millis(1),
-            "fond",
-        );
-        let w2 = Wit::with_config(
-            JoinScheduler::default(),
-            Some("quick".to_string()),
-            Duration::from_millis(1),
             "quick",
-        );
-        let mut heart = Heart::new(vec![w1, w2]);
-        assert!(heart.fond().is_some());
-        assert!(heart.quick().is_some());
+        ));
         heart.feel(Sensation::new(Experience::new("hello")));
-        heart.feel(Sensation::new(Experience::new("world")));
-        let _ = heart.run_scheduled(2);
-        assert!(!heart.quick().unwrap().memory.all().is_empty());
+        heart.beat();
+        assert_eq!(heart.buffer.len(), 1);
+        assert_eq!(heart.buffer[0].how, "hello");
     }
 
     #[test]
-    fn run_serial_processes_until_idle() {
-        let w1 = Wit::with_config(
+    fn sensor_experience_returns_buffer() {
+        let mut heart = Heart::new(Wit::with_config(
             JoinScheduler::default(),
             None,
             std::time::Duration::from_secs(0),
-            "r1",
-        );
-        let w2 = Wit::with_config(
-            JoinScheduler::default(),
-            None,
-            std::time::Duration::from_secs(0),
-            "r2",
-        );
-        let mut heart = Heart::new(vec![w1, w2]);
-        heart.feel(Sensation::new(Experience::new("hello")));
-        let _ = heart.run_serial();
-        assert_eq!(heart.wits[0].memory.all().len(), 1);
-        assert!(!heart.wits[1].memory.all().is_empty());
-    }
-
-    #[test]
-    fn heart_flows_across_three_wits() {
-        use std::time::Duration;
-        let w1 = Wit::with_config(JoinScheduler::default(), None, Duration::from_secs(0), "r1");
-        let w2 = Wit::with_config(JoinScheduler::default(), None, Duration::from_secs(0), "r2");
-        let w3 = Wit::with_config(JoinScheduler::default(), None, Duration::from_secs(0), "r3");
-        let mut heart = Heart::new(vec![w1, w2, w3]);
-        heart.feel(Sensation::new(Experience::new("a")));
-        heart.feel(Sensation::new(Experience::new("b")));
-        let _ = heart.run_serial();
-        assert_eq!(heart.wits[0].memory.all()[0].what, "a b");
-        assert_eq!(heart.wits[2].memory.all()[0].what, "a b");
+            "q",
+        ));
+        heart.feel(Sensation::new(Experience::new("hi")));
+        let exps = heart.experience();
+        assert_eq!(exps.len(), 1);
+        assert!(heart.buffer.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- refactor `Heart` to contain only a `quick` wit
- implement `beat` method and buffer returned experiences
- drop old `run_*` methods and update tests
- update `Psyche` to build heart with a single quick wit
- adjust docs and guidelines

## Testing
- `cargo test -p psyche`


------
https://chatgpt.com/codex/tasks/task_e_684941af66d483209eee81fac515448c