### PR TITLE
Improve chat page layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,3 +26,4 @@ be run with `deno run pete/main.ts`.
 - Ensure `integrate_sensory_input` runs each beat even when speaking. Only
   `take_turn` may be skipped while speech is in progress.
 - Index page should log all websocket messages and echo `pete-says` once displayed.
+- Use Tailwind CSS for styling the index page.

--- a/index.html
+++ b/index.html
@@ -7,35 +7,36 @@
       src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"
       defer
     ></script>
-    <link
-      rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/skeleton-css@2.0.4/css/skeleton.min.css"
-    />
+    <script src="https://cdn.tailwindcss.com"></script>
   </head>
-  <body x-data="chat()">
-    <div class="container">
-      <h1>Chat with Pete</h1>
-      <p id="prompt" class="u-full-width" x-text="prompt"></p>
-      <p id="reply" class="u-full-width" x-text="reply"></p>
-      <div
-        id="log"
-        style="height: 15rem; overflow-y: auto"
-        class="u-full-width"
-      >
-        <template x-for="line in lines" :key="line.id">
-          <div x-text="line.text"></div>
-        </template>
+  <body x-data="chat()" class="min-h-screen bg-gray-900 text-gray-100">
+    <div class="max-w-3xl mx-auto p-4">
+      <h1 class="text-2xl font-bold mb-4">Chat with Pete</h1>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <section>
+          <h2 class="text-lg font-semibold mb-1">Prompt</h2>
+          <div id="prompt" class="bg-gray-800 rounded p-2 h-32 overflow-y-auto" x-text="prompt"></div>
+        </section>
+        <section>
+          <h2 class="text-lg font-semibold mb-1">Pete Stream</h2>
+          <div id="reply" class="bg-gray-800 rounded p-2 h-32 overflow-y-auto" x-text="reply"></div>
+        </section>
       </div>
-      <form @submit.prevent="send">
-        <div class="row">
-          <div class="six columns">
-            <input x-model="name" placeholder="Your name" />
-          </div>
-          <div class="six columns">
-            <input x-model="input" placeholder="Say something" />
-          </div>
+
+      <section class="mt-4">
+        <h2 class="text-lg font-semibold mb-1">Conversation Log</h2>
+        <div id="log" class="bg-gray-800 rounded p-2 h-64 overflow-y-auto space-y-1">
+          <template x-for="line in lines" :key="line.id">
+            <div x-text="line.text"></div>
+          </template>
         </div>
-        <button type="submit">Send</button>
+      </section>
+
+      <form @submit.prevent="send" class="mt-4 flex flex-col md:flex-row gap-2">
+        <input x-model="name" placeholder="Your name" class="flex-1 rounded p-2 bg-gray-700 placeholder-gray-400" />
+        <input x-model="input" placeholder="Say something" class="flex-1 rounded p-2 bg-gray-700 placeholder-gray-400" />
+        <button type="submit" class="rounded bg-blue-600 px-4 py-2 text-white">Send</button>
       </form>
     </div>
     <script>


### PR DESCRIPTION
## Summary
- modernize chat page using Tailwind CSS
- split prompt and pete stream into dedicated sections
- record instructions for using Tailwind in AGENTS

## Testing
- `deno test` *(fails: JSR package manifest for '@std/assert' failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_684c830c27988320b4ac7ee5deac89e9