### PR TITLE
Improve scheduler info UI

### DIFF
--- a/pete/src/web.rs
+++ b/pete/src/web.rs
@@ -30,6 +30,7 @@ struct PsycheInfo {
 struct WitRuntimeInfo {
     name: Option<String>,
     queue_len: usize,
+    memory_len: usize,
     last: Option<String>,
 }
 
@@ -81,6 +82,7 @@ where
     WitRuntimeInfo {
         name: w.name.clone(),
         queue_len: w.queue_len(),
+        memory_len: w.memory.all().len(),
         last,
     }
 }

--- a/pete/tests/web.rs
+++ b/pete/tests/web.rs
@@ -12,3 +12,24 @@ async fn index_serves() {
     let resp = request().method("GET").path("/").reply(&filter).await;
     assert_eq!(resp.status(), 200);
 }
+
+#[tokio::test]
+async fn scheduler_reports_queue_and_memory() {
+    use psyche::{Experience, Sensation, Sensor};
+    let bus = Arc::new(EventBus::new());
+    let psyche = Arc::new(Mutex::new(Psyche::new(|| JoinScheduler::default(), vec![])));
+    {
+        let mut p = psyche.lock().await;
+        p.heart.quick.feel(Sensation::new(Experience::new("hi")));
+    }
+    let filter = web::routes(bus.clone(), psyche);
+    let resp = request()
+        .method("GET")
+        .path("/scheduler")
+        .reply(&filter)
+        .await;
+    assert_eq!(resp.status(), 200);
+    let info: serde_json::Value = serde_json::from_slice(resp.body()).unwrap();
+    assert_eq!(info["wits"][0]["queue_len"], 1);
+    assert_eq!(info["wits"][0]["memory_len"], 0);
+}

--- a/psyche/static/index.html
+++ b/psyche/static/index.html
@@ -4,6 +4,9 @@
     <meta charset="utf-8">
     <title>Pete Dashboard</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/foundation-sites@6.7.5/dist/css/foundation.min.css">
+    <style>
+      pre.callout { white-space: pre-wrap; word-wrap: break-word; margin-bottom: 0.5rem; }
+    </style>
 </head>
 <body class="grid-container" style="margin-top:1rem;">
 <h1 style="margin-bottom:1rem;">Pete Dashboard</h1>
@@ -86,7 +89,7 @@ async function refresh() {
   sched.wits.forEach((w, i) => {
     const name = w.name ?? `Processor ${i}`;
     const dom = procDom(name);
-    dom.summary.textContent = `${name} (queue: ${w.queue_len})`;
+    dom.summary.textContent = `${name} (queue: ${w.queue_len}, mem: ${w.memory_len})`;
   });
 }
 refresh();


### PR DESCRIPTION
## Summary
- wrap `<pre>` blocks for readability
- expose `memory_len` in scheduler info
- show queue and memory lengths in UI
- test scheduler info route

## Testing
- `cargo test -p pete`

------
https://chatgpt.com/codex/tasks/task_e_684a49c0c2f4832083cfadb761a3f310