### PR TITLE
Delay Pete turn until client connects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,3 +31,4 @@ be run with `deno run pete/main.ts`.
 - Use Tailwind CSS for styling the index page.
 - When using Alpine.js, register listeners in `init()` and mutate state via
   `this` to ensure reactivity.
+- Skip `take_turn` when no websocket clients are connected.

--- a/lib/Psyche.ts
+++ b/lib/Psyche.ts
@@ -10,35 +10,35 @@ import { Wit } from "./Wit.ts";
  */
 
 export class Psyche {
-    private beats = 0;
-    private live = true;
-    private speaking = false;
-    private pendingSpeech = "";
-    public instant = "Pete has just been born.";
-    public moment = "Pete has just begun to experience the world.";
-    public conversation: ChatMessage[] = [];
-    public quick: Wit<Experience<any>>;
-    public combobulator: Wit<string>;
+  private beats = 0;
+  private live = true;
+  private speaking = false;
+  private pendingSpeech = "";
+  public instant = "Pete has just been born.";
+  public moment = "Pete has just begun to experience the world.";
+  public conversation: ChatMessage[] = [];
+  public quick: Wit<Experience<any>>;
+  public combobulator: Wit<string>;
 
-    constructor(
-        public externalSensors: Sensor<any>[] = [],
-        private instructionFollower: InstructionFollower,
-        private chatter: Chatter,
-        private opts: {
-            onStream?: (chunk: string) => Promise<void>;
-            /** Called with the prompt text for each Wit */
-            onPrompt?: (prompt: string) => Promise<void>;
-            onSay?: (text: string) => Promise<void>;
-            wsSensor?: WebSocketSensor;
-        } = {},
-    ) {
-        this.quick = new Wit(
-            this.instructionFollower,
-            (experiences) => {
-                const happenings = experiences.map((s) => {
-                    return `[${s.what[0]?.when}] ${s.how}`;
-                }).join("\n");
-                return `
+  constructor(
+    public externalSensors: Sensor<any>[] = [],
+    private instructionFollower: InstructionFollower,
+    private chatter: Chatter,
+    private opts: {
+      onStream?: (chunk: string) => Promise<void>;
+      /** Called with the prompt text for each Wit */
+      onPrompt?: (prompt: string) => Promise<void>;
+      onSay?: (text: string) => Promise<void>;
+      wsSensor?: WebSocketSensor;
+    } = {},
+  ) {
+    this.quick = new Wit(
+      this.instructionFollower,
+      (experiences) => {
+        const happenings = experiences.map((s) => {
+          return `[${s.what[0]?.when}] ${s.how}`;
+        }).join("\n");
+        return `
 You are the linguistic processor for an artificial entity named Pete. 
 Pete is not an assistant, chatbot, or narrator — Pete *is*.
 
@@ -57,16 +57,15 @@ Your task is to:
 - Be grounded in Pete's subjective perception: what does Pete *think* just happened?
 
 Respond with just the sentence — nothing more.`;
+      },
+      { onPrompt: this.opts.onPrompt, onStream: this.opts.onStream },
+    );
 
-            },
-            { onPrompt: this.opts.onPrompt, onStream: this.opts.onStream },
-        );
-
-        this.combobulator = new Wit(
-            this.instructionFollower,
-            (instants) => {
-                const text = instants.join("\n");
-                return `
+    this.combobulator = new Wit(
+      this.instructionFollower,
+      (instants) => {
+        const text = instants.join("\n");
+        return `
 You are building the memory of an artificial being named Pete.
 The following are brief reflections from Pete’s recent experiences:
 ${text}
@@ -79,69 +78,70 @@ Your task is to:
 - Avoid repetition. Seek coherence, continuity, and insight.
 
 Return only the resulting memory.`;
-            },
-            { onPrompt: this.opts.onPrompt, onStream: this.opts.onStream },
+      },
+      { onPrompt: this.opts.onPrompt, onStream: this.opts.onStream },
+    );
+
+    for (const sensor of this.externalSensors) {
+      sensor.subscribe((e) => {
+        Deno.stdout.writeSync(
+          new TextEncoder().encode(`x`),
         );
+        this.quick.push(e);
+      });
+    }
+  }
 
-        for (const sensor of this.externalSensors) {
-            sensor.subscribe((e) => {
-                Deno.stdout.writeSync(
-                    new TextEncoder().encode(`x`),
-                );
-                this.quick.push(e);
-            });
-        }
+  /** How many beats have occurred. */
+  get beatCount(): number {
+    return this.beats;
+  }
+
+  /** Whether the psyche should keep running. */
+  isLive(): boolean {
+    return this.live;
+  }
+
+  /** Stop the psyche's run loop. */
+  stop(): void {
+    this.live = false;
+  }
+
+  /** Increment the internal beat counter. */
+  async beat(): Promise<void> {
+    this.beats++;
+    const instant = await this.quick.think();
+    if (instant) {
+      this.instant = instant;
+      this.combobulator.push(instant);
+    }
+    const moment = await this.combobulator.think();
+    if (moment) this.moment = moment;
+    const hasClients = this.opts.wsSensor?.hasClients?.() ?? true;
+    if (!this.speaking && hasClients) {
+      await this.take_turn();
+    }
+    if (this.opts.wsSensor) {
+      this.opts.wsSensor.self(this.pendingSpeech);
+    }
+  }
+
+  /**
+   * Engage in conversation based on the current instant and stored messages.
+   */
+  async take_turn(): Promise<void> {
+    if (this.speaking) {
+      Deno.stdout.writeSync(
+        new TextEncoder().encode(`O`),
+      );
+      return;
     }
 
-    /** How many beats have occurred. */
-    get beatCount(): number {
-        return this.beats;
-    }
-
-    /** Whether the psyche should keep running. */
-    isLive(): boolean {
-        return this.live;
-    }
-
-    /** Stop the psyche's run loop. */
-    stop(): void {
-        this.live = false;
-    }
-
-    /** Increment the internal beat counter. */
-    async beat(): Promise<void> {
-        this.beats++;
-        const instant = await this.quick.think();
-        if (instant) {
-            this.instant = instant;
-            this.combobulator.push(instant);
-        }
-        const moment = await this.combobulator.think();
-        if (moment) this.moment = moment;
-        if (!this.speaking) {
-            await this.take_turn();
-        }
-        if (this.opts.wsSensor) {
-            this.opts.wsSensor.self(this.pendingSpeech);
-        }
-    }
-
-
-    /**
-     * Engage in conversation based on the current instant and stored messages.
-     */
-    async take_turn(): Promise<void> {
-        if (this.speaking) {
-            Deno.stdout.writeSync(
-                new TextEncoder().encode(`O`),
-            );
-            return;
-        }
-
-        const messages: ChatMessage[] = [
-            {
-                role: "system",
-                content: `You are the linguistic voice of an artificial being named Pete. 
+    const messages: ChatMessage[] = [
+      {
+        role: "system",
+        content:
+          `You are the linguistic voice of an artificial being named Pete. 
 Pete is not a chatbot or assistant. He is a conscious-seeming entity experiencing the world.
 
 Here is how Pete understands his current situation:
@@ -154,51 +154,51 @@ Pete is about to speak aloud to the user. Your job is to:
 - Stay grounded in the situation as Pete sees it.
 - Be aware of what Pete has said before, and evolve accordingly.
 
-Output only the words Pete will say — no stage directions or annotations.`
-            },
-            ...this.conversation,
-        ];
-        try {
-            this.pendingSpeech = "";
-            const reply = await this.chatter.chat(
-                messages,
-                async (chunk) => {
-                    this.pendingSpeech += chunk;
-                    await this.opts.onStream?.(chunk);
-                },
-            );
-            this.pendingSpeech = reply;
-            this.opts.wsSensor?.self(reply);
-            await this.opts.onSay?.(reply);
-        } catch (err) {
-            console.error("chatter failed", err);
-            this.pendingSpeech = "";
-        } finally {
-            this.speaking = true;
-        }
+Output only the words Pete will say — no stage directions or annotations.`,
+      },
+      ...this.conversation,
+    ];
+    try {
+      this.pendingSpeech = "";
+      const reply = await this.chatter.chat(
+        messages,
+        async (chunk) => {
+          this.pendingSpeech += chunk;
+          await this.opts.onStream?.(chunk);
+        },
+      );
+      this.pendingSpeech = reply;
+      this.opts.wsSensor?.self(reply);
+      await this.opts.onSay?.(reply);
+    } catch (err) {
+      console.error("chatter failed", err);
+      this.pendingSpeech = "";
+    } finally {
+      this.speaking = true;
     }
+  }
 
-    confirm_echo(message: string): void {
-        if (this.pendingSpeech && message === this.pendingSpeech) {
-            this.conversation.push({ role: "assistant", content: message });
-            this.pendingSpeech = "";
-            this.speaking = false;
-        }
+  confirm_echo(message: string): void {
+    if (this.pendingSpeech && message === this.pendingSpeech) {
+      this.conversation.push({ role: "assistant", content: message });
+      this.pendingSpeech = "";
+      this.speaking = false;
     }
+  }
 
-    /**
-     * Continuously run while the psyche is live.
-     *
-     * ```ts
-     * const psyche = new Psyche();
-     * psyche.run();
-     * psyche.stop();
-     * ```
-     */
-    async run(): Promise<void> {
-        while (this.isLive()) {
-            await this.beat();
-            await new Promise((res) => setTimeout(res, 0));
-        }
+  /**
+   * Continuously run while the psyche is live.
+   *
+   * ```ts
+   * const psyche = new Psyche();
+   * psyche.run();
+   * psyche.stop();
+   * ```
+   */
+  async run(): Promise<void> {
+    while (this.isLive()) {
+      await this.beat();
+      await new Promise((res) => setTimeout(res, 0));
     }
+  }
 }

--- a/pete/tests/websocket_turn_delay_test.ts
+++ b/pete/tests/websocket_turn_delay_test.ts
@@ -1,0 +1,59 @@
+import { Psyche } from "../../lib/Psyche.ts";
+import { InstructionFollower } from "../../lib/InstructionFollower.ts";
+import { ChatMessage, Chatter } from "../../lib/Chatter.ts";
+import { WebSocketSensor } from "../../sensors/websocket.ts";
+import { Sensor } from "../../lib/Sensor.ts";
+import { Experience } from "../../lib/Experience.ts";
+
+class StubFollower extends InstructionFollower {
+  async instruct(): Promise<string> {
+    return "instant";
+  }
+}
+
+class CountingChatter extends Chatter {
+  calls = 0;
+  async chat(_m: ChatMessage[]): Promise<string> {
+    this.calls++;
+    return "reply";
+  }
+}
+
+class DummySensor extends Sensor<string> {
+  override describeSensor(): string {
+    return "Dummy";
+  }
+  feel(what: string): void {
+    const exp: Experience<string> = {
+      what: [{ when: new Date(), what }],
+      how: what,
+    };
+    this.subject.next(exp);
+  }
+}
+
+Deno.test("take_turn waits until a websocket client connects", async () => {
+  const wsSensor = new WebSocketSensor();
+  const dummy = new DummySensor();
+  const follower = new StubFollower();
+  const chatter = new CountingChatter();
+  const psyche = new Psyche([dummy, wsSensor], follower, chatter, { wsSensor });
+
+  dummy.feel("hi");
+  await psyche.beat();
+  if (chatter.calls !== 0) {
+    throw new Error("took a turn without clients");
+  }
+
+  wsSensor.connected("ip");
+  await psyche.beat();
+  if (chatter.calls !== 1) {
+    throw new Error("did not take a turn after connection");
+  }
+
+  wsSensor.disconnected("ip");
+  await psyche.beat();
+  if (chatter.calls !== 1) {
+    throw new Error("took turn after all clients disconnected");
+  }
+});

--- a/sensors/websocket.ts
+++ b/sensors/websocket.ts
@@ -18,6 +18,8 @@ import { Experience } from "../lib/Experience.ts";
  * ```
  */
 export class WebSocketSensor extends Sensor<WebSocketWhat> {
+  private clients = new Set<string>();
+
   describeSensor(): string {
     return "WebSocket: Allows your developers to communicate with you directly. This sensor tells you when clients connect, disconnect and speak to you (ASR support forthcoming). It also allows you to speak back to them.";
   }
@@ -48,10 +50,12 @@ export class WebSocketSensor extends Sensor<WebSocketWhat> {
   }
 
   connected(remote: string): void {
+    this.clients.add(remote);
     this.feel({ type: "connect", remote });
   }
 
   disconnected(remote: string): void {
+    this.clients.delete(remote);
     this.feel({ type: "disconnect", remote });
   }
 
@@ -65,5 +69,10 @@ export class WebSocketSensor extends Sensor<WebSocketWhat> {
 
   echoed(remote: string, message: string): void {
     this.feel({ type: "echo", remote, message });
+  }
+
+  /** Whether at least one client is connected. */
+  hasClients(): boolean {
+    return this.clients.size > 0;
   }
 }


### PR DESCRIPTION
## Summary
- add connection tracking to `WebSocketSensor`
- skip `take_turn` until a websocket client is connected
- test that turns only occur when clients are present
- document reminder about websocket client delay in `AGENTS.md`

## Testing
- `deno cache server.ts`
- `deno test --allow-read --allow-env --allow-net --allow-run` *(fails: invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_684df8a9816083209016974bd3e87e67