### PR TITLE
Improve Psyche error handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,8 +11,8 @@ If dependencies are missing, use the official install script or package manager
 before running tests. Cache dependencies with `deno cache` to speed up repeated
 runs.
 
-If network access is restricted, vendor remote modules with `deno vendor`
-so tests can run offline.
+If network access is restricted, prefetch dependencies with `deno cache --lock=deno.lock`.
+The old `deno vendor` command was removed in Deno 2.
 
 If commands fail due to environment limitations, mention that in the PR's test
 results section.


### PR DESCRIPTION
## Summary
- update agent instructions for Deno 2
- keep Pete running if the LLM provider throws

## Testing
- `deno test` *(fails: Import failed for https://deno.land/std@0.200.0/testing/asserts.ts)*

------
https://chatgpt.com/codex/tasks/task_e_684c50e1077c8320afa19161e721060b