### PR TITLE
Track last prompt for each wit

### DIFF
--- a/pete/src/web.rs
+++ b/pete/src/web.rs
@@ -33,6 +33,7 @@ struct WitRuntimeInfo {
     queue_len: usize,
     memory_len: usize,
     last: Option<String>,
+    last_prompt: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -81,11 +82,13 @@ where
     S::Output: Clone + Into<String>,
 {
     let last = w.memory.all().last().map(|s| s.what.clone().into());
+    let last_prompt = w.last_prompt.clone();
     WitRuntimeInfo {
         name: w.name.clone(),
         queue_len: w.queue_len(),
         memory_len: w.memory.all().len(),
         last,
+        last_prompt,
     }
 }
 

--- a/psyche/AGENTS.md
+++ b/psyche/AGENTS.md
@@ -12,3 +12,4 @@
 - Log processor errors instead of dropping them.
 - `Heart` implements `Sensor`; use `feel` and `experience` in place of
   `push` and `tick`.
+- Keep `Wit::last_prompt` updated so dashboard refreshes show recent prompts.

--- a/psyche/static/index.html
+++ b/psyche/static/index.html
@@ -107,6 +107,9 @@ async function refresh() {
     const name = w.name ?? `Processor ${i}`;
     const dom = procDom(name);
     dom.summary.textContent = `${name} (queue: ${w.queue_len}, mem: ${w.memory_len})`;
+    if(w.last_prompt){
+      dom.prompt.textContent = 'Prompt: ' + w.last_prompt;
+    }
   });
 }
 refresh();


### PR DESCRIPTION
## Summary
- record last prompt used by each `Wit`
- expose last prompt in `SchedulerInfo` and display it in the dashboard
- test scheduler prompt reporting
- document the new requirement in `psyche/AGENTS.md`

## Testing
- `cargo test -p psyche`
- `cargo test -p pete`


------
https://chatgpt.com/codex/tasks/task_e_684b544e503483209d2ab2c115d97636