### PR TITLE
Add websocket prompt streaming

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,35 +8,42 @@
       defer
     ></script>
     <link
-      href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css"
       rel="stylesheet"
-    >
+      href="https://cdn.jsdelivr.net/npm/skeleton-css@2.0.4/css/skeleton.min.css"
+    />
   </head>
-  <body class="bg-gray-50" x-data="chat()">
-    <div class="max-w-lg mx-auto p-4">
-      <h1 class="text-2xl mb-4 text-center">Chat with Pete</h1>
-      <div class="border h-64 overflow-y-auto p-2 mb-4 bg-white" id="log">
+  <body x-data="chat()">
+    <div class="container">
+      <h1>Chat with Pete</h1>
+      <p id="prompt" class="u-full-width" x-text="prompt"></p>
+      <p id="reply" class="u-full-width" x-text="reply"></p>
+      <div
+        id="log"
+        style="height: 15rem; overflow-y: auto"
+        class="u-full-width"
+      >
         <template x-for="line in lines" :key="line.id">
-          <div class="mb-1" x-text="line.text"></div>
+          <div x-text="line.text"></div>
         </template>
       </div>
-      <form @submit.prevent="send" class="flex gap-2">
-        <input x-model="name" class="border p-2 w-32" placeholder="Your name" />
-        <input
-          x-model="input"
-          autofocus
-          class="border p-2 flex-grow"
-          placeholder="Say something"
-        />
-        <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">
-          Send
-        </button>
+      <form @submit.prevent="send">
+        <div class="row">
+          <div class="six columns">
+            <input x-model="name" placeholder="Your name" />
+          </div>
+          <div class="six columns">
+            <input x-model="input" placeholder="Say something" />
+          </div>
+        </div>
+        <button type="submit">Send</button>
       </form>
     </div>
     <script>
       function chat() {
         const state = {
           lines: [],
+          prompt: "",
+          reply: "",
           name: "",
           input: "",
           send() {
@@ -59,9 +66,19 @@
         ws.onmessage = (e) => {
           try {
             const data = JSON.parse(e.data);
-            if (data.type === "pete-says") {
-              state.lines.push({ id: Date.now(), text: `Pete: ${data.text}` });
-              ws.send(JSON.stringify({ type: "echo", message: data.text }));
+            if (data.type === "pete-prompt") {
+              state.prompt = data.text;
+              state.reply = "";
+            } else if (data.type === "pete-stream") {
+              state.reply += data.text;
+            } else if (data.type === "pete-says") {
+              state.lines.push({
+                id: Date.now(),
+                text: `Pete: ${data.text}`,
+              });
+              ws.send(
+                JSON.stringify({ type: "echo", message: data.text }),
+              );
             }
           } catch (_) {
             // ignore invalid payloads

--- a/lib/Psyche.ts
+++ b/lib/Psyche.ts
@@ -9,145 +9,156 @@ import { WebSocketSensor } from "../sensors/websocket.ts";
  */
 
 export class Psyche {
-    private beats = 0;
-    private live = true;
-    private buffer: Experience<any>[] = [];
-    private speaking = false;
-    private pendingSpeech = "";
-    public instant = "Pete has just been born.";
-    public conversation: ChatMessage[] = [];
+  private beats = 0;
+  private live = true;
+  private buffer: Experience<any>[] = [];
+  private speaking = false;
+  private pendingSpeech = "";
+  public instant = "Pete has just been born.";
+  public conversation: ChatMessage[] = [];
 
-    constructor(
-        public externalSensors: Sensor<any>[] = [],
-        private instructionFollower: InstructionFollower,
-        private chatter: Chatter,
-        private opts: {
-            onStream?: (chunk: string) => Promise<void>;
-            onSay?: (text: string) => Promise<void>;
-            wsSensor?: WebSocketSensor;
-        } = {},
-    ) {
-        for (const sensor of this.externalSensors) {
-            sensor.subscribe((e) => {
-                Deno.stdout.writeSync(
-                    new TextEncoder().encode(`x`),
-                );
-                this.buffer.push(e);
-            });
-        }
-    }
-
-    /** How many beats have occurred. */
-    get beatCount(): number {
-        return this.beats;
-    }
-
-    /** Whether the psyche should keep running. */
-    isLive(): boolean {
-        return this.live;
-    }
-
-    /** Stop the psyche's run loop. */
-    stop(): void {
-        this.live = false;
-    }
-
-    /** Increment the internal beat counter. */
-    async beat(): Promise<void> {
-        this.beats++;
-        await this.integrate_sensory_input();
-        if (!this.speaking) {
-            await this.take_turn();
-        }
-        if (this.opts.wsSensor) {
-            this.opts.wsSensor.self(this.pendingSpeech);
-        }
-    }
-
-    /**
-     * Integrate buffered sensory input using the instruction follower.
-     * Clears the buffer and updates `instant` with the follower's response.
-     */
-    async integrate_sensory_input(): Promise<void> {
-        if (this.buffer.length === 0) return;
-        const happenings = this.buffer.map((s) => {
-            return `[${s.what[0]?.when}] ${s.how}`;
-        }).join("\n");
-        const prompt =
-            "You are the linguistic processor for an artificial entity named Pete. Speak in Pete's voice on his behalf.\n" +
-            "## Pete's Senses\n* " +
-            this.externalSensors.map((s) => s.describeSensor()).join("\n* ") +
-            "\n## Pete's Current Situation (as he understands it)\n" +
-            `${this.instant}\n` +
-            "## What just happened in the last instant\n\n" +
-            `${happenings}\n` +
-            "Condense the happenings here into one sentence, emphasizing the most salient information and omitting irrelevant information. Speak only as Pete (who is not an LLM).";
-        try {
-            this.instant = await this.instructionFollower.instruct(
-                prompt,
-                this.opts.onStream,
-            );
-        } catch (err) {
-            console.error("instruction follower failed", err);
-        }
-        this.buffer = [];
+  constructor(
+    public externalSensors: Sensor<any>[] = [],
+    private instructionFollower: InstructionFollower,
+    private chatter: Chatter,
+    private opts: {
+      onStream?: (chunk: string) => Promise<void>;
+      /** Called with the prompt used during integrate_sensory_input */
+      onPrompt?: (prompt: string) => Promise<void>;
+      onSay?: (text: string) => Promise<void>;
+      wsSensor?: WebSocketSensor;
+    } = {},
+  ) {
+    for (const sensor of this.externalSensors) {
+      sensor.subscribe((e) => {
         Deno.stdout.writeSync(
-            new TextEncoder().encode(`.`),
+          new TextEncoder().encode(`x`),
         );
+        this.buffer.push(e);
+      });
+    }
+  }
+
+  /** How many beats have occurred. */
+  get beatCount(): number {
+    return this.beats;
+  }
+
+  /** Whether the psyche should keep running. */
+  isLive(): boolean {
+    return this.live;
+  }
+
+  /** Stop the psyche's run loop. */
+  stop(): void {
+    this.live = false;
+  }
+
+  /** Increment the internal beat counter. */
+  async beat(): Promise<void> {
+    this.beats++;
+    await this.integrate_sensory_input();
+    if (!this.speaking) {
+      await this.take_turn();
+    }
+    if (this.opts.wsSensor) {
+      this.opts.wsSensor.self(this.pendingSpeech);
+    }
+  }
+
+  /**
+   * Integrate buffered sensory input using the instruction follower.
+   * Clears the buffer and updates `instant` with the follower's response.
+   */
+  async integrate_sensory_input(): Promise<void> {
+    if (this.buffer.length === 0) return;
+    const happenings = this.buffer.map((s) => {
+      return `[${s.what[0]?.when}] ${s.how}`;
+    }).join("\n");
+    const prompt =
+      "You are the linguistic processor for an artificial entity named Pete. Speak in Pete's voice on his behalf.\n" +
+      "## Pete's Senses\n* " +
+      this.externalSensors.map((s) => s.describeSensor()).join("\n* ") +
+      "\n## Pete's Current Situation (as he understands it)\n" +
+      `${this.instant}\n` +
+      "## What just happened in the last instant\n\n" +
+      `${happenings}\n` +
+      "Condense the happenings here into one sentence, emphasizing the most salient information and omitting irrelevant information. Speak only as Pete (who is not an LLM).";
+    try {
+      await this.opts.onPrompt?.(prompt);
+      this.instant = await this.instructionFollower.instruct(
+        prompt,
+        this.opts.onStream,
+      );
+    } catch (err) {
+      console.error("instruction follower failed", err);
+    }
+    this.buffer = [];
+    Deno.stdout.writeSync(
+      new TextEncoder().encode(`.`),
+    );
+  }
+
+  /**
+   * Engage in conversation based on the current instant and stored messages.
+   */
+  async take_turn(): Promise<void> {
+    if (this.speaking) {
+      Deno.stdout.writeSync(
+        new TextEncoder().encode(`O`),
+      );
+      return;
     }
 
-    /**
-     * Engage in conversation based on the current instant and stored messages.
-     */
-    async take_turn(): Promise<void> {
-        if (this.speaking) {
-            Deno.stdout.writeSync(
-                new TextEncoder().encode(`O`),
-            );
-            return;
-        }
-
-        const messages: ChatMessage[] = [
-            {
-                role: "system",
-                content: `You are the linguistic processing unit for an artificial entity named Pete. Here's the situation as Pete understands it: ${this.instant}\n\nSpeak in Pete's voice on his behalf to the user. As your conversation progresses, you will receive more information about Pete's situation. Use this information to inform your responses, and respond only with spoken text (no non-linguistic notes). Everything you return will be spoken out loud by Pete. Be concise, clear, and conversational. Do not use any markdown or code blocks. You will have a chance to continue further so do not try to say everything at once.`,
-            },
-            ...this.conversation,
-        ];
-        try {
-            const reply = await this.chatter.chat(messages);
-            this.pendingSpeech = reply;
-            this.opts.wsSensor?.self(reply);
-            await this.opts.onSay?.(reply);
-        } catch (err) {
-            console.error("chatter failed", err);
-            this.pendingSpeech = "";
-        } finally {
-            this.speaking = true;
-        }
+    const messages: ChatMessage[] = [
+      {
+        role: "system",
+        content:
+          `You are the linguistic processing unit for an artificial entity named Pete. Here's the situation as Pete understands it: ${this.instant}\n\nSpeak in Pete's voice on his behalf to the user. As your conversation progresses, you will receive more information about Pete's situation. Use this information to inform your responses, and respond only with spoken text (no non-linguistic notes). Everything you return will be spoken out loud by Pete. Be concise, clear, and conversational. Do not use any markdown or code blocks. You will have a chance to continue further so do not try to say everything at once.`,
+      },
+      ...this.conversation,
+    ];
+    try {
+      this.pendingSpeech = "";
+      const reply = await this.chatter.chat(
+        messages,
+        async (chunk) => {
+          this.pendingSpeech += chunk;
+          await this.opts.onStream?.(chunk);
+        },
+      );
+      this.pendingSpeech = reply;
+      this.opts.wsSensor?.self(reply);
+      await this.opts.onSay?.(reply);
+    } catch (err) {
+      console.error("chatter failed", err);
+      this.pendingSpeech = "";
+    } finally {
+      this.speaking = true;
     }
+  }
 
-    confirm_echo(message: string): void {
-        if (this.pendingSpeech && message === this.pendingSpeech) {
-            this.conversation.push({ role: "assistant", content: message });
-            this.pendingSpeech = "";
-            this.speaking = false;
-        }
+  confirm_echo(message: string): void {
+    if (this.pendingSpeech && message === this.pendingSpeech) {
+      this.conversation.push({ role: "assistant", content: message });
+      this.pendingSpeech = "";
+      this.speaking = false;
     }
+  }
 
-    /**
-     * Continuously run while the psyche is live.
-     *
-     * ```ts
-     * const psyche = new Psyche();
-     * psyche.run();
-     * psyche.stop();
-     * ```
-     */
-    async run(): Promise<void> {
-        while (this.isLive()) {
-            await this.beat();
-            await new Promise((res) => setTimeout(res, 0));
-        }
+  /**
+   * Continuously run while the psyche is live.
+   *
+   * ```ts
+   * const psyche = new Psyche();
+   * psyche.run();
+   * psyche.stop();
+   * ```
+   */
+  async run(): Promise<void> {
+    while (this.isLive()) {
+      await this.beat();
+      await new Promise((res) => setTimeout(res, 0));
     }
+  }
 }

--- a/pete/tests/on_prompt_test.ts
+++ b/pete/tests/on_prompt_test.ts
@@ -1,0 +1,47 @@
+import { Psyche } from "../../lib/Psyche.ts";
+import { InstructionFollower } from "../../lib/InstructionFollower.ts";
+import { Chatter } from "../../lib/Chatter.ts";
+import { Sensor } from "../../lib/Sensor.ts";
+import { Experience } from "../../lib/Experience.ts";
+
+class StubFollower extends InstructionFollower {
+  async instruct(prompt: string): Promise<string> {
+    return prompt;
+  }
+}
+
+class StubChatter extends Chatter {
+  async chat(): Promise<string> {
+    return "";
+  }
+}
+
+class DummySensor extends Sensor<string> {
+  override describeSensor(): string {
+    return "Dummy";
+  }
+  feel(what: string): void {
+    const exp: Experience<string> = {
+      what: [{ when: new Date(), what }],
+      how: what,
+    };
+    this.subject.next(exp);
+  }
+}
+
+Deno.test("onPrompt receives prompt text", async () => {
+  const follower = new StubFollower();
+  const chatter = new StubChatter();
+  const sensor = new DummySensor();
+  let got = "";
+  const psyche = new Psyche([sensor], follower, chatter, {
+    onPrompt: async (p) => {
+      got = p;
+    },
+  });
+  sensor.feel("hi");
+  await psyche.beat();
+  if (!got.includes("hi")) {
+    throw new Error("prompt not forwarded");
+  }
+});


### PR DESCRIPTION
## Summary
- expose `onPrompt` option on `Psyche`
- stream prompts and replies over the websocket in `main.ts`
- update the client UI using Skeleton CSS and show prompt/streamed reply
- test prompt callback

## Testing
- `deno test` *(fails: JSR package manifest for '@std/assert' failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_684c7e86d0e08320aebdab0b46cfb088