### PR TITLE
Fix trait import for pete and update guidelines

### DIFF
--- a/pete/AGENTS.md
+++ b/pete/AGENTS.md
@@ -3,3 +3,5 @@
 - Add integration tests under `tests/`.
 - `cargo test -p pete` before commit.
 - Implement external sensors in this crate.
+- Import necessary traits (e.g. `psyche::Sensor`) when calling trait methods on
+  `Heart`.

--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -4,6 +4,8 @@ use log::info;
 use std::sync::Arc;
 use tokio::signal;
 use tokio::sync::Mutex;
+// bring trait into scope so we can call `experience()` on `Heart`
+use psyche::Sensor;
 
 #[tokio::main]
 async fn main() -> Result<()> {


### PR DESCRIPTION
## Summary
- import `psyche::Sensor` in `pete/main.rs`
- document trait-import requirement in `pete/AGENTS.md`

## Testing
- `cargo test --all`

------
https://chatgpt.com/codex/tasks/task_e_6849b6a5671c83208e4dbf0788842abe