### PR TITLE
Require name for chat messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ deno run pete/main.ts
 Start a chat server with:
 
 ```sh
-deno run --allow-net server.ts
+deno run --allow-net --allow-read server.ts
 ```
 
 Open `http://localhost:8000` in your browser to chat with Pete.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Pete Chat</title>
+    <script
+      src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"
+      defer
+    ></script>
+    <link
+      href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css"
+      rel="stylesheet"
+    >
+  </head>
+  <body class="bg-gray-50" x-data="chat()">
+    <div class="max-w-lg mx-auto p-4">
+      <h1 class="text-2xl mb-4 text-center">Chat with Pete</h1>
+      <div class="border h-64 overflow-y-auto p-2 mb-4 bg-white" id="log">
+        <template x-for="line in lines" :key="line.id">
+          <div class="mb-1" x-text="line.text"></div>
+        </template>
+      </div>
+      <form @submit.prevent="send" class="flex gap-2">
+        <input x-model="name" class="border p-2 w-32" placeholder="Your name" />
+        <input
+          x-model="input"
+          autofocus
+          class="border p-2 flex-grow"
+          placeholder="Say something"
+        />
+        <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">
+          Send
+        </button>
+      </form>
+    </div>
+    <script>
+      function chat() {
+        const ws = new WebSocket("ws://" + location.host + "/ws");
+        ws.onmessage = () => {
+          const log = document.getElementById("log");
+          log.scrollTop = log.scrollHeight;
+        };
+        return {
+          lines: [],
+          name: "",
+          input: "",
+          send() {
+            if (!this.name) {
+              alert("Please enter your name");
+              return;
+            }
+            ws.send(
+              JSON.stringify({ name: this.name, message: this.input }),
+            );
+            this.lines.push({
+              id: Date.now(),
+              text: `${this.name}: ${this.input}`,
+            });
+            this.input = "";
+          },
+        };
+      }
+    </script>
+  </body>
+</html>

--- a/pete/tests/websocket_sensor_test.ts
+++ b/pete/tests/websocket_sensor_test.ts
@@ -11,14 +11,27 @@ Deno.test("connected emits connection experience", () => {
   assertEquals(type, "connect");
 });
 
-Deno.test("received emits message experience", () => {
+Deno.test("received emits message experience with name", () => {
   const sensor = new WebSocketSensor();
-  let received = "";
+  let event;
   sensor.subscribe((exp) => {
     if (exp.what[0].what.type === "message") {
-      received = (exp.what[0].what as any).message;
+      event = exp;
     }
   });
-  sensor.received("ip", "hi");
-  assertEquals(received, "hi");
+  sensor.received("ip", "Bob", "hi");
+  assertEquals(event!.what[0].what.message, "hi");
+  assertEquals(event!.what[0].what.name, "Bob");
+});
+
+Deno.test("how uses provided name", () => {
+  const sensor = new WebSocketSensor();
+  let how = "";
+  sensor.subscribe((exp) => {
+    if (exp.what[0].what.type === "message") {
+      how = exp.how;
+    }
+  });
+  sensor.received("ip", "Alice", "hello");
+  assertEquals(how, "Alice says: hello");
 });

--- a/sensors/websocket.ts
+++ b/sensors/websocket.ts
@@ -1,7 +1,7 @@
 export type WebSocketWhat =
   | { type: "connect"; remote: string }
   | { type: "disconnect"; remote: string }
-  | { type: "message"; remote: string; message: string };
+  | { type: "message"; remote: string; name: string; message: string };
 
 import { Sensor } from "../lib/Sensor.ts";
 import { Experience } from "../lib/Experience.ts";
@@ -26,7 +26,7 @@ export class WebSocketSensor extends Sensor<WebSocketWhat> {
         how = `Client ${what.remote} disconnected.`;
         break;
       case "message":
-        how = `Client ${what.remote} says: ${what.message}`;
+        how = `${what.name} says: ${what.message}`;
         break;
     }
     const exp: Experience<WebSocketWhat> = {
@@ -44,7 +44,7 @@ export class WebSocketSensor extends Sensor<WebSocketWhat> {
     this.feel({ type: "disconnect", remote });
   }
 
-  received(remote: string, message: string): void {
-    this.feel({ type: "message", remote, message });
+  received(remote: string, name: string, message: string): void {
+    this.feel({ type: "message", remote, name, message });
   }
 }


### PR DESCRIPTION
## Summary
- prompt for a username in the chat UI
- use that name in `WebSocketSensor`
- read `index.html` from disk for the web server
- adjust tests for the new behaviour
- document new read permission for the server

## Testing
- `deno cache server.ts` *(fails: unsuccessful tunnel)*
- `deno test` *(fails: unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_684bb13e7f3883209c77362d0b794265