### PR TITLE
Refactor pete module structure and add Psyche runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,12 @@ runs.
 If commands fail due to environment limitations, mention that in the PR's test
 results section.
 
-
 ### Environment setup
+
 If the standard install script is blocked, download the Deno binary from GitHub
 releases and place it in `/usr/local/bin`.
+
+### Module layout
+
+`lib.ts` is the main library entry point. `main.ts` demonstrates usage and can
+be run with `deno run pete/main.ts`.

--- a/README.md
+++ b/README.md
@@ -11,3 +11,8 @@ Run tests with:
 deno test
 ```
 
+Run Pete's main program:
+
+```sh
+deno run pete/main.ts
+```

--- a/pete/README.md
+++ b/pete/README.md
@@ -3,7 +3,7 @@
 A simple Deno module exposing sensory primitives powered by RxJS.
 
 ```ts
-import { Sensor } from "./mod.ts";
+import { Sensor } from "./lib.ts";
 
 const sensor = new Sensor<string>((s) => s.what.length > 0);
 
@@ -14,3 +14,8 @@ sensor.feel("warmth");
 
 Run tests with `deno test` (ensure you have Deno installed).
 
+Run the example Pete program:
+
+```sh
+deno run main.ts
+```

--- a/pete/heartbeat_sensor.ts
+++ b/pete/heartbeat_sensor.ts
@@ -1,4 +1,4 @@
-import { Sensor } from "./mod.ts";
+import { Sensor } from "./lib.ts";
 
 /**
  * HeartbeatSensor emits a message every baseInterval milliseconds

--- a/pete/lib.ts
+++ b/pete/lib.ts
@@ -1,10 +1,10 @@
-// mod.ts - pete deno package
+// lib.ts - pete deno package
 //
 // This module exposes basic sensory primitives using RxJS for reactive streams.
 //
 // Example usage:
 //
-//     import { Sensor } from "./mod.ts";
+//     import { Sensor } from "./lib.ts";
 //     const sensor = new Sensor<string>();
 //     sensor.subscribe((s) => console.log(`felt ${s.what} at ${s.when}`));
 //     sensor.feel("warmth");
@@ -61,11 +61,48 @@ export class Sensor<X> {
   }
 }
 
-
 /**
  * Psyche holds a collection of sensors representing external stimuli.
  */
 export class Psyche<X = unknown> {
-  constructor(public externalSensors: Sensor<X>[] = []) {}
-}
+  private beats = 0;
+  private live = true;
 
+  constructor(public externalSensors: Sensor<X>[] = []) {}
+
+  /** How many beats have occurred. */
+  get beatCount(): number {
+    return this.beats;
+  }
+
+  /** Whether the psyche should keep running. */
+  isLive(): boolean {
+    return this.live;
+  }
+
+  /** Stop the psyche's run loop. */
+  stop(): void {
+    this.live = false;
+  }
+
+  /** Increment the internal beat counter. */
+  beat(): void {
+    this.beats++;
+  }
+
+  /**
+   * Continuously run while the psyche is live.
+   *
+   * ```ts
+   * const psyche = new Psyche();
+   * psyche.run();
+   * psyche.stop();
+   * ```
+   */
+  async run(): Promise<void> {
+    while (this.isLive()) {
+      this.beat();
+      await new Promise((res) => setTimeout(res, 0));
+    }
+  }
+}

--- a/pete/main.ts
+++ b/pete/main.ts
@@ -1,4 +1,4 @@
-import { Psyche } from "./mod.ts";
+import { Psyche } from "./lib.ts";
 import { HeartbeatSensor } from "./heartbeat_sensor.ts";
 
 /**
@@ -7,3 +7,8 @@ import { HeartbeatSensor } from "./heartbeat_sensor.ts";
 export const Pete = new Psyche([
   new HeartbeatSensor(),
 ]);
+
+// Start Pete's life cycle.
+Pete.run();
+
+export default Pete;

--- a/pete/tests/mod_test.ts
+++ b/pete/tests/mod_test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "https://raw.githubusercontent.com/denoland/deno_std/0.224.0/assert/mod.ts";
-import { Sensor } from "../mod.ts";
+import { Sensor } from "../lib.ts";
 
 Deno.test("sensor emits filtered sensations", async () => {
   const sensor = new Sensor<number>((s) => s.what > 0);

--- a/pete/tests/psyche_test.ts
+++ b/pete/tests/psyche_test.ts
@@ -1,5 +1,8 @@
-import { assertEquals, assert } from "https://raw.githubusercontent.com/denoland/deno_std/0.224.0/assert/mod.ts";
-import { Psyche } from "../mod.ts";
+import {
+  assert,
+  assertEquals,
+} from "https://raw.githubusercontent.com/denoland/deno_std/0.224.0/assert/mod.ts";
+import { Psyche } from "../lib.ts";
 import { HeartbeatSensor } from "../heartbeat_sensor.ts";
 
 Deno.test("psyche stores external sensors", () => {
@@ -16,4 +19,12 @@ Deno.test("heartbeat sensor emits a message", async () => {
   await new Promise((res) => setTimeout(res, 10));
   sensor.stop();
   assert(messages.length > 0);
+});
+
+Deno.test("psyche run increments beats", async () => {
+  const psyche = new Psyche();
+  const running = psyche.run();
+  psyche.stop();
+  await running;
+  assert(psyche.beatCount > 0);
 });


### PR DESCRIPTION
## Summary
- rename `mod.ts` to `lib.ts`
- move `pete.ts` to `main.ts` and run Pete automatically
- implement a beat loop and lifecycle controls in `Psyche`
- update imports, docs, and tests
- document layout in `AGENTS.md`

## Testing
- `deno test` *(fails: error trying to connect to raw.githubusercontent.com)*

------
https://chatgpt.com/codex/tasks/task_e_684b970b2ed0832096f96ed107a5264e