### PR TITLE
Add pete Deno sensor package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# AGENT Instructions
+
+This repository contains Deno packages. Install Deno before running tests.
+
+## Testing
+
+Run `deno test` from the repository root. Tests reside in `pete/tests` and
+should follow BDD/TDD style using Deno's built-in testing tools.
+
+If dependencies are missing, use the official install script or package manager
+before running tests. Cache dependencies with `deno cache` to speed up repeated
+runs.
+
+If commands fail due to environment limitations, mention that in the PR's test
+results section.
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Daringsby Repository
+
+This repository hosts a Deno package called **pete**.
+
+See `pete/README.md` for package details.
+
+Run tests with:
+
+```sh
+# ensure deno is installed
+deno test
+```
+

--- a/pete/README.md
+++ b/pete/README.md
@@ -1,0 +1,16 @@
+# pete
+
+A simple Deno module exposing sensory primitives powered by RxJS.
+
+```ts
+import { Sensor } from "./mod.ts";
+
+const sensor = new Sensor<string>((s) => s.what.length > 0);
+
+sensor.subscribe((s) => console.log(`felt ${s.what} at ${s.when}`));
+
+sensor.feel("warmth");
+```
+
+Run tests with `deno test` (ensure you have Deno installed).
+

--- a/pete/mod.ts
+++ b/pete/mod.ts
@@ -1,0 +1,63 @@
+// mod.ts - pete deno package
+//
+// This module exposes basic sensory primitives using RxJS for reactive streams.
+//
+// Example usage:
+//
+//     import { Sensor } from "./mod.ts";
+//     const sensor = new Sensor<string>();
+//     sensor.subscribe((s) => console.log(`felt ${s.what} at ${s.when}`));
+//     sensor.feel("warmth");
+//
+import { Subject, Subscription } from "npm:rxjs";
+
+/** A single sensation felt by a sensor. */
+export interface Sensation<X> {
+  /** Timestamp of the sensation */
+  when: Date;
+  /** Sensory payload */
+  what: X;
+}
+
+/**
+ * An experience is a collection of sensations with a description of how they
+ * feel together.
+ */
+export interface Experience<X> {
+  /** The sensations that make up the experience */
+  what: Sensation<X>[];
+  /** A sentence describing how the sensations feel together */
+  how: string;
+}
+
+/**
+ * Sensor is an observable source of sensations using RxJS. A filter predicate
+ * can be provided to ignore certain sensations.
+ */
+export class Sensor<X> {
+  private subject = new Subject<Sensation<X>>();
+
+  constructor(private filter: (s: Sensation<X>) => boolean = () => true) {}
+
+  /** Emit a new sensation if it passes the filter. */
+  feel(what: X): void {
+    const sensation: Sensation<X> = {
+      when: new Date(),
+      what,
+    };
+    if (this.filter(sensation)) {
+      this.subject.next(sensation);
+    }
+  }
+
+  /** Subscribe to the sensations produced by this sensor. */
+  subscribe(observer: (s: Sensation<X>) => void): Subscription {
+    return this.subject.subscribe(observer);
+  }
+
+  /** Expose the observable for advanced RxJS usage. */
+  asObservable() {
+    return this.subject.asObservable();
+  }
+}
+

--- a/pete/tests/mod_test.ts
+++ b/pete/tests/mod_test.ts
@@ -1,0 +1,18 @@
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { Sensor } from "../mod.ts";
+
+deno.test("sensor emits filtered sensations", async () => {
+  const sensor = new Sensor<number>((s) => s.what > 0);
+  const results: number[] = [];
+
+  sensor.subscribe((s) => results.push(s.what));
+
+  sensor.feel(-1);
+  sensor.feel(1);
+  sensor.feel(2);
+
+  // Allow microtasks to flush
+  await Promise.resolve();
+
+  assertEquals(results, [1, 2]);
+});


### PR DESCRIPTION
## Summary
- introduce `pete` Deno library with `Sensor` class and fundamental interfaces
- document how to use `pete`
- add tests for `Sensor`
- add AGENT instructions for Deno workflow

## Testing
- `deno test` *(fails: `deno` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b90c61e1883208edb2c47cc407e51