### PR TITLE
Implement address-aware web sensors

### DIFF
--- a/psyche/src/bus.rs
+++ b/psyche/src/bus.rs
@@ -5,8 +5,11 @@ use tokio::sync::broadcast;
 pub enum Event {
     /// Log line created via [`log`].
     Log(String),
-    /// Chat line submitted from a user.
-    Chat(String),
+    /// Chat line submitted from a user along with their address when known.
+    Chat {
+        line: String,
+        addr: Option<std::net::SocketAddr>,
+    },
     /// WebSocket client connected from an address.
     Connected(std::net::SocketAddr),
     /// WebSocket client disconnected.
@@ -48,9 +51,15 @@ mod tests {
     async fn send_and_receive_chat() {
         let bus = EventBus::new();
         let mut rx = bus.subscribe();
-        bus.send(Event::Chat("hi".into()));
+        bus.send(Event::Chat {
+            line: "hi".into(),
+            addr: None,
+        });
         match rx.recv().await {
-            Ok(Event::Chat(line)) => assert_eq!(line, "hi"),
+            Ok(Event::Chat { line, addr }) => {
+                assert_eq!(line, "hi");
+                assert!(addr.is_none());
+            }
             other => panic!("unexpected event: {:?}", other),
         }
     }


### PR DESCRIPTION
## Summary
- track remote addresses in `Event::Chat`
- express chat and connection events using the new address data
- update the web server to handle the new event shape
- extend sensor tests for the new behaviour

## Testing
- `cargo test -p pete`
- `cargo test -p psyche --lib`


------
https://chatgpt.com/codex/tasks/task_e_684a492526208320a1d4e359515f1d48