### PR TITLE
Increase autologos snippet lines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,3 +40,5 @@ be run with `deno run pete/main.ts`.
 - Vary Ollama temperature between 0.7 and 1 on each request.
 - When adding a new environment variable, document it in `env.example` and update
   related tests.
+- Cache Deno dependencies with `deno cache --lock=deno.lock` when network access is restricted.
+- Autologos snippets should include about 10 lines so Pete can read his own code.

--- a/pete/tests/autologos_sensor_test.ts
+++ b/pete/tests/autologos_sensor_test.ts
@@ -16,6 +16,12 @@ Deno.test("codeSection returns snippet", async () => {
   sensor.stop();
   const section = await (sensor as any).codeSection();
   assert(section.includes("export"), "expected snippet with code");
+  const lines = section.split(/\r?\n/);
+  const expected = ((sensor as any).snippetLines as number) + 1;
+  assert(
+    lines.length >= expected,
+    `expected at least ${expected} lines but got ${lines.length}`,
+  );
 });
 
 Deno.test("stateInfo reports memory", () => {

--- a/sensors/autologos.ts
+++ b/sensors/autologos.ts
@@ -5,6 +5,7 @@ import { walk } from "https://deno.land/std/fs/walk.ts";
 /**
  * Autologos surfaces glimpses of its own code and runtime state.
  * It emits random messages roughly once every baseInterval milliseconds.
+ * Snippets include `snippetLines` number of lines from random source files.
  */
 export class Autologos extends Sensor<null> {
   private running = true;
@@ -13,6 +14,7 @@ export class Autologos extends Sensor<null> {
     private readonly baseInterval = 60_000,
     private readonly jitter = 10_000,
     private readonly root = ".",
+    private readonly snippetLines = 10,
   ) {
     super();
     this.schedule();
@@ -82,8 +84,11 @@ export class Autologos extends Sensor<null> {
     const file = files[Math.floor(Math.random() * files.length)];
     const text = await Deno.readTextFile(file);
     const lines = text.split(/\r?\n/);
-    const start = Math.max(0, Math.floor(Math.random() * lines.length - 3));
-    const snippet = lines.slice(start, start + 3).join("\n");
+    const start = Math.max(
+      0,
+      Math.floor(Math.random() * lines.length - this.snippetLines),
+    );
+    const snippet = lines.slice(start, start + this.snippetLines).join("\n");
     return `From ${file}:\n${snippet}`;
   }
 


### PR DESCRIPTION
## Summary
- expand Autologos snippet capture to 10 lines
- check snippet length in Autologos tests
- document dependency caching and snippet length guidance in AGENTS

## Testing
- `deno test` *(fails: unable to download https://deno.land/std@0.224.0/fs/walk.ts)*

------
https://chatgpt.com/codex/tasks/task_e_684e21cb553083208a3914a6ee6dcc68