### PR TITLE
Add feelings emoji to chat UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,3 +31,5 @@ be run with `deno run pete/main.ts`.
 - Use Tailwind CSS for styling the index page.
 - When using Alpine.js, register listeners in `init()` and mutate state via
   `this` to ensure reactivity.
+- Emit a `pete-feels` websocket event whenever Pete's feelings change and
+  update tests accordingly.

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
   >
     <div class="max-w-3xl mx-auto p-4">
       <h1 class="text-2xl font-bold mb-4">Chat with Pete</h1>
+      <div id="feeling" class="text-center text-[10rem] mb-4" x-text="feeling"></div>
 
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
         <section>
@@ -73,6 +74,7 @@
           lines: [],
           prompt: "",
           reply: "",
+          feeling: "\u{1F610}",
           name: "",
           input: "",
           init() {
@@ -90,6 +92,9 @@
                     break;
                   case "pete-stream":
                     this.reply += data.text;
+                    break;
+                  case "pete-feels":
+                    this.feeling = data.text;
                     break;
                   case "pete-says":
                     this.lines.push({

--- a/lib/Psyche.ts
+++ b/lib/Psyche.ts
@@ -31,6 +31,7 @@ export class Psyche {
             /** Called with the prompt text for each Wit */
             onPrompt?: (prompt: string) => Promise<void>;
             onSay?: (text: string) => Promise<void>;
+            onFeel?: (emoji: string) => Promise<void>;
             wsSensor?: WebSocketSensor;
         } = {},
     ) {
@@ -164,6 +165,7 @@ Respond with just one emoji (any single unicode icon) — nothing more.`;
                 Deno.stdout.writeSync(
                     new TextEncoder().encode(heart),
                 );
+                await this.opts.onFeel?.(heart);
             }
         }
 

--- a/main.ts
+++ b/main.ts
@@ -56,6 +56,16 @@ const pete = new Psyche(
         }
       }
     },
+    onFeel: async (emoji: string) => {
+      const payload = JSON.stringify({ type: "pete-feels", text: emoji });
+      for (const ws of clients) {
+        try {
+          ws.send(payload);
+        } catch (_) {
+          // ignore failed sends
+        }
+      }
+    },
     wsSensor,
   },
 );

--- a/pete/tests/on_feel_test.ts
+++ b/pete/tests/on_feel_test.ts
@@ -1,0 +1,49 @@
+import { Psyche } from "../../lib/Psyche.ts";
+import { InstructionFollower } from "../../lib/InstructionFollower.ts";
+import { Chatter } from "../../lib/Chatter.ts";
+import { Sensor } from "../../lib/Sensor.ts";
+import { Experience } from "../../lib/Experience.ts";
+
+class StubFollower extends InstructionFollower {
+  async instruct(): Promise<string> {
+    return "🙂";
+  }
+}
+
+class StubChatter extends Chatter {
+  async chat(): Promise<string> {
+    return "";
+  }
+}
+
+class DummySensor extends Sensor<string> {
+  override describeSensor(): string {
+    return "Dummy";
+  }
+  feel(what: string): void {
+    const exp: Experience<string> = {
+      what: [{ when: new Date(), what }],
+      how: what,
+    };
+    this.subject.next(exp);
+  }
+}
+
+Deno.test("onFeel receives updated emoji", async () => {
+  const follower = new StubFollower();
+  const chatter = new StubChatter();
+  const sensor = new DummySensor();
+  const emotions: string[] = [];
+  const psyche = new Psyche([sensor], follower, chatter, {
+    onFeel: async (e) => emotions.push(e),
+  });
+  sensor.feel("tick");
+  await psyche.beat();
+  sensor.feel("tock");
+  await psyche.beat();
+  sensor.feel("boom");
+  await psyche.beat();
+  if (!emotions.includes("🙂")) {
+    throw new Error("feeling not forwarded");
+  }
+});


### PR DESCRIPTION
## Summary
- display Pete's current feeling prominently on index page
- expose `onFeel` callback in Psyche and send `pete-feels` websocket event
- update main server to broadcast feelings
- add tests for `onFeel`
- note new event in AGENTS guide

## Testing
- `deno test` *(fails: invalid peer certificate for npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_684dfb4338548320ba9a94c4995e04ca