### PR TITLE
Update dashboard with live scheduler info

### DIFF
--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -21,7 +21,23 @@ async fn main() -> Result<()> {
     let model = std::env::var("OLLAMA_MODEL").unwrap_or_else(|_| "gemma3".into());
     lingproc::ensure_model_available(&model).await?;
     info!("model {model} ready");
-    let make_sched = || psyche::ProcessorScheduler::new(lingproc::OllamaProcessor::new(&model));
+    let mut idx = 0;
+    let bus_clone = bus.clone();
+    let model_clone = model.clone();
+    let make_sched = move || {
+        idx += 1;
+        let name = match idx {
+            1 => "quick",
+            2 => "combobulator",
+            3 => "contextualizer",
+            _ => "proc",
+        };
+        psyche::ProcessorScheduler::new(
+            lingproc::OllamaProcessor::new(&model_clone),
+            bus_clone.clone(),
+            name,
+        )
+    };
     let psyche = Arc::new(Mutex::new(psyche::Psyche::new(
         make_sched,
         external_sensors,

--- a/pete/src/web.rs
+++ b/pete/src/web.rs
@@ -117,6 +117,8 @@ async fn handle_ws(ws: warp::ws::WebSocket, addr: Option<SocketAddr>, bus: Arc<E
                 Event::Chat(l) => format!("chat: {l}"),
                 Event::Connected(a) => format!("connected {a}"),
                 Event::Disconnected(a) => format!("disconnected {a}"),
+                Event::ProcessorPrompt { name, prompt } => format!("prompt:{name}:{prompt}"),
+                Event::ProcessorChunk { name, chunk } => format!("chunk:{name}:{chunk}"),
             };
             if sender.send(Message::text(line)).await.is_err() {
                 break;

--- a/psyche/static/index.html
+++ b/psyche/static/index.html
@@ -19,18 +19,52 @@
     <pre id="log" class="callout" style="height:300px; overflow:auto;"></pre>
   </div>
   <div class="cell medium-6">
-    <h2>System Info</h2>
-    <button id="refresh" class="button secondary" style="margin-bottom:0.5rem;">Refresh</button>
-    <pre id="info" class="callout" style="height:150px; overflow:auto;"></pre>
-    <h3>Scheduler</h3>
-    <div id="sched-details"></div>
+    <h2>Scheduler</h2>
+    <div id="sched"></div>
+    <h2>Heart</h2>
+    <pre id="heart" class="callout" style="height:150px; overflow:auto;"></pre>
   </div>
 </div>
 <script>
 const ws = new WebSocket(`ws://${location.host}/ws`);
+const procs = {};
+function procDom(name) {
+  if(!procs[name]) {
+    const det = document.createElement('details');
+    det.open = true;
+    const summary = document.createElement('summary');
+    det.appendChild(summary);
+    const prompt = document.createElement('pre');
+    prompt.className = 'callout';
+    const chunks = document.createElement('pre');
+    chunks.className = 'callout';
+    det.appendChild(prompt);
+    det.appendChild(chunks);
+    document.getElementById('sched').appendChild(det);
+    procs[name] = {det, summary, prompt, chunks};
+  }
+  return procs[name];
+}
+
 ws.onmessage = ev => {
   const pre = document.getElementById('log');
   pre.textContent = ev.data + '\n' + pre.textContent;
+  if(ev.data.startsWith('prompt:')) {
+    const rest = ev.data.slice(7);
+    const idx = rest.indexOf(':');
+    const name = rest.slice(0, idx);
+    const prompt = rest.slice(idx + 1);
+    const dom = procDom(name);
+    dom.prompt.textContent = prompt;
+    dom.chunks.textContent = '';
+  } else if(ev.data.startsWith('chunk:')) {
+    const rest = ev.data.slice(6);
+    const idx = rest.indexOf(':');
+    const name = rest.slice(0, idx);
+    const chunk = rest.slice(idx + 1);
+    const dom = procDom(name);
+    dom.chunks.textContent += chunk;
+  }
 };
 document.getElementById('chat-form').addEventListener('submit', ev => {
   ev.preventDefault();
@@ -44,26 +78,19 @@ document.getElementById('chat-form').addEventListener('submit', ev => {
 async function refresh() {
   const psyche = await (await fetch('/psyche')).json();
   const sched = await (await fetch('/scheduler')).json();
-  document.getElementById('info').textContent = JSON.stringify({psyche, sched}, null, 2);
-  const body = document.getElementById('sched-details');
-  body.innerHTML = '';
+  document.getElementById('heart').textContent = JSON.stringify({
+    instant: psyche.instant,
+    moment: psyche.moment,
+    context: psyche.context
+  }, null, 2);
   sched.wits.forEach((w, i) => {
-    const pinfo = psyche.wits[i] || {};
-    const pct = pinfo.interval_ms ? Math.min(100, Math.round(100 * (pinfo.interval_ms - w.due_ms) / pinfo.interval_ms)) : 0;
-    const det = document.createElement('details');
-    det.open = true;
     const name = w.name ?? `Processor ${i}`;
-    det.innerHTML = `<summary>${name}</summary>` +
-      `<blockquote>${w.last ?? ''}</blockquote>` +
-      `<div>Queue: ${w.queue_len}, due: ${w.due_ms}ms</div>` +
-      `<div class="progress" role="progressbar" aria-valuenow="${pct}" aria-valuemin="0" aria-valuemax="100">` +
-      `<div class="progress-meter" style="width:${pct}%"></div></div>`;
-    body.appendChild(det);
+    const dom = procDom(name);
+    dom.summary.textContent = `${name} (queue: ${w.queue_len}, due: ${w.due_ms}ms)`;
   });
 }
-document.getElementById('refresh').addEventListener('click', refresh);
 refresh();
-setInterval(refresh, 100);
+setInterval(refresh, 1000);
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- track processor prompts and chunks via new Event variants
- broadcast processor events over websocket
- show scheduler and heart panels in the dashboard
- name processor schedulers per wit

## Testing
- `cargo test -p pete`
- `cargo test -p psyche`


------
https://chatgpt.com/codex/tasks/task_e_6849f23d8564832087d605130d0b5d6d