### PR TITLE
Implement echo handshake for Pete

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,3 +28,5 @@ be run with `deno run pete/main.ts`.
 
 - Update tests whenever constructor parameters change, especially for `Psyche`.
 - Cache server dependencies with `deno cache server.ts` before tests.
+- Keep WebSocket sensor tests in sync with any new event types or message
+  flows.

--- a/index.html
+++ b/index.html
@@ -36,7 +36,16 @@
     <script>
       function chat() {
         const ws = new WebSocket("ws://" + location.host + "/ws");
-        ws.onmessage = () => {
+        ws.onmessage = (e) => {
+          try {
+            const data = JSON.parse(e.data);
+            if (data.type === "pete-says") {
+              this.lines.push({ id: Date.now(), text: `Pete: ${data.text}` });
+              ws.send(JSON.stringify({ type: "echo", message: data.text }));
+            }
+          } catch (_) {
+            // ignore invalid payloads
+          }
           const log = document.getElementById("log");
           log.scrollTop = log.scrollHeight;
         };

--- a/pete/tests/take_turn_test.ts
+++ b/pete/tests/take_turn_test.ts
@@ -12,7 +12,9 @@ class StubFollower extends InstructionFollower {
 
 class StubChatter extends Chatter {
   messages: ChatMessage[] = [];
+  calls = 0;
   async chat(messages: ChatMessage[]): Promise<string> {
+    this.calls++;
     this.messages = messages;
     return "reply";
   }
@@ -40,5 +42,26 @@ Deno.test("take_turn prepends system message with instant", async () => {
   const first = chatter.messages[0];
   if (!first.content.includes("instant") || first.role !== "system") {
     throw new Error("system message missing");
+  }
+});
+
+Deno.test("reply added after echo", async () => {
+  const sensor = new EmptySensor();
+  const follower = new StubFollower();
+  const chatter = new StubChatter();
+  const psyche = new Psyche([sensor], follower, chatter);
+
+  await psyche.take_turn();
+  if (psyche.conversation.some((m) => m.role === "assistant")) {
+    throw new Error("assistant added early");
+  }
+  await psyche.take_turn();
+  if (chatter.calls !== 1) {
+    throw new Error("should not chat while speaking");
+  }
+  psyche.confirm_echo("reply");
+  const last = psyche.conversation.pop();
+  if (last?.content !== "reply" || last.role !== "assistant") {
+    throw new Error("reply missing after echo");
   }
 });

--- a/pete/tests/websocket_sensor_test.ts
+++ b/pete/tests/websocket_sensor_test.ts
@@ -35,3 +35,19 @@ Deno.test("how uses provided name", () => {
   sensor.received("ip", "Alice", "hello");
   assertEquals(how, "Alice says: hello");
 });
+
+Deno.test("self emits internal desire", () => {
+  const sensor = new WebSocketSensor();
+  let type = "";
+  sensor.subscribe((exp) => type = exp.what[0].what.type);
+  sensor.self("hi");
+  assertEquals(type, "self");
+});
+
+Deno.test("echoed emits echo event", () => {
+  const sensor = new WebSocketSensor();
+  let type = "";
+  sensor.subscribe((exp) => type = exp.what[0].what.type);
+  sensor.echoed("ip", "ok");
+  assertEquals(type, "echo");
+});

--- a/sensors/websocket.ts
+++ b/sensors/websocket.ts
@@ -1,7 +1,9 @@
 export type WebSocketWhat =
   | { type: "connect"; remote: string }
   | { type: "disconnect"; remote: string }
-  | { type: "message"; remote: string; name: string; message: string };
+  | { type: "message"; remote: string; name: string; message: string }
+  | { type: "self"; message: string }
+  | { type: "echo"; remote: string; message: string };
 
 import { Sensor } from "../lib/Sensor.ts";
 import { Experience } from "../lib/Experience.ts";
@@ -28,6 +30,12 @@ export class WebSocketSensor extends Sensor<WebSocketWhat> {
       case "message":
         how = `${what.name} says: ${what.message}`;
         break;
+      case "self":
+        how = `I feel myself wanting to say: ${what.message}`;
+        break;
+      case "echo":
+        how = `Echo from ${what.remote}: ${what.message}`;
+        break;
     }
     const exp: Experience<WebSocketWhat> = {
       what: [{ when: new Date(), what }],
@@ -46,5 +54,13 @@ export class WebSocketSensor extends Sensor<WebSocketWhat> {
 
   received(remote: string, name: string, message: string): void {
     this.feel({ type: "message", remote, name, message });
+  }
+
+  self(message: string): void {
+    this.feel({ type: "self", message });
+  }
+
+  echoed(remote: string, message: string): void {
+    this.feel({ type: "echo", remote, message });
   }
 }


### PR DESCRIPTION
## Summary
- notify AGENT about new test requirements for websocket events
- extend WebSocketSensor to emit `self` and `echo` events
- update Psyche to hold output until an echo is received
- send `pete-says` messages to the browser and echo them back
- update client script to send echo when Pete speaks
- test new behaviour

## Testing
- `deno test` *(fails: Import 'https://deno.land/std@0.200.0/testing/asserts.ts' failed)*

------
https://chatgpt.com/codex/tasks/task_e_684bb787d8ac83209fb5f341b2f87fa4