### PR TITLE
Throttle heartbeat when idle

### DIFF
--- a/pete/tests/heart.rs
+++ b/pete/tests/heart.rs
@@ -9,13 +9,7 @@ async fn heart_beats_continuously() {
     let sensors: Vec<Box<dyn psyche::Sensor<Input = Event> + Send + Sync>> = vec![Box::new(
         HeartbeatSensor::new(std::time::Duration::from_millis(10)),
     )];
-    let make = || {
-        Wit::with_config(
-            JoinScheduler::default(),
-            None,
-            "w",
-        )
-    };
+    let make = || Wit::with_config(JoinScheduler::default(), None, "w");
     let heart = Heart::new(make(), make(), make());
     let psyche = Arc::new(Mutex::new(Psyche::with_heart(heart, sensors)));
     let handle = spawn_heartbeat(psyche.clone());
@@ -23,6 +17,21 @@ async fn heart_beats_continuously() {
     {
         let p = psyche.lock().await;
         assert!(p.heart.quick.memory.all().len() > 1);
+    }
+    handle.abort();
+}
+
+#[tokio::test]
+async fn idle_heart_does_not_spin() {
+    let sensors: Vec<Box<dyn psyche::Sensor<Input = Event> + Send + Sync>> = vec![];
+    let make = || Wit::with_config(JoinScheduler::default(), None, "w");
+    let heart = Heart::new(make(), make(), make());
+    let psyche = Arc::new(Mutex::new(Psyche::with_heart(heart, sensors)));
+    let handle = spawn_heartbeat(psyche.clone());
+    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    {
+        let p = psyche.lock().await;
+        assert_eq!(p.heart.beat, 0);
     }
     handle.abort();
 }


### PR DESCRIPTION
## Summary
- limit `spawn_heartbeat` to beat only when work is queued
- test that idle hearts stay at beat 0

## Testing
- `cargo test -p psyche`
- `cargo test -p pete`


------
https://chatgpt.com/codex/tasks/task_e_684b519f3ce083208d758bc4daa93241