### PR TITLE
Add new Psyche class with heartbeat sensor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,3 +14,7 @@ runs.
 If commands fail due to environment limitations, mention that in the PR's test
 results section.
 
+
+### Environment setup
+If the standard install script is blocked, download the Deno binary from GitHub
+releases and place it in `/usr/local/bin`.

--- a/pete/heartbeat_sensor.ts
+++ b/pete/heartbeat_sensor.ts
@@ -1,0 +1,35 @@
+import { Sensor } from "./mod.ts";
+
+/**
+ * HeartbeatSensor emits a message every baseInterval milliseconds
+ * with a small random jitter. The message includes the current time.
+ */
+export class HeartbeatSensor extends Sensor<string> {
+  private running = true;
+  private timerId?: number;
+  constructor(
+    private readonly baseInterval = 60_000,
+    private readonly jitter = 1_000,
+  ) {
+    super();
+    this.schedule();
+  }
+
+  private schedule() {
+    if (!this.running) return;
+    const delta = Math.floor(Math.random() * (this.jitter * 2)) - this.jitter;
+    const delay = this.baseInterval + delta;
+    this.timerId = setTimeout(() => {
+      const timeoclock = new Date().toLocaleTimeString();
+      this.feel(`It's ${timeoclock}, and I feel my heart beat.`);
+      this.schedule();
+    }, delay);
+  }
+
+  stop() {
+    this.running = false;
+    if (this.timerId !== undefined) {
+      clearTimeout(this.timerId);
+    }
+  }
+}

--- a/pete/mod.ts
+++ b/pete/mod.ts
@@ -61,3 +61,11 @@ export class Sensor<X> {
   }
 }
 
+
+/**
+ * Psyche holds a collection of sensors representing external stimuli.
+ */
+export class Psyche<X = unknown> {
+  constructor(public externalSensors: Sensor<X>[] = []) {}
+}
+

--- a/pete/pete.ts
+++ b/pete/pete.ts
@@ -1,0 +1,9 @@
+import { Psyche } from "./mod.ts";
+import { HeartbeatSensor } from "./heartbeat_sensor.ts";
+
+/**
+ * Pete is a psyche with a single heartbeat sensor.
+ */
+export const Pete = new Psyche([
+  new HeartbeatSensor(),
+]);

--- a/pete/tests/mod_test.ts
+++ b/pete/tests/mod_test.ts
@@ -1,7 +1,7 @@
-import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { assertEquals } from "https://raw.githubusercontent.com/denoland/deno_std/0.224.0/assert/mod.ts";
 import { Sensor } from "../mod.ts";
 
-deno.test("sensor emits filtered sensations", async () => {
+Deno.test("sensor emits filtered sensations", async () => {
   const sensor = new Sensor<number>((s) => s.what > 0);
   const results: number[] = [];
 

--- a/pete/tests/psyche_test.ts
+++ b/pete/tests/psyche_test.ts
@@ -1,0 +1,19 @@
+import { assertEquals, assert } from "https://raw.githubusercontent.com/denoland/deno_std/0.224.0/assert/mod.ts";
+import { Psyche } from "../mod.ts";
+import { HeartbeatSensor } from "../heartbeat_sensor.ts";
+
+Deno.test("psyche stores external sensors", () => {
+  const sensor = new HeartbeatSensor(1, 0);
+  const psyche = new Psyche([sensor]);
+  assertEquals(psyche.externalSensors.length, 1);
+  sensor.stop();
+});
+
+Deno.test("heartbeat sensor emits a message", async () => {
+  const sensor = new HeartbeatSensor(5, 0);
+  const messages: string[] = [];
+  sensor.subscribe((s) => messages.push(s.what));
+  await new Promise((res) => setTimeout(res, 10));
+  sensor.stop();
+  assert(messages.length > 0);
+});


### PR DESCRIPTION
## Summary
- add `Psyche` container for sensors
- implement `HeartbeatSensor` that emits a heartbeat message every minute
- expose `Pete` psyche instance
- include tests for new sensor and psyche
- document fallback Deno install method

## Testing
- `DENO_TLS_CA_STORE=system deno cache pete/mod.ts pete/heartbeat_sensor.ts pete/pete.ts pete/tests/mod_test.ts pete/tests/psyche_test.ts`
- `DENO_TLS_CA_STORE=system deno test -A`

------
https://chatgpt.com/codex/tasks/task_e_684b92b4c40483209fb8cfddb6dfa0a7