### PR TITLE
Fix chat display separation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,5 +25,7 @@ be run with `deno run pete/main.ts`.
   flows.
 - Ensure `integrate_sensory_input` runs each beat even when speaking. Only
   `take_turn` may be skipped while speech is in progress.
-- Index page should log all websocket messages and echo `pete-says` once displayed.
+- Index page should echo `pete-says` once displayed.
+- Prompts go to the prompt box and streams go to the stream box.
+- Only `pete-says` and user-sent messages belong in the chat log.
 - Use Tailwind CSS for styling the index page.

--- a/index.html
+++ b/index.html
@@ -41,14 +41,13 @@
     </div>
     <script>
       function chat() {
-        const state = {
-          lines: [],
-          prompt: "",
-          reply: "",
-          name: "",
-          input: "",
-          streamLineId: null,
-          send() {
+          const state = {
+            lines: [],
+            prompt: "",
+            reply: "",
+            name: "",
+            input: "",
+            send() {
             if (!this.name) {
               alert("Please enter your name");
               return;
@@ -72,21 +71,9 @@
               case "pete-prompt":
                 state.prompt = data.text;
                 state.reply = "";
-                state.lines.push({
-                  id: Date.now(),
-                  text: `Prompt: ${data.text}`,
-                });
-                state.streamLineId = null;
                 break;
               case "pete-stream":
                 state.reply += data.text;
-                if (!state.streamLineId) {
-                  state.streamLineId = Date.now();
-                  state.lines.push({ id: state.streamLineId, text: data.text });
-                } else {
-                  const line = state.lines.find((l) => l.id === state.streamLineId);
-                  if (line) line.text += data.text;
-                }
                 break;
               case "pete-says":
                 state.lines.push({
@@ -96,13 +83,13 @@
                 ws.send(
                   JSON.stringify({ type: "echo", message: data.text }),
                 );
-                state.streamLineId = null;
                 break;
               default:
-                state.lines.push({ id: Date.now(), text: e.data });
+                // ignore other message types
+                break;
             }
           } catch (_) {
-            state.lines.push({ id: Date.now(), text: String(e.data) });
+            // ignore parse errors
           }
           const log = document.getElementById("log");
           log.scrollTop = log.scrollHeight;


### PR DESCRIPTION
## Summary
- separate prompt and stream handling in index.html
- clarify index page behavior in AGENTS instructions

## Testing
- `deno cache server.ts` *(fails: file not found)*
- `deno test` *(fails: JSR package manifest for '@std/assert' failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_684c86cba378832089ae763a5db06c27