### PR TITLE
Add websocket server and sensor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,3 +27,4 @@ be run with `deno run pete/main.ts`.
 ### Reminders
 
 - Update tests whenever constructor parameters change, especially for `Psyche`.
+- Cache server dependencies with `deno cache server.ts` before tests.

--- a/README.md
+++ b/README.md
@@ -16,3 +16,13 @@ Run Pete's main program:
 ```sh
 deno run pete/main.ts
 ```
+
+## Web Server
+
+Start a chat server with:
+
+```sh
+deno run --allow-net server.ts
+```
+
+Open `http://localhost:8000` in your browser to chat with Pete.

--- a/pete/tests/websocket_sensor_test.ts
+++ b/pete/tests/websocket_sensor_test.ts
@@ -1,0 +1,24 @@
+import { WebSocketSensor } from "../../sensors/websocket.ts";
+import { assertEquals } from "https://deno.land/std@0.200.0/testing/asserts.ts";
+
+Deno.test("connected emits connection experience", () => {
+  const sensor = new WebSocketSensor();
+  let type = "";
+  sensor.subscribe((exp) => {
+    type = exp.what[0].what.type;
+  });
+  sensor.connected("ip");
+  assertEquals(type, "connect");
+});
+
+Deno.test("received emits message experience", () => {
+  const sensor = new WebSocketSensor();
+  let received = "";
+  sensor.subscribe((exp) => {
+    if (exp.what[0].what.type === "message") {
+      received = (exp.what[0].what as any).message;
+    }
+  });
+  sensor.received("ip", "hi");
+  assertEquals(received, "hi");
+});

--- a/sensors/websocket.ts
+++ b/sensors/websocket.ts
@@ -1,0 +1,50 @@
+export type WebSocketWhat =
+  | { type: "connect"; remote: string }
+  | { type: "disconnect"; remote: string }
+  | { type: "message"; remote: string; message: string };
+
+import { Sensor } from "../lib/Sensor.ts";
+import { Experience } from "../lib/Experience.ts";
+
+/**
+ * WebSocketSensor emits experiences for websocket events.
+ *
+ * ```ts
+ * const sensor = new WebSocketSensor();
+ * sensor.connected("1.1.1.1");
+ * sensor.received("1.1.1.1", "hi");
+ * ```
+ */
+export class WebSocketSensor extends Sensor<WebSocketWhat> {
+  feel(what: WebSocketWhat): void {
+    let how: string;
+    switch (what.type) {
+      case "connect":
+        how = `Client ${what.remote} connected.`;
+        break;
+      case "disconnect":
+        how = `Client ${what.remote} disconnected.`;
+        break;
+      case "message":
+        how = `Client ${what.remote} says: ${what.message}`;
+        break;
+    }
+    const exp: Experience<WebSocketWhat> = {
+      what: [{ when: new Date(), what }],
+      how,
+    };
+    this.subject.next(exp);
+  }
+
+  connected(remote: string): void {
+    this.feel({ type: "connect", remote });
+  }
+
+  disconnected(remote: string): void {
+    this.feel({ type: "disconnect", remote });
+  }
+
+  received(remote: string, message: string): void {
+    this.feel({ type: "message", remote, message });
+  }
+}

--- a/server.ts
+++ b/server.ts
@@ -1,0 +1,92 @@
+import { serve } from "https://deno.land/std@0.200.0/http/server.ts";
+import { HeartbeatSensor } from "./sensors/heartbeat.ts";
+import { WebSocketSensor } from "./sensors/websocket.ts";
+import { Psyche } from "./lib/Psyche.ts";
+import { Ollama } from "npm:ollama";
+import { OllamaChatter, OllamaInstructionFollower } from "./providers/ollama.ts";
+
+const wsSensor = new WebSocketSensor();
+const clients = new Set<WebSocket>();
+
+const pete = new Psyche(
+  [new HeartbeatSensor(), wsSensor],
+  new OllamaInstructionFollower(new Ollama(), "gemma3"),
+  new OllamaChatter(new Ollama(), "gemma3"),
+  async (chunk: string) => {
+    for (const ws of clients) {
+      try {
+        ws.send(chunk);
+      } catch (_) {
+        // ignore failed sends
+      }
+    }
+  },
+);
+
+pete.run();
+
+function page(): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Pete Chat</title>
+  <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css" rel="stylesheet">
+</head>
+<body class="bg-gray-50" x-data="chat()">
+  <div class="max-w-lg mx-auto p-4">
+    <h1 class="text-2xl mb-4 text-center">Chat with Pete</h1>
+    <div class="border h-64 overflow-y-auto p-2 mb-4 bg-white" id="log">
+      <template x-for="line in lines" :key="line.id">
+        <div class="mb-1" x-text="line.text"></div>
+      </template>
+    </div>
+    <form @submit.prevent="send" class="flex gap-2">
+      <input x-model="input" autofocus class="border p-2 flex-grow" placeholder="Say something" />
+      <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">Send</button>
+    </form>
+  </div>
+<script>
+function chat() {
+  const ws = new WebSocket("ws://" + location.host + "/ws");
+  return {
+    lines: [],
+    input: '',
+    send() {
+      ws.send(this.input);
+      this.lines.push({ id: Date.now(), text: 'You: ' + this.input });
+      this.input = '';
+    }
+  };
+}
+</script>
+</body>
+</html>`;
+}
+
+serve((req, info) => {
+  const { pathname } = new URL(req.url);
+  if (pathname === "/ws" && req.headers.get("upgrade") === "websocket") {
+    const { socket, response } = Deno.upgradeWebSocket(req);
+    const remote = (info.remoteAddr as Deno.NetAddr).hostname;
+    clients.add(socket);
+    wsSensor.connected(remote);
+    socket.onclose = () => {
+      clients.delete(socket);
+      wsSensor.disconnected(remote);
+    };
+    socket.onmessage = (e) => {
+      const text = String(e.data);
+      wsSensor.received(remote, text);
+      pete.conversation.push({ role: "user", content: text });
+    };
+    return response;
+  }
+
+  if (pathname === "/") {
+    return new Response(page(), { headers: { "content-type": "text/html" } });
+  }
+
+  return new Response("Not found", { status: 404 });
+});


### PR DESCRIPTION
## Summary
- implement `WebSocketSensor` for chat events
- add a demo `server.ts` that exposes a websocket chat interface
- document how to run the server
- include tests for the new sensor
- update agent instructions with caching reminder

## Testing
- `deno cache server.ts` *(fails: Import 'https://deno.land/std@0.200.0/http/server.ts' failed)*
- `deno cache main.ts` *(fails: Failed caching npm package 'tslib@2.8.1')*
- `deno test` *(fails: Import 'https://deno.land/std@0.200.0/testing/asserts.ts' failed)*

------
https://chatgpt.com/codex/tasks/task_e_684bafb801a083209affc3106868233f