### PR TITLE
Fix duplicate websocket setup

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,10 @@
           name: "",
           input: "",
           init() {
-            this.ws = new WebSocket("ws://" + location.host + "/ws");
+            if (!this.ws || this.ws.readyState > 1) {
+              // Avoid creating more than one connection if init() is called twice
+              this.ws = new WebSocket("ws://" + location.host + "/ws");
+            }
             this.ws.onmessage = (e) => {
               try {
                 const data = JSON.parse(e.data);


### PR DESCRIPTION
## Summary
- guard `chat.init()` so websocket connection isn't created twice

## Testing
- `deno test` *(fails: JSR package manifest for '@std/assert' failed to load)*

------
https://chatgpt.com/codex/tasks/task_e_684c8daac91883209d037fab2304a129