### PR TITLE
Add random temperature to Ollama provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,3 +37,4 @@ be run with `deno run pete/main.ts`.
   tests accordingly.
 - Update Autologos sensor tests when output types change.
 - Skip `take_turn` when no websocket clients are connected.
+- Vary Ollama temperature between 0.7 and 1 on each request.

--- a/pete/tests/ollama_temperature_test.ts
+++ b/pete/tests/ollama_temperature_test.ts
@@ -1,0 +1,34 @@
+import { OllamaInstructionFollower, OllamaChatter } from "../../providers/ollama.ts";
+import { ChatMessage } from "../../lib/Chatter.ts";
+
+class StubOllama {
+  temps: number[] = [];
+  async *generate(options: { options?: { temperature?: number } }) {
+    this.temps.push(options.options?.temperature ?? -1);
+    yield { response: "" };
+  }
+  async *chat(options: { options?: { temperature?: number } }) {
+    this.temps.push(options.options?.temperature ?? -1);
+    yield { message: { content: "" } };
+  }
+}
+
+deno.test("instruction follower sets temperature between 0.7 and 1", async () => {
+  const client = new StubOllama();
+  const follower = new OllamaInstructionFollower(client as any, "model");
+  await follower.instruct("hi");
+  const t = client.temps[0];
+  if (t < 0.7 || t > 1) {
+    throw new Error(`temperature ${t}`);
+  }
+});
+
+deno.test("chatter sets temperature between 0.7 and 1", async () => {
+  const client = new StubOllama();
+  const chatter = new OllamaChatter(client as any, "model");
+  await chatter.chat([ { role: "user", content: "hi" } ] as ChatMessage[]);
+  const t = client.temps[0];
+  if (t < 0.7 || t > 1) {
+    throw new Error(`temperature ${t}`);
+  }
+});

--- a/providers/ollama.ts
+++ b/providers/ollama.ts
@@ -10,10 +10,12 @@ export class OllamaInstructionFollower extends InstructionFollower {
     prompt: string,
     onChunk?: (chunk: string) => Promise<void>,
   ): Promise<string> {
+    const temperature = 0.7 + Math.random() * 0.3;
     const stream = await this.client.generate({
       stream: true,
       model: this.model,
-      prompt: prompt,
+      prompt,
+      options: { temperature },
     });
     let response = "";
     for await (const chunk of stream) {
@@ -39,10 +41,12 @@ export class OllamaChatter extends Chatter {
     onChunk?: (chunk: string) => Promise<void>,
   ): Promise<string> {
     console.log(`Messages: ${JSON.stringify(messages)}`);
+    const temperature = 0.7 + Math.random() * 0.3;
     const stream = await this.client.chat({
       stream: true,
       model: this.model,
       messages,
+      options: { temperature },
     });
     let response = "";
     for await (const chunk of stream) {


### PR DESCRIPTION
## Summary
- vary Ollama temperature between 0.7 and 1 for each request
- test that the provider sets the temperature
- document temperature requirement in AGENTS.md

## Testing
- `deno test` *(fails: Import 'https://deno.land/std@0.224.0/fs/walk.ts' failed)*

------
https://chatgpt.com/codex/tasks/task_e_684e088e2dc88320bc4ceae271d3ffcc