### PR TITLE
Add Pete heartbeat sensor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,6 +1375,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "chrono",
  "futures-util",
  "lingproc",
  "log",

--- a/pete/Cargo.toml
+++ b/pete/Cargo.toml
@@ -13,6 +13,7 @@ warp = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 futures-util = "0.3"
+chrono = { version = "0.4", features = ["std", "clock"] }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/pete/src/lib.rs
+++ b/pete/src/lib.rs
@@ -3,4 +3,4 @@
 pub mod sensors;
 pub mod web;
 
-pub use sensors::{ChatSensor, ConnectionSensor};
+pub use sensors::{ChatSensor, ConnectionSensor, HeartbeatSensor};

--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -17,6 +17,7 @@ async fn main() -> Result<()> {
     let external_sensors: Vec<Box<dyn psyche::Sensor<Input = psyche::bus::Event> + Send + Sync>> = vec![
         Box::new(pete::sensors::ChatSensor::default()),
         Box::new(pete::sensors::ConnectionSensor::default()),
+        Box::new(pete::sensors::HeartbeatSensor::default()),
     ];
 
     let model = std::env::var("OLLAMA_MODEL").unwrap_or_else(|_| "gemma3".into());


### PR DESCRIPTION
## Summary
- add HeartbeatSensor emitting periodic time updates
- export new sensor and wire into main
- document and test the new behavior
- pull in chrono for local time

## Testing
- `cargo check -p pete`
- `cargo test -p pete`

------
https://chatgpt.com/codex/tasks/task_e_6849bc504afc8320875cbdf8ed90cf11