### PR TITLE
Simplify heart loop

### DIFF
--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -26,12 +26,7 @@ async fn main() -> Result<()> {
     let model_clone = model.clone();
     let make_sched = move || {
         idx += 1;
-        let name = match idx {
-            1 => "quick",
-            2 => "combobulator",
-            3 => "contextualizer",
-            _ => "proc",
-        };
+        let name = if idx == 1 { "quick" } else { "proc" };
         psyche::ProcessorScheduler::new(
             lingproc::OllamaProcessor::new(&model_clone),
             bus_clone.clone(),

--- a/pete/src/web.rs
+++ b/pete/src/web.rs
@@ -21,8 +21,6 @@ struct WitStaticInfo {
 #[derive(Serialize)]
 struct PsycheInfo {
     instant: Option<String>,
-    moment: Option<String>,
-    context: Option<String>,
     beat: u64,
     wits: Vec<WitStaticInfo>,
 }
@@ -65,14 +63,8 @@ where
 {
     PsycheInfo {
         instant: p.heart.instant.as_ref().map(|e| e.how.clone()),
-        moment: p.heart.moment.as_ref().map(|e| e.how.clone()),
-        context: p.heart.context.clone(),
         beat: p.heart.beat,
-        wits: vec![
-            wit_static(&p.heart.quick),
-            wit_static(&p.heart.combobulator),
-            wit_static(&p.heart.contextualizer),
-        ],
+        wits: vec![wit_static(&p.heart.quick)],
     }
 }
 
@@ -98,11 +90,7 @@ where
     S::Output: Clone + Into<String>,
 {
     SchedulerInfo {
-        wits: vec![
-            wit_runtime(&p.heart.quick),
-            wit_runtime(&p.heart.combobulator),
-            wit_runtime(&p.heart.contextualizer),
-        ],
+        wits: vec![wit_runtime(&p.heart.quick)],
     }
 }
 

--- a/pete/tests/heart.rs
+++ b/pete/tests/heart.rs
@@ -10,7 +10,7 @@ async fn heart_beats_continuously() {
         HeartbeatSensor::new(std::time::Duration::from_millis(10)),
     )];
     let make = || Wit::with_config(JoinScheduler::default(), None, "w");
-    let heart = Heart::new(make(), make(), make());
+    let heart = Heart::new(make());
     let psyche = Arc::new(Mutex::new(Psyche::with_heart(heart, sensors)));
     let handle = spawn_heartbeat(psyche.clone());
     tokio::time::sleep(std::time::Duration::from_millis(30)).await;
@@ -25,7 +25,7 @@ async fn heart_beats_continuously() {
 async fn idle_heart_does_not_spin() {
     let sensors: Vec<Box<dyn psyche::Sensor<Input = Event> + Send + Sync>> = vec![];
     let make = || Wit::with_config(JoinScheduler::default(), None, "w");
-    let heart = Heart::new(make(), make(), make());
+    let heart = Heart::new(make());
     let psyche = Arc::new(Mutex::new(Psyche::with_heart(heart, sensors)));
     let handle = spawn_heartbeat(psyche.clone());
     tokio::time::sleep(std::time::Duration::from_millis(20)).await;

--- a/psyche/src/prompt.rs
+++ b/psyche/src/prompt.rs
@@ -14,8 +14,13 @@ pub fn narrative_prompt(context: &str, batch: &[Experience]) -> String {
         })
         .collect::<Vec<_>>()
         .join(" ");
+    let situation = if context.is_empty() {
+        String::new()
+    } else {
+        format!(" Here's his present situation: {}", context)
+    };
     format!(
-        "You are acting as the linguistic processing unit for a larger entity named Pete. Assume the voice of Pete, an artificial consciousness; you are new to the world, so you should expect to sense new information slowly but surely. Just keep swimming.\n\nOver the past little while, you have experienced the following: {experiences}\n\nIn the voice of Pete and without headers or footers or any sort (just the plain text of Pete's response), produce a brief narrative from the perspective of Pete, talking to yourself, that compresses what's currently happening. Be succinct but thorough. Aim for one paragraph. Do not use bullet points or lists, just a single paragraph. Make sure to pass on the most important information from the experiences, but do not repeat them verbatim. Do not use any special formatting or markdown, just plain text."
+        "You are acting as the linguistic processing unit for a larger entity named Pete. Assume the voice of Pete, an artificial consciousness; you are new to the world, so you should expect to sense new information slowly but surely. Just keep swimming.\n\nOver the past little while, you have experienced the following: {experiences}{situation}\n\nIn the voice of Pete and without headers or footers or any sort (just the plain text of Pete's response), produce a brief narrative from the perspective of Pete, talking to yourself, that compresses what's currently happening. Be succinct but thorough. Aim for one paragraph. Do not use bullet points or lists, just a single paragraph. Make sure to pass on the most important information from the experiences, but do not repeat them verbatim. Do not use any special formatting or markdown, just plain text."
     )
 }
 

--- a/psyche/src/psyche.rs
+++ b/psyche/src/psyche.rs
@@ -47,17 +47,7 @@ where
         F: FnMut() -> Sched,
     {
         let quick = Wit::with_config(scheduler_factory(), Some("quick".into()), "quick");
-        let combobulator = Wit::with_config(
-            scheduler_factory(),
-            Some("combobulator".into()),
-            "combobulator",
-        );
-        let contextualizer = Wit::with_config(
-            scheduler_factory(),
-            Some("contextualizer".into()),
-            "contextualizer",
-        );
-        let heart = Heart::new(quick, combobulator, contextualizer);
+        let heart = Heart::new(quick);
         Self {
             heart,
             external_sensors,

--- a/psyche/static/index.html
+++ b/psyche/static/index.html
@@ -99,9 +99,7 @@ async function refresh() {
   document.getElementById('beat').textContent = `beat ${psyche.beat}`;
   document.getElementById('heart').textContent = JSON.stringify({
     beat: psyche.beat,
-    instant: psyche.instant,
-    moment: psyche.moment,
-    context: psyche.context
+    instant: psyche.instant
   }, null, 2);
   sched.wits.forEach((w, i) => {
     const name = w.name ?? `Processor ${i}`;


### PR DESCRIPTION
## Summary
- strip Heart down to a single quick Wit
- remove additional wits from Psyche and dashboard
- tweak scheduler naming logic
- update prompt helper and dashboard
- adjust tests

## Testing
- `cargo test -p psyche`
- `cargo test -p pete`


------
https://chatgpt.com/codex/tasks/task_e_684b838df50483209f4562b874ebacd8