### PR TITLE
Ensure wits tick on interval

### DIFF
--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -4,8 +4,6 @@ use log::info;
 use std::sync::Arc;
 use tokio::signal;
 use tokio::sync::Mutex;
-// bring trait into scope so we can call `experience()` on `Heart`
-use psyche::Sensor;
 
 use pete::web;
 
@@ -45,11 +43,12 @@ async fn main() -> Result<()> {
         let psyche = psyche.clone();
         tokio::spawn(async move {
             loop {
-                {
+                let sleep = {
                     let mut p = psyche.lock().await;
-                    let _ = p.heart.experience();
-                }
-                tokio::task::yield_now().await;
+                    p.heart.beat();
+                    std::time::Duration::from_millis(p.heart.due_ms())
+                };
+                tokio::time::sleep(sleep).await;
             }
         });
     }

--- a/psyche/src/processor_scheduler.rs
+++ b/psyche/src/processor_scheduler.rs
@@ -129,7 +129,7 @@ mod tests {
         let mut wit = Wit::with_config(scheduler, None, std::time::Duration::from_secs(0), "mock");
         wit.feel(Sensation::new(Experience::new("one")));
         wit.feel(Sensation::new(Experience::new("two")));
-        let exp = wit.experience().pop().unwrap();
+        let exp = wit.tick().unwrap();
         assert!(exp.how.starts_with("processed"));
         assert!(wit.memory.all()[0].what.starts_with("processed"));
     }
@@ -155,7 +155,7 @@ mod tests {
         let scheduler = ProcessorScheduler::new(FailProcessor);
         let mut wit = Wit::with_config(scheduler, None, std::time::Duration::from_secs(0), "fail");
         wit.feel(Sensation::new(Experience::new("one")));
-        assert!(wit.experience().is_empty());
+        assert!(wit.tick().is_none());
         assert!(wit.memory.all().is_empty());
     }
 }

--- a/psyche/src/psyche.rs
+++ b/psyche/src/psyche.rs
@@ -17,7 +17,7 @@ use crate::{Heart, Scheduler, Sensation, Sensor, Wit, bus};
 /// let mut psyche = Psyche::new(make, external_sensors);
 /// use std::net::SocketAddr;
 /// psyche.process_event(Event::Connected("127.0.0.1:1".parse().unwrap()));
-/// let _ = psyche.heart.experience();
+/// psyche.heart.beat();
 /// assert_eq!(psyche.heart.quick().unwrap().memory.all().len(), 1);
 /// ```
 pub struct Psyche<Sched>


### PR DESCRIPTION
## Summary
- cycle wits based on configured intervals
- expose `Heart::due_ms` and tick wits in `Heart::beat`
- adjust main loop to sleep until next tick
- update tests and docs

## Testing
- `cargo test -p psyche`
- `cargo test -p pete`


------
https://chatgpt.com/codex/tasks/task_e_6849bdea00a083208c22f9ce0cf77c16