### PR TITLE
Improve beat loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,3 +33,5 @@ be run with `deno run pete/main.ts`.
 - Cache server dependencies with `deno cache server.ts` before tests.
 - Keep WebSocket sensor tests in sync with any new event types or message
   flows.
+- Ensure `integrate_sensory_input` runs each beat even when speaking. Only
+  `take_turn` may be skipped while speech is in progress.

--- a/lib/Psyche.ts
+++ b/lib/Psyche.ts
@@ -54,7 +54,9 @@ export class Psyche {
         this.beats++;
         // console.log(`Beat ${this.beats} at ${new Date().toLocaleTimeString()}`);
         await this.integrate_sensory_input();
-        await this.take_turn();
+        if (!this.speaking) {
+            await this.take_turn();
+        }
     }
 
     /**

--- a/pete/tests/beat_sensory_test.ts
+++ b/pete/tests/beat_sensory_test.ts
@@ -1,0 +1,46 @@
+import { Psyche } from "../../lib/Psyche.ts";
+import { InstructionFollower } from "../../lib/InstructionFollower.ts";
+import { Chatter, ChatMessage } from "../../lib/Chatter.ts";
+import { Sensor } from "../../lib/Sensor.ts";
+import { Experience } from "../../lib/Experience.ts";
+
+class CountingFollower extends InstructionFollower {
+  calls = 0;
+  async instruct(): Promise<string> {
+    this.calls++;
+    return "instant";
+  }
+}
+
+class SilentChatter extends Chatter {
+  async chat(_m: ChatMessage[]): Promise<string> {
+    return "reply";
+  }
+}
+
+class StubSensor extends Sensor<string> {
+  feel(what: string): void {
+    const exp: Experience<string> = {
+      what: [{ when: new Date(), what }],
+      how: what,
+    };
+    this.subject.next(exp);
+  }
+}
+
+Deno.test("integrate_sensory_input runs while speaking", async () => {
+  const sensor = new StubSensor();
+  const follower = new CountingFollower();
+  const chatter = new SilentChatter();
+  const psyche = new Psyche([sensor], follower, chatter);
+
+  sensor.feel("one");
+  await psyche.beat(); // start speaking
+
+  sensor.feel("two");
+  await psyche.beat(); // should integrate again even though speaking
+
+  if (follower.calls !== 2) {
+    throw new Error("expected integrate_sensory_input on each beat");
+  }
+});


### PR DESCRIPTION
## Summary
- document integrate_sensory_input requirement in `AGENTS.md`
- keep taking turns only when not speaking
- verify integrate_sensory_input runs on every beat

## Testing
- `deno test` *(fails: Import https://deno.land/std@0.200.0/testing/asserts.ts failed)*

------
https://chatgpt.com/codex/tasks/task_e_684c521b69f88320bde3b338d5c08732