### PR TITLE
Enable multi-wit prompt and streaming tabs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,11 +27,13 @@ be run with `deno run pete/main.ts`.
 - Update tests when adding or modifying Wits.
 - Index page should echo `pete-says` once displayed.
 - Prompts go to the prompt box and streams go to the stream box.
+- Forward each Wit name with its prompt or streamed chunk so the UI can show a
+  tab per Wit.
 - Only `pete-says` and user-sent messages belong in the chat log.
 - Use Tailwind CSS for styling the index page.
 - When using Alpine.js, register listeners in `init()` and mutate state via
   `this` to ensure reactivity.
-- Emit a `pete-feels` websocket event whenever Pete's feelings change and
-  update tests accordingly.
+- Emit a `pete-feels` websocket event whenever Pete's feelings change and update
+  tests accordingly.
 - Update Autologos sensor tests when output types change.
 - Skip `take_turn` when no websocket clients are connected.

--- a/index.html
+++ b/index.html
@@ -16,15 +16,27 @@
   >
     <div class="max-w-3xl mx-auto p-4">
       <h1 class="text-2xl font-bold mb-4">Chat with Pete</h1>
-      <div id="feeling" class="text-center text-[10rem] mb-4" x-text="feeling"></div>
+      <div id="feeling" class="text-center text-[10rem] mb-4" x-text="feeling">
+      </div>
 
+      <div class="mb-2 flex space-x-2" x-show="Object.keys(wits).length">
+        <template x-for="(wit, name) in wits" :key="name">
+          <button
+            class="px-2 py-1 rounded"
+            :class="currentWit === name ? 'bg-blue-600' : 'bg-gray-700'"
+            @click="currentWit = name"
+            x-text="name"
+          >
+          </button>
+        </template>
+      </div>
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
         <section>
           <h2 class="text-lg font-semibold mb-1">Prompt</h2>
           <div
             id="prompt"
             class="bg-gray-800 rounded p-2 h-32 overflow-y-auto"
-            x-text="prompt"
+            x-text="wits[currentWit]?.prompt || ''"
           >
           </div>
         </section>
@@ -33,7 +45,7 @@
           <div
             id="reply"
             class="bg-gray-800 rounded p-2 h-32 overflow-y-auto"
-            x-text="reply"
+            x-text="wits[currentWit]?.stream || ''"
           >
           </div>
         </section>
@@ -72,8 +84,8 @@
       function chat() {
         return {
           lines: [],
-          prompt: "",
-          reply: "",
+          wits: {},
+          currentWit: "",
           feeling: "\u{1F610}",
           name: "",
           input: "",
@@ -87,11 +99,18 @@
                 const data = JSON.parse(e.data);
                 switch (data.type) {
                   case "pete-prompt":
-                    this.prompt = data.text;
-                    this.reply = "";
+                    if (!this.wits[data.name]) {
+                      this.wits[data.name] = { prompt: "", stream: "" };
+                    }
+                    this.wits[data.name].prompt = data.text;
+                    this.wits[data.name].stream = "";
+                    if (!this.currentWit) this.currentWit = data.name;
                     break;
                   case "pete-stream":
-                    this.reply += data.text;
+                    if (!this.wits[data.name]) {
+                      this.wits[data.name] = { prompt: "", stream: "" };
+                    }
+                    this.wits[data.name].stream += data.text;
                     break;
                   case "pete-feels":
                     this.feeling = data.text;

--- a/main.ts
+++ b/main.ts
@@ -25,8 +25,12 @@ const pete = new Psyche(
   ),
   new OllamaChatter(new Ollama(), "gemma3"),
   {
-    onPrompt: async (prompt: string) => {
-      const payload = JSON.stringify({ type: "pete-prompt", text: prompt });
+    onPrompt: async (name: string, prompt: string) => {
+      const payload = JSON.stringify({
+        type: "pete-prompt",
+        name,
+        text: prompt,
+      });
       for (const ws of clients) {
         try {
           ws.send(payload);
@@ -48,8 +52,12 @@ const pete = new Psyche(
         }
       }
     },
-    onStream: async (chunk: string) => {
-      const payload = JSON.stringify({ type: "pete-stream", text: chunk });
+    onStream: async (name: string, chunk: string) => {
+      const payload = JSON.stringify({
+        type: "pete-stream",
+        name,
+        text: chunk,
+      });
       for (const ws of clients) {
         try {
           ws.send(payload);

--- a/pete/tests/on_prompt_test.ts
+++ b/pete/tests/on_prompt_test.ts
@@ -33,15 +33,15 @@ Deno.test("onPrompt receives prompt text", async () => {
   const follower = new StubFollower();
   const chatter = new StubChatter();
   const sensor = new DummySensor();
-  const prompts: string[] = [];
+  const prompts: { name: string; prompt: string }[] = [];
   const psyche = new Psyche([sensor], follower, chatter, {
-    onPrompt: async (p) => {
-      prompts.push(p);
+    onPrompt: async (name, p) => {
+      prompts.push({ name, prompt: p });
     },
   });
   sensor.feel("hi");
   await psyche.beat();
-  if (!prompts.some((p) => p.includes("hi"))) {
+  if (!prompts.some((p) => p.prompt.includes("hi") && p.name === "quick")) {
     throw new Error("prompt not forwarded");
   }
 });


### PR DESCRIPTION
## Summary
- propagate wit name through prompt & stream callbacks
- send wit name over websocket
- display prompt/stream tabs for each wit
- update onPrompt test to expect wit name
- document new behaviour in AGENTS instructions

## Testing
- `deno fmt lib/Wit.ts lib/Psyche.ts main.ts index.html pete/tests/on_prompt_test.ts`
- `deno fmt AGENTS.md`
- `deno test` *(fails: Import 'https://deno.land/std@0.224.0/fs/walk.ts' failed)*

------
https://chatgpt.com/codex/tasks/task_e_684e0165739c8320917a49e741a0c0be