### PR TITLE
Fix websocket chat state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,9 @@ If dependencies are missing, use the official install script or package manager
 before running tests. Cache dependencies with `deno cache` to speed up repeated
 runs.
 
+If network access is restricted, vendor remote modules with `deno vendor`
+so tests can run offline.
+
 If commands fail due to environment limitations, mention that in the PR's test
 results section.
 

--- a/index.html
+++ b/index.html
@@ -35,21 +35,7 @@
     </div>
     <script>
       function chat() {
-        const ws = new WebSocket("ws://" + location.host + "/ws");
-        ws.onmessage = (e) => {
-          try {
-            const data = JSON.parse(e.data);
-            if (data.type === "pete-says") {
-              this.lines.push({ id: Date.now(), text: `Pete: ${data.text}` });
-              ws.send(JSON.stringify({ type: "echo", message: data.text }));
-            }
-          } catch (_) {
-            // ignore invalid payloads
-          }
-          const log = document.getElementById("log");
-          log.scrollTop = log.scrollHeight;
-        };
-        return {
+        const state = {
           lines: [],
           name: "",
           input: "",
@@ -68,6 +54,23 @@
             this.input = "";
           },
         };
+
+        const ws = new WebSocket("ws://" + location.host + "/ws");
+        ws.onmessage = (e) => {
+          try {
+            const data = JSON.parse(e.data);
+            if (data.type === "pete-says") {
+              state.lines.push({ id: Date.now(), text: `Pete: ${data.text}` });
+              ws.send(JSON.stringify({ type: "echo", message: data.text }));
+            }
+          } catch (_) {
+            // ignore invalid payloads
+          }
+          const log = document.getElementById("log");
+          log.scrollTop = log.scrollHeight;
+        };
+
+        return state;
       }
     </script>
   </body>


### PR DESCRIPTION
## Summary
- fix chat state handling in index.html so Pete's lines reach the client
- document offline module caching in AGENTS instructions

## Testing
- `deno test` *(fails: unsuccessful tunnel while fetching https://deno.land/std@0.200.0/testing/asserts.ts)*

------
https://chatgpt.com/codex/tasks/task_e_684bc230aca883209337bfc6ba831f14