### PR TITLE
Add InstructionFollower and mock implementation

### DIFF
--- a/lib/InstructionFollower.ts
+++ b/lib/InstructionFollower.ts
@@ -1,0 +1,32 @@
+export abstract class InstructionFollower {
+  /**
+   * Process a prompt and produce a response.
+   * @param prompt text to process
+   * @param onChunk optional handler for streaming output chunks
+   * @returns resolved response string
+   */
+  abstract instruct(
+    prompt: string,
+    onChunk?: (chunk: string) => void,
+  ): Promise<string>;
+}
+
+/**
+ * Mock implementation replacing every word with "Malkovitch".
+ *
+ * ```ts
+ * const follower = new MockInstructionFollower();
+ * const reply = await follower.instruct("Hello world");
+ * // reply === "Malkovitch Malkovitch"
+ * ```
+ */
+export class MockInstructionFollower extends InstructionFollower {
+  async instruct(
+    prompt: string,
+    onChunk?: (chunk: string) => void,
+  ): Promise<string> {
+    const result = prompt.replace(/\b\w+\b/g, "Malkovitch");
+    if (onChunk) onChunk(result);
+    return result;
+  }
+}

--- a/pete/tests/instruction_follower_test.ts
+++ b/pete/tests/instruction_follower_test.ts
@@ -1,0 +1,21 @@
+import { MockInstructionFollower } from "../../lib/InstructionFollower.ts";
+
+function assertEquals(actual: unknown, expected: unknown) {
+  if (actual !== expected) {
+    throw new Error(`Expected ${expected}, got ${actual}`);
+  }
+}
+
+Deno.test("replaces every word with Malkovitch", async () => {
+  const follower = new MockInstructionFollower();
+  const result = await follower.instruct("Hello there, world!");
+  assertEquals(result, "Malkovitch Malkovitch, Malkovitch!");
+});
+
+Deno.test("calls onChunk with the replaced text", async () => {
+  const follower = new MockInstructionFollower();
+  let chunk = "";
+  const result = await follower.instruct("Hi", (c) => chunk = c);
+  assertEquals(result, "Malkovitch");
+  assertEquals(chunk, "Malkovitch");
+});


### PR DESCRIPTION
## Summary
- add `InstructionFollower` abstract class with `MockInstructionFollower`
- provide local tests using `Deno.test`

## Testing
- `deno test --no-lock`

------
https://chatgpt.com/codex/tasks/task_e_684b9be49f54832082b32f11bd0649ee