### PR TITLE
Add Chatter and conversation support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,3 +23,7 @@ releases and place it in `/usr/local/bin`.
 
 `lib.ts` is the main library entry point. `main.ts` demonstrates usage and can
 be run with `deno run pete/main.ts`.
+
+### Reminders
+
+- Update tests whenever constructor parameters change, especially for `Psyche`.

--- a/lib/Chatter.ts
+++ b/lib/Chatter.ts
@@ -1,0 +1,34 @@
+export interface ChatMessage {
+  content: string;
+  role: "assistant" | "user" | "system";
+}
+
+/**
+ * Chatter produces conversational responses to a sequence of messages.
+ */
+export abstract class Chatter {
+  /**
+   * Generate a response given the conversation so far.
+   * @param messages ordered chat messages
+   * @param onChunk optional streaming handler
+   */
+  abstract chat(
+    messages: ChatMessage[],
+    onChunk?: (chunk: string) => Promise<void>,
+  ): Promise<string>;
+}
+
+/**
+ * Mock implementation that echoes the last message content.
+ * Useful for unit tests without calling a real LLM.
+ */
+export class MockChatter extends Chatter {
+  async chat(
+    messages: ChatMessage[],
+    onChunk?: (chunk: string) => Promise<void>,
+  ): Promise<string> {
+    const response = messages[messages.length - 1]?.content ?? "";
+    if (onChunk) await onChunk(response);
+    return response;
+  }
+}

--- a/lib/Psyche.ts
+++ b/lib/Psyche.ts
@@ -1,93 +1,111 @@
 import { Sensor } from "./Sensor.ts";
 import { InstructionFollower } from "./InstructionFollower.ts";
 import { Experience } from "./Experience.ts";
-
-export class Message {
-    constructor(
-        public content: string,
-        public role: "assistant" | "user",
-    ) { }
-}
+import { ChatMessage, Chatter } from "./Chatter.ts";
 
 /**
  * Psyche holds a collection of sensors representing external stimuli.
  */
 
 export class Psyche {
-    private beats = 0;
-    private live = true;
-    private buffer: Experience<unknown>[] = [];
-    public instant = "Pete has just been born.";
-    public conversation: Message[] = [];
+  private beats = 0;
+  private live = true;
+  private buffer: Experience<unknown>[] = [];
+  public instant = "Pete has just been born.";
+  public conversation: ChatMessage[] = [];
 
-    constructor(
-        public externalSensors: Sensor<unknown>[] = [],
-        private instructionFollower: InstructionFollower,
-        private onStream?: (chunk: string) => Promise<void>,
-    ) {
-        for (const sensor of this.externalSensors) {
-            sensor.subscribe((e) => {
-                this.buffer.push(e);
-            });
-        }
+  constructor(
+    public externalSensors: Sensor<unknown>[] = [],
+    private instructionFollower: InstructionFollower,
+    private chatter: Chatter,
+    private onStream?: (chunk: string) => Promise<void>,
+  ) {
+    for (const sensor of this.externalSensors) {
+      sensor.subscribe((e) => {
+        this.buffer.push(e);
+      });
     }
+  }
 
-    /** How many beats have occurred. */
-    get beatCount(): number {
-        return this.beats;
-    }
+  /** How many beats have occurred. */
+  get beatCount(): number {
+    return this.beats;
+  }
 
-    /** Whether the psyche should keep running. */
-    isLive(): boolean {
-        return this.live;
-    }
+  /** Whether the psyche should keep running. */
+  isLive(): boolean {
+    return this.live;
+  }
 
-    /** Stop the psyche's run loop. */
-    stop(): void {
-        this.live = false;
-    }
+  /** Stop the psyche's run loop. */
+  stop(): void {
+    this.live = false;
+  }
 
-    /** Increment the internal beat counter. */
-    async beat(): Promise<void> {
-        this.beats++;
-        // console.log(`Beat ${this.beats} at ${new Date().toLocaleTimeString()}`);
-        await this.integrate_sensory_input();
-    }
+  /** Increment the internal beat counter. */
+  async beat(): Promise<void> {
+    this.beats++;
+    // console.log(`Beat ${this.beats} at ${new Date().toLocaleTimeString()}`);
+    await this.integrate_sensory_input();
+  }
 
-    /**
-     * Integrate buffered sensory input using the instruction follower.
-     * Clears the buffer and updates `instant` with the follower's response.
-     */
-    async integrate_sensory_input(): Promise<void> {
-        if (this.buffer.length === 0) return;
-        const happenings = this.buffer.map((s) => {
-            return `[${s.what[0]?.when}] ${s.how}`;
-        }).join("\n");
-        const prompt =
-            "You are the linguistic processor for an artificial entity named Pete. Speak in Pete's voice on his behalf.\n" +
-            "## Pete's Current Situation (as he understands it)\n" +
-            `${this.instant}\n` +
-            "## What just happened in the last instant\n\n" +
-            `${happenings}\n` +
-            "Condense the happenings here into one sentence, emphasizing the most salient information and omitting irrelevant information. Speak only as Pete (who is not an LLM).";
-        this.instant = await this.instructionFollower.instruct(prompt, this.onStream);
-        this.buffer = [];
-        console.log(`Beat ${this.beats} at ${new Date().toLocaleTimeString()}: ${this.instant}`);
-    }
+  /**
+   * Integrate buffered sensory input using the instruction follower.
+   * Clears the buffer and updates `instant` with the follower's response.
+   */
+  async integrate_sensory_input(): Promise<void> {
+    if (this.buffer.length === 0) return;
+    const happenings = this.buffer.map((s) => {
+      return `[${s.what[0]?.when}] ${s.how}`;
+    }).join("\n");
+    const prompt =
+      "You are the linguistic processor for an artificial entity named Pete. Speak in Pete's voice on his behalf.\n" +
+      "## Pete's Current Situation (as he understands it)\n" +
+      `${this.instant}\n` +
+      "## What just happened in the last instant\n\n" +
+      `${happenings}\n` +
+      "Condense the happenings here into one sentence, emphasizing the most salient information and omitting irrelevant information. Speak only as Pete (who is not an LLM).";
+    this.instant = await this.instructionFollower.instruct(
+      prompt,
+      this.onStream,
+    );
+    this.buffer = [];
+    console.log(
+      `Beat ${this.beats} at ${
+        new Date().toLocaleTimeString()
+      }: ${this.instant}`,
+    );
+    await this.take_turn();
+  }
 
-    /**
-     * Continuously run while the psyche is live.
-     *
-     * ```ts
-     * const psyche = new Psyche();
-     * psyche.run();
-     * psyche.stop();
-     * ```
-     */
-    async run(): Promise<void> {
-        while (this.isLive()) {
-            await this.beat();
-            await new Promise((res) => setTimeout(res, 0));
-        }
+  /**
+   * Engage in conversation based on the current instant and stored messages.
+   */
+  async take_turn(): Promise<void> {
+    const messages: ChatMessage[] = [
+      {
+        role: "system",
+        content: `You are Pete. Here's your situation: ${this.instant}`,
+      },
+      ...this.conversation,
+    ];
+    const reply = await this.chatter.chat(messages, this.onStream);
+    this.conversation.push({ role: "assistant", content: reply });
+  }
+
+  /**
+   * Continuously run while the psyche is live.
+   *
+   * ```ts
+   * const psyche = new Psyche();
+   * psyche.run();
+   * psyche.stop();
+   * ```
+   */
+  async run(): Promise<void> {
+    while (this.isLive()) {
+      await this.beat();
+      await new Promise((res) => setTimeout(res, 0));
     }
+  }
 }

--- a/main.ts
+++ b/main.ts
@@ -1,6 +1,9 @@
 import { Psyche } from "./lib/Psyche.ts";
 import { HeartbeatSensor } from "./sensors/heartbeat.ts";
-import { OllamaInstructionFollower } from "./providers/ollama.ts";
+import {
+  OllamaChatter,
+  OllamaInstructionFollower,
+} from "./providers/ollama.ts";
 import { Ollama } from "npm:ollama";
 /**
  * Pete is our main character.
@@ -8,6 +11,7 @@ import { Ollama } from "npm:ollama";
 export const Pete = new Psyche(
   [new HeartbeatSensor()],
   new OllamaInstructionFollower(new Ollama(), "gemma3"),
+  new OllamaChatter(new Ollama(), "gemma3"),
   async (chunk: string) => {
     await Deno.stdout.write(new TextEncoder().encode(chunk));
   },

--- a/pete/tests/psyche_integration_test.ts
+++ b/pete/tests/psyche_integration_test.ts
@@ -1,6 +1,8 @@
 import { Psyche } from "../../lib/Psyche.ts";
 import { Sensor } from "../../lib/Sensor.ts";
 import { InstructionFollower } from "../../lib/InstructionFollower.ts";
+import { ChatMessage, Chatter } from "../../lib/Chatter.ts";
+import { Experience } from "../../lib/Experience.ts";
 
 function assert(condition: unknown, msg = "Assertion failed") {
   if (!condition) throw new Error(msg);
@@ -14,13 +16,37 @@ class StubFollower extends InstructionFollower {
   }
 }
 
+class StubChatter extends Chatter {
+  messages: ChatMessage[] = [];
+  async chat(messages: ChatMessage[]): Promise<string> {
+    this.messages = messages;
+    return "ok";
+  }
+}
+
+class StubSensor extends Sensor<string> {
+  feel(what: string): void {
+    const exp: Experience<string> = {
+      what: [{ when: new Date(), what }],
+      how: what,
+    };
+    this.subject.next(exp);
+  }
+}
+
 Deno.test("integrate_sensory_input summarizes buffered sensations", async () => {
-  const sensor = new Sensor<string>();
+  const sensor = new StubSensor();
   const follower = new StubFollower();
-  const psyche = new Psyche([sensor], follower);
+  const chatter = new StubChatter();
+  const psyche = new Psyche([sensor], follower, chatter);
 
   sensor.feel("hello world");
   await psyche.integrate_sensory_input();
 
   assert(follower.prompt.includes("hello world"), "prompt missing sensation");
+  const first = chatter.messages[0];
+  assert(
+    first.role === "system" && first.content.includes("stub"),
+    "chatter not called",
+  );
 });

--- a/pete/tests/take_turn_test.ts
+++ b/pete/tests/take_turn_test.ts
@@ -1,0 +1,44 @@
+import { Psyche } from "../../lib/Psyche.ts";
+import { InstructionFollower } from "../../lib/InstructionFollower.ts";
+import { ChatMessage, Chatter } from "../../lib/Chatter.ts";
+import { Sensor } from "../../lib/Sensor.ts";
+import { Experience } from "../../lib/Experience.ts";
+
+class StubFollower extends InstructionFollower {
+  async instruct(): Promise<string> {
+    return "instant";
+  }
+}
+
+class StubChatter extends Chatter {
+  messages: ChatMessage[] = [];
+  async chat(messages: ChatMessage[]): Promise<string> {
+    this.messages = messages;
+    return "reply";
+  }
+}
+
+class EmptySensor extends Sensor<null> {
+  feel(_: null): void {
+    const exp: Experience<null> = {
+      what: [{ when: new Date(), what: null }],
+      how: "",
+    };
+    this.subject.next(exp);
+  }
+}
+
+Deno.test("take_turn prepends system message with instant", async () => {
+  const sensor = new EmptySensor();
+  const follower = new StubFollower();
+  const chatter = new StubChatter();
+  const psyche = new Psyche([sensor], follower, chatter);
+
+  psyche.conversation.push({ role: "user", content: "hi" });
+  await psyche.take_turn();
+
+  const first = chatter.messages[0];
+  if (!first.content.includes("instant") || first.role !== "system") {
+    throw new Error("system message missing");
+  }
+});

--- a/providers/ollama.ts
+++ b/providers/ollama.ts
@@ -2,28 +2,57 @@ import { Ollama } from "npm:ollama";
 import { InstructionFollower } from "../lib/InstructionFollower.ts";
 
 export class OllamaInstructionFollower extends InstructionFollower {
-    constructor(protected client: Ollama, protected model: string) {
-        super();
-    }
+  constructor(protected client: Ollama, protected model: string) {
+    super();
+  }
 
-    async instruct(
-        prompt: string,
-        onChunk?: (chunk: string) => Promise<void>,
-    ): Promise<string> {
-        console.log(`Prompt: ${prompt}`);
-        const stream = await this.client.generate({
-            stream: true,
-            model: this.model,
-            prompt: prompt,
-        });
-        let response = "";
-        for await (const chunk of stream) {
-            const content = chunk.response || "";
-            response += content;
-            if (onChunk) {
-                await onChunk(content);
-            }
-        }
-        return response;
+  async instruct(
+    prompt: string,
+    onChunk?: (chunk: string) => Promise<void>,
+  ): Promise<string> {
+    console.log(`Prompt: ${prompt}`);
+    const stream = await this.client.generate({
+      stream: true,
+      model: this.model,
+      prompt: prompt,
+    });
+    let response = "";
+    for await (const chunk of stream) {
+      const content = chunk.response || "";
+      response += content;
+      if (onChunk) {
+        await onChunk(content);
+      }
     }
+    return response;
+  }
+}
+
+import { ChatMessage, Chatter } from "../lib/Chatter.ts";
+
+export class OllamaChatter extends Chatter {
+  constructor(protected client: Ollama, protected model: string) {
+    super();
+  }
+
+  async chat(
+    messages: ChatMessage[],
+    onChunk?: (chunk: string) => Promise<void>,
+  ): Promise<string> {
+    console.log(`Messages: ${JSON.stringify(messages)}`);
+    const stream = await this.client.chat({
+      stream: true,
+      model: this.model,
+      messages,
+    });
+    let response = "";
+    for await (const chunk of stream) {
+      const content = chunk.message?.content || "";
+      response += content;
+      if (onChunk) {
+        await onChunk(content);
+      }
+    }
+    return response;
+  }
 }


### PR DESCRIPTION
## Summary
- create `Chatter` abstraction with mock implementation
- extend Ollama provider with streaming chat capability
- update `Psyche` to use `Chatter` and add `take_turn`
- adjust main program and tests for new constructor
- document reminder about updating tests when constructors change

## Testing
- `deno test -A` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_684bad8c6ae4832080920cce18eaa108