### PR TITLE
Implement reactive perception module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@
 - Log errors instead of silently discarding them.
 - Include tests that verify the heart passes experiences across multiple wits.
 - Sensors should return a vector of experiences.
+- The `perception` module offers a reactive model broadcasting `Sensation`s to subscribers.
 - External sensors belong to each psyche's crate, not the `psyche` library.
 - When testing streams created with `async_stream`, ensure you poll once more
   after the final item to trigger any cleanup logic.

--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -9,6 +9,7 @@ mod experience;
 mod heart;
 mod join_scheduler;
 mod memory;
+mod perception;
 mod processor_scheduler;
 mod prompt;
 mod psyche;
@@ -21,6 +22,10 @@ pub use experience::Experience;
 pub use heart::Heart;
 pub use join_scheduler::JoinScheduler;
 pub use memory::Memory;
+pub use perception::{
+    Experience as ReactiveExperience, Sensation as ReactiveSensation, Sensor as ReactiveSensor,
+    SubjectSensor,
+};
 pub use processor_scheduler::ProcessorScheduler;
 pub use prompt::narrative_prompt;
 pub use psyche::Psyche;

--- a/psyche/src/perception.rs
+++ b/psyche/src/perception.rs
@@ -1,0 +1,110 @@
+use chrono::{DateTime, Utc};
+use std::sync::{
+    Mutex,
+    mpsc::{Receiver, Sender, channel},
+};
+
+/// A single sensory input tagged with when it was perceived.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Sensation<T> {
+    /// Timestamp for when the sensation was recorded.
+    pub when: DateTime<Utc>,
+    /// Raw sensory value.
+    pub what: T,
+}
+
+impl<T> Sensation<T> {
+    /// Create a new `Sensation` happening right now.
+    pub fn new(value: T) -> Self {
+        Self {
+            when: Utc::now(),
+            what: value,
+        }
+    }
+}
+
+/// Collection of sensations plus a textual interpretation.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Experience<T> {
+    /// Sensory inputs composing this experience.
+    pub what: Vec<Sensation<T>>,
+    /// How the psyche interprets them.
+    pub how: String,
+}
+
+impl<T> Experience<T> {
+    /// Create an experience from sensations and descriptive text.
+    pub fn new(what: Vec<Sensation<T>>, how: impl Into<String>) -> Self {
+        Self {
+            what,
+            how: how.into(),
+        }
+    }
+}
+
+/// Reactive sensor producing sensations for subscribers.
+pub trait Sensor<T>: Send + Sync {
+    /// Provide a new input to the sensor.
+    fn feel(&self, sensation: Sensation<T>);
+    /// Subscribe to future emitted sensations.
+    fn subscribe(&self) -> Receiver<Sensation<T>>;
+}
+
+/// Subject sensor broadcasting sensations to subscribers with optional filtering.
+pub struct SubjectSensor<T> {
+    subscribers: Mutex<Vec<Sender<Sensation<T>>>>,
+    filter: Box<dyn Fn(&Sensation<T>) -> bool + Send + Sync>,
+}
+
+impl<T> SubjectSensor<T> {
+    /// Create a new `SubjectSensor` with the provided filter.
+    pub fn new<F>(filter: F) -> Self
+    where
+        F: Fn(&Sensation<T>) -> bool + Send + Sync + 'static,
+    {
+        Self {
+            subscribers: Mutex::new(Vec::new()),
+            filter: Box::new(filter),
+        }
+    }
+}
+
+impl<T: Clone + Send + 'static> Sensor<T> for SubjectSensor<T> {
+    fn feel(&self, sensation: Sensation<T>) {
+        if !(self.filter)(&sensation) {
+            return;
+        }
+        let mut subs = self.subscribers.lock().unwrap();
+        subs.retain(|tx| tx.send(sensation.clone()).is_ok());
+    }
+
+    fn subscribe(&self) -> Receiver<Sensation<T>> {
+        let (tx, rx) = channel();
+        self.subscribers.lock().unwrap().push(tx);
+        rx
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn filtered_sensations_reach_subscribers() {
+        let sensor: SubjectSensor<u8> = SubjectSensor::new(|s| s.what % 2 == 0);
+        let rx = sensor.subscribe();
+        sensor.feel(Sensation::new(1));
+        sensor.feel(Sensation::new(2));
+        assert_eq!(rx.recv().unwrap().what, 2);
+    }
+
+    #[test]
+    fn multiple_subscribers_receive() {
+        let sensor: SubjectSensor<&str> = SubjectSensor::new(|_| true);
+        let rx1 = sensor.subscribe();
+        let rx2 = sensor.subscribe();
+        sensor.feel(Sensation::new("hi"));
+        assert_eq!(rx1.recv().unwrap().what, "hi");
+        assert_eq!(rx2.recv().unwrap().what, "hi");
+    }
+}


### PR DESCRIPTION
## Summary
- add reactive `perception` module with `Sensation`, `Experience`, `Sensor` and `SubjectSensor`
- expose new types from `psyche` crate
- document new workflow guidance in `AGENTS.md`
- cover reactive sensors with tests

## Testing
- `cargo test -p psyche perception::`


------
https://chatgpt.com/codex/tasks/task_e_684b8d5eb7d08320bc2f788b948b3e19