### PR TITLE
Integrate sensory input in Pete's psyche

### DIFF
--- a/lib/Psyche.ts
+++ b/lib/Psyche.ts
@@ -1,48 +1,81 @@
 import { Sensor } from "./Sensor.ts";
+import { InstructionFollower } from "./InstructionFollower.ts";
+import { Sensation } from "./Sensation.ts";
 
 /**
  * Psyche holds a collection of sensors representing external stimuli.
  */
 
 export class Psyche<X = unknown> {
-    private beats = 0;
-    private live = true;
+  private beats = 0;
+  private live = true;
+  private buffer: Sensation<X>[] = [];
+  public instant = "Pete has just been born.";
 
-    constructor(public externalSensors: Sensor<X>[] = []) { }
-
-    /** How many beats have occurred. */
-    get beatCount(): number {
-        return this.beats;
+  constructor(
+    public externalSensors: Sensor<X>[] = [],
+    private instructionFollower: InstructionFollower,
+  ) {
+    for (const sensor of this.externalSensors) {
+      sensor.subscribe((s) => this.buffer.push(s));
     }
+  }
 
-    /** Whether the psyche should keep running. */
-    isLive(): boolean {
-        return this.live;
-    }
+  /** How many beats have occurred. */
+  get beatCount(): number {
+    return this.beats;
+  }
 
-    /** Stop the psyche's run loop. */
-    stop(): void {
-        this.live = false;
-    }
+  /** Whether the psyche should keep running. */
+  isLive(): boolean {
+    return this.live;
+  }
 
-    /** Increment the internal beat counter. */
-    beat(): void {
-        this.beats++;
-    }
+  /** Stop the psyche's run loop. */
+  stop(): void {
+    this.live = false;
+  }
 
-    /**
-     * Continuously run while the psyche is live.
-     *
-     * ```ts
-     * const psyche = new Psyche();
-     * psyche.run();
-     * psyche.stop();
-     * ```
-     */
-    async run(): Promise<void> {
-        while (this.isLive()) {
-            this.beat();
-            await new Promise((res) => setTimeout(res, 0));
-        }
+  /** Increment the internal beat counter. */
+  beat(): void {
+    this.beats++;
+  }
+
+  /**
+   * Integrate buffered sensory input using the instruction follower.
+   * Clears the buffer and updates `instant` with the follower's response.
+   */
+  async integrate_sensory_input(): Promise<void> {
+    if (this.buffer.length === 0) return;
+    const happenings = this.buffer.map((s) => {
+      const when = s.when.toLocaleString();
+      return `[${when}] ${s.what}`;
+    }).join("\n");
+    const prompt =
+      "You are the linguistic processor for an artificial entity named Pete. Speak in Pete's voice on his behalf.\n" +
+      "## Pete's Current Situation (as he understands it)\n" +
+      `${this.instant}\n` +
+      "## What just happened in the last instant\n\n" +
+      `${happenings}\n` +
+      "Condense the happenings here into one sentence, emphasizing the most salient information and omitting irrelevant information. Speak only as Pete (who is not an LLM).";
+    this.instant = await this.instructionFollower.instruct(prompt);
+    this.buffer = [];
+  }
+
+  /**
+   * Continuously run while the psyche is live.
+   *
+   * ```ts
+   * const psyche = new Psyche();
+   * psyche.run();
+   * psyche.stop();
+   * ```
+   */
+  async run(): Promise<void> {
+    while (this.isLive()) {
+      this.beat();
+      await this.integrate_sensory_input();
+      await new Promise((res) => setTimeout(res, 0));
     }
+  }
 }

--- a/main.ts
+++ b/main.ts
@@ -1,13 +1,14 @@
 import { Psyche } from "./lib/Psyche.ts";
 import { HeartbeatSensor } from "./sensors/heartbeat.ts";
+import { MockInstructionFollower } from "./lib/InstructionFollower.ts";
 
 /**
  * Pete is our main character.
  */
-export const Pete = new Psyche([
-  new HeartbeatSensor(),
-]);
+export const Pete = new Psyche(
+  [new HeartbeatSensor()],
+  new MockInstructionFollower(),
+);
 
 // Start Pete's life cycle.
 Pete.run();
-

--- a/pete/tests/psyche_integration_test.ts
+++ b/pete/tests/psyche_integration_test.ts
@@ -1,0 +1,26 @@
+import { Psyche } from "../../lib/Psyche.ts";
+import { Sensor } from "../../lib/Sensor.ts";
+import { InstructionFollower } from "../../lib/InstructionFollower.ts";
+
+function assert(condition: unknown, msg = "Assertion failed") {
+  if (!condition) throw new Error(msg);
+}
+
+class StubFollower extends InstructionFollower {
+  prompt = "";
+  async instruct(prompt: string): Promise<string> {
+    this.prompt = prompt;
+    return "stub";
+  }
+}
+
+Deno.test("integrate_sensory_input summarizes buffered sensations", async () => {
+  const sensor = new Sensor<string>();
+  const follower = new StubFollower();
+  const psyche = new Psyche([sensor], follower);
+
+  sensor.feel("hello world");
+  await psyche.integrate_sensory_input();
+
+  assert(follower.prompt.includes("hello world"), "prompt missing sensation");
+});


### PR DESCRIPTION
## Summary
- require an InstructionFollower when constructing a Psyche
- buffer sensations and integrate them each beat
- wire integrate_sensory_input in Psyche's run loop
- use MockInstructionFollower in main
- test integration of sensory input

## Testing
- `deno cache main.ts` *(fails: invalid peer certificate)*
- `deno test` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_684b9e40737c83209a80839f352f7d5a