### PR TITLE
Improve dashboard UI

### DIFF
--- a/pete/src/web.rs
+++ b/pete/src/web.rs
@@ -23,6 +23,7 @@ struct PsycheInfo {
     instant: Option<String>,
     moment: Option<String>,
     context: Option<String>,
+    beat: u64,
     wits: Vec<WitStaticInfo>,
 }
 
@@ -65,6 +66,7 @@ where
         instant: p.heart.instant.as_ref().map(|e| e.how.clone()),
         moment: p.heart.moment.as_ref().map(|e| e.how.clone()),
         context: p.heart.context.clone(),
+        beat: p.heart.beat,
         wits: vec![
             wit_static(&p.heart.quick),
             wit_static(&p.heart.combobulator),

--- a/pete/tests/web.rs
+++ b/pete/tests/web.rs
@@ -33,3 +33,14 @@ async fn scheduler_reports_queue_and_memory() {
     assert_eq!(info["wits"][0]["queue_len"], 1);
     assert_eq!(info["wits"][0]["memory_len"], 0);
 }
+
+#[tokio::test]
+async fn psyche_reports_beat() {
+    let bus = Arc::new(EventBus::new());
+    let psyche = Arc::new(Mutex::new(Psyche::new(|| JoinScheduler::default(), vec![])));
+    let filter = web::routes(bus.clone(), psyche);
+    let resp = request().method("GET").path("/psyche").reply(&filter).await;
+    assert_eq!(resp.status(), 200);
+    let info: serde_json::Value = serde_json::from_slice(resp.body()).unwrap();
+    assert!(info["beat"].as_u64().is_some());
+}

--- a/psyche/static/index.html
+++ b/psyche/static/index.html
@@ -3,29 +3,40 @@
 <head>
     <meta charset="utf-8">
     <title>Pete Dashboard</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/foundation-sites@6.7.5/dist/css/foundation.min.css">
-    <style>
-      pre.callout { white-space: pre-wrap; word-wrap: break-word; margin-bottom: 0.5rem; }
-    </style>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/foundation-sites@6.7.5/dist/css/foundation.min.css">
+<style>
+  body { margin:0; background:#202020; color:#f0f0f0; }
+  #log { list-style:none; padding:0; margin:0; max-height:40vh; overflow:auto; }
+  #log li { white-space:pre-wrap; word-break:break-word; }
+  #heart { height:25vh; overflow:auto; }
+  #sched { max-height:40vh; overflow:auto; }
+  details { margin-bottom:0.5rem; }
+  .card { margin-bottom:1rem; }
+</style>
 </head>
-<body class="grid-container" style="margin-top:1rem;">
-<h1 style="margin-bottom:1rem;">Pete Dashboard</h1>
-<div class="grid-x grid-margin-x">
-  <div class="cell medium-6">
-    <h2>Logs</h2>
-    <form id="chat-form" class="input-group" style="margin-bottom:0.5rem;">
-      <input id="chat-input" type="text" class="input-group-field" autocomplete="off">
-      <div class="input-group-button">
-        <button class="button primary" type="submit">Send</button>
-      </div>
-    </form>
-    <pre id="log" class="callout" style="height:300px; overflow:auto;"></pre>
+<body class="grid-container fluid">
+<header class="grid-x align-justify align-middle card primary">
+  <div class="cell shrink"><h1 style="margin:0;">Pete Dashboard</h1></div>
+  <div class="cell shrink"><span id="beat" class="label success"></span></div>
+</header>
+<div class="grid-x small-up-1 medium-up-2">
+  <div class="cell">
+    <div class="card callout primary">
+      <h2>Logs</h2>
+      <form id="chat-form" class="grid-x">
+        <input id="chat-input" class="cell auto" type="text" autocomplete="off">
+        <button class="button cell shrink" type="submit">Send</button>
+      </form>
+      <ul id="log"></ul>
+    </div>
   </div>
-  <div class="cell medium-6">
-    <h2>Scheduler</h2>
-    <div id="sched"></div>
-    <h2>Heart</h2>
-    <pre id="heart" class="callout" style="height:150px; overflow:auto;"></pre>
+  <div class="cell">
+    <div class="card callout secondary">
+      <h2>Scheduler</h2>
+      <div id="sched"></div>
+      <h2>Heart</h2>
+      <pre id="heart"></pre>
+    </div>
   </div>
 </div>
 <script>
@@ -50,8 +61,10 @@ function procDom(name) {
 }
 
 ws.onmessage = ev => {
-  const pre = document.getElementById('log');
-  pre.textContent = ev.data + '\n' + pre.textContent;
+  const log = document.getElementById('log');
+  const li = document.createElement('li');
+  li.textContent = ev.data;
+  log.prepend(li);
   if(ev.data.startsWith('prompt:')) {
     const rest = ev.data.slice(7);
     const idx = rest.indexOf(':');
@@ -81,7 +94,9 @@ document.getElementById('chat-form').addEventListener('submit', ev => {
 async function refresh() {
   const psyche = await (await fetch('/psyche')).json();
   const sched = await (await fetch('/scheduler')).json();
+  document.getElementById('beat').textContent = `beat ${psyche.beat}`;
   document.getElementById('heart').textContent = JSON.stringify({
+    beat: psyche.beat,
     instant: psyche.instant,
     moment: psyche.moment,
     context: psyche.context


### PR DESCRIPTION
## Summary
- redesign dashboard HTML for Foundation styling
- show current heart beat count
- expose `beat` in psyche info route
- test new route behaviour

## Testing
- `cargo test -p pete`

------
https://chatgpt.com/codex/tasks/task_e_684b490d40188320acc3030925200e0d