### PR TITLE
Implement web server for pete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,10 +1375,14 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "futures-util",
  "lingproc",
  "log",
  "psyche",
+ "serde",
+ "serde_json",
  "tokio",
+ "warp",
 ]
 
 [[package]]

--- a/pete/AGENTS.md
+++ b/pete/AGENTS.md
@@ -1,6 +1,7 @@
 # Pete Binary Notes
 - Keep `main.rs` small; move logic to libs.
 - Add integration tests under `tests/`.
+- Use `warp` for the HTTP/WebSocket server with routes in `web`.
 - `cargo test -p pete` before commit.
 - Implement external sensors in this crate.
 - Import necessary traits (e.g. `psyche::Sensor`) when calling trait methods on

--- a/pete/Cargo.toml
+++ b/pete/Cargo.toml
@@ -9,6 +9,10 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 anyhow = "1"
 log = { version = "0.4.27", features = ["std"] }
 lingproc = { path = "../lingproc" }
+warp = "0.3"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+futures-util = "0.3"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/pete/src/lib.rs
+++ b/pete/src/lib.rs
@@ -1,5 +1,6 @@
 //! Library components for the Pete psyche.
 
 pub mod sensors;
+pub mod web;
 
 pub use sensors::{ChatSensor, ConnectionSensor};

--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -7,6 +7,8 @@ use tokio::sync::Mutex;
 // bring trait into scope so we can call `experience()` on `Heart`
 use psyche::Sensor;
 
+use pete::web;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let bus = Arc::new(psyche::bus::EventBus::new());
@@ -51,7 +53,17 @@ async fn main() -> Result<()> {
         });
     }
 
-    info!("pete running without web server");
+    {
+        let bus = bus.clone();
+        let psyche = psyche.clone();
+        tokio::spawn(async move {
+            if let Err(e) = web::serve(bus, psyche).await {
+                log::error!("web server error: {e}");
+            }
+        });
+    }
+
+    info!("pete running on http://localhost:8080");
     signal::ctrl_c().await?;
     Ok(())
 }

--- a/pete/src/web.rs
+++ b/pete/src/web.rs
@@ -1,0 +1,195 @@
+use futures_util::{SinkExt, StreamExt, future};
+use serde::{Deserialize, Serialize};
+use serde_json;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use warp::{Filter, ws::Message};
+
+use psyche::{
+    Psyche, Scheduler,
+    bus::{Event, EventBus},
+};
+
+static INDEX_HTML: &str = include_str!("../../psyche/static/index.html");
+
+#[derive(Serialize)]
+struct WitStaticInfo {
+    name: Option<String>,
+    interval_ms: u64,
+}
+
+#[derive(Serialize)]
+struct PsycheInfo {
+    instant: Option<String>,
+    moment: Option<String>,
+    context: Option<String>,
+    wits: Vec<WitStaticInfo>,
+}
+
+#[derive(Serialize)]
+struct WitRuntimeInfo {
+    name: Option<String>,
+    queue_len: usize,
+    due_ms: u64,
+    last: Option<String>,
+}
+
+#[derive(Serialize)]
+struct SchedulerInfo {
+    wits: Vec<WitRuntimeInfo>,
+}
+
+#[derive(Deserialize)]
+struct ChatMsg {
+    #[serde(rename = "type")]
+    kind: String,
+    line: String,
+}
+
+fn wit_static<S>(w: &psyche::Wit<S>) -> WitStaticInfo
+where
+    S: Scheduler,
+    S::Output: Clone + Into<String>,
+{
+    WitStaticInfo {
+        name: w.name.clone(),
+        interval_ms: w.interval.as_millis() as u64,
+    }
+}
+
+fn psyche_info<S>(p: &Psyche<S>) -> PsycheInfo
+where
+    S: Scheduler,
+    S::Output: Clone + Into<String>,
+{
+    PsycheInfo {
+        instant: p.heart.instant.as_ref().map(|e| e.how.clone()),
+        moment: p.heart.moment.as_ref().map(|e| e.how.clone()),
+        context: p.heart.context.clone(),
+        wits: vec![
+            wit_static(&p.heart.quick),
+            wit_static(&p.heart.combobulator),
+            wit_static(&p.heart.contextualizer),
+        ],
+    }
+}
+
+fn wit_runtime<S>(w: &psyche::Wit<S>) -> WitRuntimeInfo
+where
+    S: Scheduler,
+    S::Output: Clone + Into<String>,
+{
+    let due = w.due_ms();
+    let last = w.memory.all().last().map(|s| s.what.clone().into());
+    WitRuntimeInfo {
+        name: w.name.clone(),
+        queue_len: w.queue_len(),
+        due_ms: due,
+        last,
+    }
+}
+
+fn scheduler_info<S>(p: &Psyche<S>) -> SchedulerInfo
+where
+    S: Scheduler,
+    S::Output: Clone + Into<String>,
+{
+    SchedulerInfo {
+        wits: vec![
+            wit_runtime(&p.heart.quick),
+            wit_runtime(&p.heart.combobulator),
+            wit_runtime(&p.heart.contextualizer),
+        ],
+    }
+}
+
+async fn handle_ws(ws: warp::ws::WebSocket, addr: Option<SocketAddr>, bus: Arc<EventBus>) {
+    if let Some(a) = addr {
+        bus.send(Event::Connected(a));
+    }
+    let (mut sender, mut receiver) = ws.split();
+    let mut bus_rx = bus.subscribe();
+    let send_task = tokio::spawn(async move {
+        while let Ok(evt) = bus_rx.recv().await {
+            let line = match evt {
+                Event::Log(l) => l,
+                Event::Chat(l) => format!("chat: {l}"),
+                Event::Connected(a) => format!("connected {a}"),
+                Event::Disconnected(a) => format!("disconnected {a}"),
+            };
+            if sender.send(Message::text(line)).await.is_err() {
+                break;
+            }
+        }
+    });
+    let bus_send = bus.clone();
+    let recv_task = tokio::spawn(async move {
+        while let Some(Ok(msg)) = receiver.next().await {
+            if msg.is_text() {
+                if let Ok(chat) = serde_json::from_str::<ChatMsg>(msg.to_str().unwrap()) {
+                    if chat.kind == "chat" {
+                        bus_send.send(Event::Chat(chat.line));
+                    }
+                }
+            }
+        }
+    });
+    let _ = future::join(send_task, recv_task).await;
+    if let Some(a) = addr {
+        bus.send(Event::Disconnected(a));
+    }
+}
+
+pub fn routes<S>(
+    bus: Arc<EventBus>,
+    psyche: Arc<Mutex<Psyche<S>>>,
+) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone
+where
+    S: Scheduler + Send + 'static,
+    S::Output: Clone + Into<String> + Send + 'static,
+{
+    let index = warp::path::end().map(|| warp::reply::html(INDEX_HTML));
+
+    let bus_ws = bus.clone();
+    let ws_route = warp::path("ws")
+        .and(warp::ws())
+        .and(warp::addr::remote())
+        .map(move |ws: warp::ws::Ws, addr| {
+            let bus = bus_ws.clone();
+            ws.on_upgrade(move |socket| handle_ws(socket, addr, bus))
+        });
+
+    let psyche_state = psyche.clone();
+    let psyche_route = warp::path("psyche").and_then(move || {
+        let psyche = psyche_state.clone();
+        async move {
+            let p = psyche.lock().await;
+            let info = psyche_info(&*p);
+            Ok::<_, warp::Rejection>(warp::reply::json(&info))
+        }
+    });
+
+    let psyche_sched = psyche.clone();
+    let sched_route = warp::path("scheduler").and_then(move || {
+        let psyche = psyche_sched.clone();
+        async move {
+            let p = psyche.lock().await;
+            let info = scheduler_info(&*p);
+            Ok::<_, warp::Rejection>(warp::reply::json(&info))
+        }
+    });
+
+    index.or(ws_route).or(psyche_route).or(sched_route)
+}
+
+pub async fn serve<S>(bus: Arc<EventBus>, psyche: Arc<Mutex<Psyche<S>>>) -> anyhow::Result<()>
+where
+    S: Scheduler + Send + 'static,
+    S::Output: Clone + Into<String> + Send + 'static,
+{
+    warp::serve(routes(bus, psyche))
+        .run(([0, 0, 0, 0], 8080))
+        .await;
+    Ok(())
+}

--- a/pete/tests/web.rs
+++ b/pete/tests/web.rs
@@ -1,0 +1,14 @@
+use pete::web;
+use psyche::{JoinScheduler, Psyche, bus::EventBus};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use warp::test::request;
+
+#[tokio::test]
+async fn index_serves() {
+    let bus = Arc::new(EventBus::new());
+    let psyche = Arc::new(Mutex::new(Psyche::new(|| JoinScheduler::default(), vec![])));
+    let filter = web::routes(bus.clone(), psyche);
+    let resp = request().method("GET").path("/").reply(&filter).await;
+    assert_eq!(resp.status(), 200);
+}

--- a/psyche/src/wit.rs
+++ b/psyche/src/wit.rs
@@ -62,6 +62,13 @@ where
         self.queue.len()
     }
 
+    /// Milliseconds until the next tick based on [`Self::interval`].
+    pub fn due_ms(&self) -> u64 {
+        self.interval
+            .saturating_sub(self.last_tick.elapsed())
+            .as_millis() as u64
+    }
+
     /// Update the context string used when processing experiences.
     pub fn set_context(&mut self, ctx: impl Into<String>) {
         self.context = ctx.into();


### PR DESCRIPTION
## Summary
- add warp-based server to expose Pete's state via HTTP and WebSockets
- hook server into `main` and run at startup
- expose wit tick timing with `due_ms`
- include lightweight server integration test
- document warp usage for Pete in `AGENTS.md`

## Testing
- `cargo test -p pete`

------
https://chatgpt.com/codex/tasks/task_e_6849b8c929ac83208907454e93309a8d