### PR TITLE
Decouple speech loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,3 +38,5 @@ be run with `deno run pete/main.ts`.
 - Update Autologos sensor tests when output types change.
 - Skip `take_turn` when no websocket clients are connected.
 - Vary Ollama temperature between 0.7 and 1 on each request.
+- When adding a new environment variable, document it in `env.example` and update
+  related tests.

--- a/env.example
+++ b/env.example
@@ -3,6 +3,8 @@
 
 # LLM server
 OLLAMA_URL=http://localhost:11434
+# Separate host for conversation generation
+OLLAMA_CHATTER_URL=http://localhost:11435
 # Optional comma separated hosts for load balancing
 OLLAMA_URLS=http://localhost:11434
 # Default model for completions

--- a/main.ts
+++ b/main.ts
@@ -23,7 +23,10 @@ const pete = new Psyche(
     new Ollama({ host: Deno.env.get("OLLAMA_URL") }),
     "gemma3:27b",
   ),
-  new OllamaChatter(new Ollama({ host: Deno.env.get("OLLAMA_URL") }), "gemma3:27b"),
+  new OllamaChatter(
+    new Ollama({ host: Deno.env.get("OLLAMA_CHATTER_URL") ?? Deno.env.get("OLLAMA_URL") }),
+    "gemma3:27b",
+  ),
   {
     onPrompt: async (name: string, prompt: string) => {
       const payload = JSON.stringify({

--- a/pete/tests/websocket_turn_delay_test.ts
+++ b/pete/tests/websocket_turn_delay_test.ts
@@ -41,18 +41,19 @@ Deno.test("take_turn waits until a websocket client connects", async () => {
 
   dummy.feel("hi");
   await psyche.beat();
+  await psyche.speechBeat();
   if (chatter.calls !== 0) {
     throw new Error("took a turn without clients");
   }
 
   wsSensor.connected("ip");
-  await psyche.beat();
+  await psyche.speechBeat();
   if (chatter.calls !== 1) {
     throw new Error("did not take a turn after connection");
   }
 
   wsSensor.disconnected("ip");
-  await psyche.beat();
+  await psyche.speechBeat();
   if (chatter.calls !== 1) {
     throw new Error("took turn after all clients disconnected");
   }


### PR DESCRIPTION
## Summary
- run Pete's speech generation in its own loop
- use `OLLAMA_CHATTER_URL` for the chatter LLM
- document the new env var
- adjust websocket turn delay test
- remind to document env vars in `AGENTS.md`

## Testing
- `deno test` *(fails: Import 'https://deno.land/std@0.224.0/fs/walk.ts' failed)*

------
https://chatgpt.com/codex/tasks/task_e_684e1a6e7d3483209ed4b9291811e8ba