### PR TITLE
Handle idle connection sensor gracefully

### DIFF
--- a/pete/AGENTS.md
+++ b/pete/AGENTS.md
@@ -6,3 +6,4 @@
 - Implement external sensors in this crate.
 - Import necessary traits (e.g. `psyche::Sensor`) when calling trait methods on
   `Heart`.
+- Sensors should return an empty vector when idle rather than verbose messages.

--- a/pete/src/sensors.rs
+++ b/pete/src/sensors.rs
@@ -67,7 +67,7 @@ impl Sensor for ConnectionSensor {
             Some(Event::Disconnected(addr)) => {
                 vec![Experience::new(format!("Connection from {addr} closed."))]
             }
-            _ => vec![Experience::new("No connection events.")],
+            _ => Vec::new(),
         }
     }
 }
@@ -144,6 +144,12 @@ mod tests {
         sensor.feel(Sensation::new(Event::Disconnected(addr)));
         let exps = sensor.experience();
         assert_eq!(exps[0].how, "Connection from 127.0.0.1:80 closed.");
+    }
+
+    #[test]
+    fn no_connection_event_yields_empty() {
+        let mut sensor = ConnectionSensor::default();
+        assert!(sensor.experience().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- avoid logging 'No connection events' from connection sensor
- document empty vector behaviour in `pete/AGENTS.md`
- test connection sensor with no events

## Testing
- `cargo test -p pete`


------
https://chatgpt.com/codex/tasks/task_e_6849c0346adc83208f288b6a2e7c502e