### PR TITLE
Trim echoed speech

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,3 +40,5 @@ be run with `deno run pete/main.ts`.
 - Vary Ollama temperature between 0.7 and 1 on each request.
 - When adding a new environment variable, document it in `env.example` and update
   related tests.
+- When confirming echoed speech, trim whitespace in both the echo and pending
+  speech so minor differences don't stall the loop.

--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@
                     this.ws.send(
                       JSON.stringify({
                         type: "echo",
-                        message: data.text,
+                        message: data.text.trim(),
                       }),
                     );
                     break;

--- a/lib/Psyche.ts
+++ b/lib/Psyche.ts
@@ -221,8 +221,10 @@ Output only the words Pete will say — no stage directions or annotations.`,
     }
 
     confirm_echo(message: string): void {
-        if (this.pendingSpeech && message === this.pendingSpeech) {
-            this.conversation.push({ role: "assistant", content: message });
+        const pending = this.pendingSpeech.trim();
+        const heard = message.trim();
+        if (pending && heard === pending) {
+            this.conversation.push({ role: "assistant", content: pending });
             this.pendingSpeech = "";
             this.speaking = false;
         }

--- a/pete/tests/confirm_echo_trim_test.ts
+++ b/pete/tests/confirm_echo_trim_test.ts
@@ -1,0 +1,41 @@
+import { Psyche } from "../../lib/Psyche.ts";
+import { InstructionFollower } from "../../lib/InstructionFollower.ts";
+import { Chatter, ChatMessage } from "../../lib/Chatter.ts";
+import { Sensor } from "../../lib/Sensor.ts";
+import { Experience } from "../../lib/Experience.ts";
+
+class StubFollower extends InstructionFollower {
+  async instruct(): Promise<string> {
+    return "instant";
+  }
+}
+
+class StubChatter extends Chatter {
+  async chat(_m: ChatMessage[]): Promise<string> {
+    return "reply";
+  }
+}
+
+class EmptySensor extends Sensor<null> {
+  feel(_: null): void {
+    const exp: Experience<null> = {
+      what: [{ when: new Date(), what: null }],
+      how: "",
+    };
+    this.subject.next(exp);
+  }
+}
+
+Deno.test("confirm_echo trims message", async () => {
+  const sensor = new EmptySensor();
+  const follower = new StubFollower();
+  const chatter = new StubChatter();
+  const psyche = new Psyche([sensor], follower, chatter);
+
+  await psyche.take_turn();
+  psyche.confirm_echo("reply\n");
+  const last = psyche.conversation.pop();
+  if (last?.content !== "reply" || last.role !== "assistant") {
+    throw new Error("echo not recognized with newline");
+  }
+});


### PR DESCRIPTION
## Summary
- trim whitespace when echoing Pete's speech from the UI
- allow `confirm_echo` to accept trimmed messages
- test echo trimming behaviour
- remind maintainers in `AGENTS.md` about trimming echoed speech

## Testing
- `deno test` *(fails: Import 'https://deno.land/std@0.224.0/fs/walk.ts' failed)*

------
https://chatgpt.com/codex/tasks/task_e_684e206ea5288320b2426631d148da77