### PR TITLE
Bundle pete sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1002,6 +1002,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1377,6 +1396,7 @@ dependencies = [
  "assert_cmd",
  "chrono",
  "futures-util",
+ "include_dir",
  "lingproc",
  "log",
  "psyche",

--- a/pete/Cargo.toml
+++ b/pete/Cargo.toml
@@ -14,6 +14,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 futures-util = "0.3"
 chrono = { version = "0.4", features = ["std", "clock"] }
+include_dir = "0.7"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/pete/src/lib.rs
+++ b/pete/src/lib.rs
@@ -1,6 +1,8 @@
 //! Library components for the Pete psyche.
 
 pub mod sensors;
+pub mod source;
 pub mod web;
 
 pub use sensors::{ChatSensor, ConnectionSensor, HeartbeatSensor};
+pub use source::{get_file, list_files};

--- a/pete/src/source.rs
+++ b/pete/src/source.rs
@@ -1,26 +1,36 @@
 use include_dir::{Dir, include_dir};
 
-/// Embedded source files for Pete.
+/// Embedded source files for the entire workspace.
 ///
-/// The module exposes helpers to list bundled files and retrieve their
-/// contents as UTF-8 strings.
+/// This module bundles the source tree of every crate along with Markdown
+/// files so that examples and tests can inspect them at runtime.
 ///
 /// # Examples
 /// ```
 /// use pete::source::{list_files, get_file};
 /// let files = list_files();
-/// assert!(files.contains(&"main.rs"));
-/// let main = get_file("main.rs").unwrap();
+/// assert!(files.contains(&"pete/src/main.rs"));
+/// let main = get_file("pete/src/main.rs").unwrap();
 /// assert!(main.contains("pete"));
 /// ```
-static SRC: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/src");
+///
+/// File paths are relative to the workspace root. This includes every
+/// crate as well as Markdown documentation.
+static SRC: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/..");
 
 /// Return the list of bundled file paths.
 pub fn list_files() -> Vec<&'static str> {
-    let mut names: Vec<&'static str> = SRC
-        .files()
-        .map(|f| f.path().to_str().expect("utf8 path"))
-        .collect();
+    fn gather<'a>(d: &'a Dir<'a>, out: &mut Vec<&'a str>) {
+        for f in d.files() {
+            out.push(f.path().to_str().expect("utf8 path"));
+        }
+        for sub in d.dirs() {
+            gather(sub, out);
+        }
+    }
+
+    let mut names = Vec::new();
+    gather(&SRC, &mut names);
     names.sort();
     names
 }

--- a/pete/src/source.rs
+++ b/pete/src/source.rs
@@ -1,0 +1,31 @@
+use include_dir::{Dir, include_dir};
+
+/// Embedded source files for Pete.
+///
+/// The module exposes helpers to list bundled files and retrieve their
+/// contents as UTF-8 strings.
+///
+/// # Examples
+/// ```
+/// use pete::source::{list_files, get_file};
+/// let files = list_files();
+/// assert!(files.contains(&"main.rs"));
+/// let main = get_file("main.rs").unwrap();
+/// assert!(main.contains("pete"));
+/// ```
+static SRC: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/src");
+
+/// Return the list of bundled file paths.
+pub fn list_files() -> Vec<&'static str> {
+    let mut names: Vec<&'static str> = SRC
+        .files()
+        .map(|f| f.path().to_str().expect("utf8 path"))
+        .collect();
+    names.sort();
+    names
+}
+
+/// Retrieve a bundled file by name.
+pub fn get_file(name: &str) -> Option<&'static str> {
+    SRC.get_file(name).and_then(|f| f.contents_utf8())
+}

--- a/pete/tests/source.rs
+++ b/pete/tests/source.rs
@@ -3,11 +3,11 @@ use pete::source::{get_file, list_files};
 #[test]
 fn lists_main_rs() {
     let files = list_files();
-    assert!(files.iter().any(|f| *f == "main.rs"));
+    assert!(files.iter().any(|f| *f == "pete/src/main.rs"));
 }
 
 #[test]
 fn loads_main_rs() {
     let expected = include_str!("../src/main.rs");
-    assert_eq!(get_file("main.rs"), Some(expected));
+    assert_eq!(get_file("pete/src/main.rs"), Some(expected));
 }

--- a/pete/tests/source.rs
+++ b/pete/tests/source.rs
@@ -1,0 +1,13 @@
+use pete::source::{get_file, list_files};
+
+#[test]
+fn lists_main_rs() {
+    let files = list_files();
+    assert!(files.iter().any(|f| *f == "main.rs"));
+}
+
+#[test]
+fn loads_main_rs() {
+    let expected = include_str!("../src/main.rs");
+    assert_eq!(get_file("main.rs"), Some(expected));
+}


### PR DESCRIPTION
## Summary
- add `source` module to provide compile-time embedded source files
- expose `list_files` and `get_file` from the `pete` crate
- test new API

## Testing
- `cargo test -p pete`

------
https://chatgpt.com/codex/tasks/task_e_6849f135578483208e930d1a2c2c90ee