### PR TITLE
Add multi-layer Heart with context pipeline

### DIFF
--- a/psyche/src/heart.rs
+++ b/psyche/src/heart.rs
@@ -1,58 +1,79 @@
 use crate::{Experience, Scheduler, Sensation, Sensor, Wit};
 
-/// A single layer heart containing just the "quick" [`Wit`].
+/// Multi-layer heart chaining a quick wit, combobulator and contextualizer.
 ///
-/// `Heart` implements [`Sensor`], forwarding sensations directly to the quick
-/// wit. Call [`Heart::beat`] to process queued sensations and store the
-/// resulting experiences.
-pub struct Heart<W> {
-    /// The sole wit handling all reflection.
-    pub quick: W,
-    /// Buffer of experiences returned from the last [`beat`](Self::beat) call.
-    pub buffer: Vec<Experience>,
-}
-
-impl<W> Heart<W> {
-    /// Create a heart from a single quick wit.
-    pub fn new(quick: W) -> Self {
-        Self {
-            quick,
-            buffer: Vec::new(),
-        }
-    }
-
-    /// Reference to the quick wit.
-    pub fn quick(&self) -> Option<&W> {
-        Some(&self.quick)
-    }
-
-    /// Mutable reference to the quick wit.
-    pub fn quick_mut(&mut self) -> Option<&mut W> {
-        Some(&mut self.quick)
-    }
-}
-
-impl<S> Heart<Wit<S>>
+/// `Heart` implements [`Sensor`], forwarding sensations to the quick wit. Call
+/// [`Heart::beat`] to propagate experiences through the wits and update the
+/// current instant, moment and context.
+pub struct Heart<S>
 where
     S: Scheduler,
     S::Output: Clone + Into<String>,
 {
-    /// Process queued sensations and store produced experiences.
-    ///
-    /// ```
-    /// use psyche::{Heart, JoinScheduler, Wit, Sensation, Sensor, Experience};
-    /// let mut heart = Heart::new(Wit::new(JoinScheduler::default(), "q"));
-    /// heart.feel(Sensation::new(Experience::new("hi")));
-    /// heart.beat();
-    /// assert!(!heart.buffer.is_empty());
-    /// ```
+    /// First layer reflecting raw experiences.
+    pub quick: Wit<S>,
+    /// Wit buffering instants into moments.
+    pub combobulator: Wit<S>,
+    /// Wit summarizing moments into context.
+    pub contextualizer: Wit<S>,
+    /// Latest experience from the quick wit.
+    pub instant: Option<Experience>,
+    /// Latest experience from the combobulator.
+    pub moment: Option<Experience>,
+    /// Latest context string from the contextualizer.
+    pub context: Option<String>,
+}
+
+impl<S> Heart<S>
+where
+    S: Scheduler,
+    S::Output: Clone + Into<String>,
+{
+    /// Create a new heart from three wits.
+    pub fn new(quick: Wit<S>, combobulator: Wit<S>, contextualizer: Wit<S>) -> Self {
+        Self {
+            quick,
+            combobulator,
+            contextualizer,
+            instant: None,
+            moment: None,
+            context: None,
+        }
+    }
+
+    /// Reference to the quick wit.
+    pub fn quick(&self) -> Option<&Wit<S>> {
+        Some(&self.quick)
+    }
+
+    /// Mutable reference to the quick wit.
+    pub fn quick_mut(&mut self) -> Option<&mut Wit<S>> {
+        Some(&mut self.quick)
+    }
+
+    /// Propagate experiences through all wits updating instant, moment and context.
     pub fn beat(&mut self) {
-        let outputs = self.quick.experience();
-        self.buffer.extend(outputs);
+        if let Some(inst) = self.quick.experience().pop() {
+            self.instant = Some(inst.clone());
+            self.combobulator.feel(Sensation::new(inst));
+        }
+
+        if let Some(mom) = self.combobulator.experience().pop() {
+            self.moment = Some(mom.clone());
+            self.contextualizer.feel(Sensation::new(mom));
+        }
+
+        if let Some(ctx) = self.contextualizer.experience().pop() {
+            let c = ctx.how.clone();
+            self.context = Some(c.clone());
+            self.quick.set_context(c.clone());
+            self.combobulator.set_context(c.clone());
+            self.contextualizer.set_context(c);
+        }
     }
 }
 
-impl<S> Sensor for Heart<Wit<S>>
+impl<S> Sensor for Heart<S>
 where
     S: Scheduler,
     S::Output: Clone + Into<String>,
@@ -66,40 +87,32 @@ where
 
     fn experience(&mut self) -> Vec<Experience> {
         self.beat();
-        std::mem::take(&mut self.buffer)
+        Vec::new()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{JoinScheduler, Sensation, Sensor, Wit};
+    use crate::{JoinScheduler, Sensation, Sensor};
 
     #[test]
-    fn beat_stores_output() {
-        let mut heart = Heart::new(Wit::with_config(
-            JoinScheduler::default(),
-            Some("quick".into()),
-            std::time::Duration::from_secs(0),
-            "quick",
-        ));
-        heart.feel(Sensation::new(Experience::new("hello")));
-        heart.beat();
-        assert_eq!(heart.buffer.len(), 1);
-        assert_eq!(heart.buffer[0].how, "hello");
-    }
-
-    #[test]
-    fn sensor_experience_returns_buffer() {
-        let mut heart = Heart::new(Wit::with_config(
-            JoinScheduler::default(),
-            None,
-            std::time::Duration::from_secs(0),
-            "q",
-        ));
+    fn passes_experiences_through_layers() {
+        let make = || {
+            Wit::with_config(
+                JoinScheduler::default(),
+                None,
+                std::time::Duration::from_secs(0),
+                "w",
+            )
+        };
+        let mut heart = Heart::new(make(), make(), make());
         heart.feel(Sensation::new(Experience::new("hi")));
-        let exps = heart.experience();
-        assert_eq!(exps.len(), 1);
-        assert!(heart.buffer.is_empty());
+        heart.beat();
+        assert_eq!(heart.instant.as_ref().unwrap().how, "hi");
+        assert_eq!(heart.moment.as_ref().unwrap().how, "hi");
+        assert_eq!(heart.context.as_deref(), Some("hi"));
+        assert_eq!(heart.quick.context, "hi");
+        assert_eq!(heart.combobulator.context, "hi");
     }
 }

--- a/psyche/src/psyche.rs
+++ b/psyche/src/psyche.rs
@@ -26,7 +26,7 @@ where
     Sched::Output: Clone + Into<String>,
 {
     /// Internal heart managing the quick wit.
-    pub heart: Heart<Wit<Sched>>,
+    pub heart: Heart<Sched>,
     pub(crate) external_sensors: Vec<Box<dyn Sensor<Input = bus::Event> + Send + Sync>>,
 }
 
@@ -47,12 +47,25 @@ where
         F: FnMut() -> Sched,
     {
         use std::time::Duration;
-        let heart = Heart::new(Wit::with_config(
+        let quick = Wit::with_config(
             scheduler_factory(),
             Some("quick".into()),
             Duration::from_secs(1),
             "quick",
-        ));
+        );
+        let combobulator = Wit::with_config(
+            scheduler_factory(),
+            Some("combobulator".into()),
+            Duration::from_secs(1),
+            "combobulator",
+        );
+        let contextualizer = Wit::with_config(
+            scheduler_factory(),
+            Some("contextualizer".into()),
+            Duration::from_secs(1),
+            "contextualizer",
+        );
+        let heart = Heart::new(quick, combobulator, contextualizer);
         Self {
             heart,
             external_sensors,
@@ -61,7 +74,7 @@ where
 
     /// Create a psyche from a prebuilt [`Heart`].
     pub fn with_heart(
-        heart: Heart<Wit<Sched>>,
+        heart: Heart<Sched>,
         external_sensors: Vec<Box<dyn Sensor<Input = bus::Event> + Send + Sync>>,
     ) -> Self {
         Self {


### PR DESCRIPTION
## Summary
- expand `Wit` with a context field and prompt injection
- redesign `Heart` to chain quick -> combobulator -> contextualizer
- create new Heart test to verify experience propagation
- update `Psyche` to build the new heart layout

## Testing
- `cargo test -p psyche`

------
https://chatgpt.com/codex/tasks/task_e_684999d04c9c83209dc3591271456309