### PR TITLE
Limit embedded sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1403,6 +1403,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "walkdir",
  "warp",
 ]
 
@@ -1826,6 +1827,15 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -2445,6 +2455,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2599,6 +2619,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/pete/Cargo.toml
+++ b/pete/Cargo.toml
@@ -18,3 +18,6 @@ include_dir = "0.7"
 
 [dev-dependencies]
 assert_cmd = "2"
+
+[build-dependencies]
+walkdir = "2"

--- a/pete/build.rs
+++ b/pete/build.rs
@@ -1,0 +1,47 @@
+use std::{
+    env,
+    fs::{File, create_dir_all},
+    io::Write,
+    path::PathBuf,
+};
+use walkdir::WalkDir;
+
+fn main() {
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    let workspace = manifest_dir.parent().unwrap();
+    let crates = ["pete", "psyche", "memory", "modeldb", "lingproc"];
+
+    let mut files = Vec::new();
+    for c in &crates {
+        let src = workspace.join(c).join("src");
+        for entry in WalkDir::new(&src) {
+            let entry = entry.unwrap();
+            if entry.file_type().is_file() {
+                if let Some(ext) = entry.path().extension() {
+                    if ext == "rs" {
+                        files.push(entry.path().to_path_buf());
+                    }
+                }
+            }
+        }
+    }
+    files.sort();
+
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    create_dir_all(&out_dir).unwrap();
+    let dest_path = out_dir.join("sources.rs");
+    let mut out = File::create(&dest_path).unwrap();
+
+    writeln!(out, "pub static FILES: &[(&str, &str)] = &[").unwrap();
+    for path in &files {
+        let rel = path.strip_prefix(workspace).unwrap();
+        writeln!(
+            out,
+            "    (\"{}\", include_str!(\"{}\")),",
+            rel.display(),
+            path.display()
+        )
+        .unwrap();
+    }
+    writeln!(out, "];").unwrap();
+}

--- a/pete/src/source.rs
+++ b/pete/src/source.rs
@@ -1,41 +1,25 @@
-use include_dir::{Dir, include_dir};
+//! Embedded Rust source files for the entire workspace.
+//!
+//! This module exposes the contents of every `src/*.rs` file so tests can
+//! verify example code without bundling unrelated assets.
+//!
+//! # Examples
+//! ```
+//! use pete::source::{list_files, get_file};
+//! let files = list_files();
+//! assert!(files.contains(&"pete/src/main.rs"));
+//! let main = get_file("pete/src/main.rs").unwrap();
+//! assert!(main.contains("pete"));
+//! ```
 
-/// Embedded source files for the entire workspace.
-///
-/// This module bundles the source tree of every crate along with Markdown
-/// files so that examples and tests can inspect them at runtime.
-///
-/// # Examples
-/// ```
-/// use pete::source::{list_files, get_file};
-/// let files = list_files();
-/// assert!(files.contains(&"pete/src/main.rs"));
-/// let main = get_file("pete/src/main.rs").unwrap();
-/// assert!(main.contains("pete"));
-/// ```
-///
-/// File paths are relative to the workspace root. This includes every
-/// crate as well as Markdown documentation.
-static SRC: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/..");
+include!(concat!(env!("OUT_DIR"), "/sources.rs"));
 
 /// Return the list of bundled file paths.
 pub fn list_files() -> Vec<&'static str> {
-    fn gather<'a>(d: &'a Dir<'a>, out: &mut Vec<&'a str>) {
-        for f in d.files() {
-            out.push(f.path().to_str().expect("utf8 path"));
-        }
-        for sub in d.dirs() {
-            gather(sub, out);
-        }
-    }
-
-    let mut names = Vec::new();
-    gather(&SRC, &mut names);
-    names.sort();
-    names
+    FILES.iter().map(|(n, _)| *n).collect()
 }
 
 /// Retrieve a bundled file by name.
 pub fn get_file(name: &str) -> Option<&'static str> {
-    SRC.get_file(name).and_then(|f| f.contents_utf8())
+    FILES.iter().find(|(n, _)| *n == name).map(|(_, c)| *c)
 }


### PR DESCRIPTION
## Summary
- keep embedded source files slimmed down to `*/src/**/*.rs`
- generate a source list at build time
- expose helper functions to read the embedded files

## Testing
- `cargo test -p pete -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_6849f847557c832090404632f2bfbdfd