### PR TITLE
Add chat history struct and rename traits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@ This repository is now a Rust workspace.
 
 - Install the stable Rust toolchain before running tests.
 - Run tests with `cargo test` from the repository root.
+- Format with `cargo fmt` when possible.
 - Crate `pete` depends on the local `psyche` crate.
 - Keep examples and inline docs up to date with code changes.
 - When adding binary arguments or library APIs, update tests accordingly.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,22 @@
 This repository contains a Rust workspace with two crates:
 
 - **psyche** – a library crate providing the `Psyche` type
+- **ling** – helper LLM abstractions exposed through the `psyche` crate
 - **pete** – a binary crate depending on `psyche`
+
+Example with the `OllamaProvider`:
+
+```rust,no_run
+use psyche::ling::OllamaProvider;
+use psyche::Psyche;
+
+let narrator = OllamaProvider::new("http://localhost:11434", "mistral").unwrap();
+let voice = OllamaProvider::new("http://localhost:11434", "mistral").unwrap();
+let vectorizer = OllamaProvider::new("http://localhost:11434", "mistral").unwrap();
+let psyche = Psyche::new(Box::new(narrator), Box::new(voice), Box::new(vectorizer));
+psyche.run();
+```
+
 
 Run tests with:
 

--- a/pete/Cargo.toml
+++ b/pete/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2024"
 
 [dependencies]
 psyche = { path = "../psyche" }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+anyhow = "1"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -1,6 +1,17 @@
 use psyche::Psyche;
+use psyche::ling::OllamaProvider;
+use std::process::Command;
 
-fn main() {
-    let psyche = Psyche::new();
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let _server = Command::new("ollama").arg("serve").spawn().ok();
+
+    let narrator = OllamaProvider::new("http://localhost:11434", "mistral")?;
+    let voice = OllamaProvider::new("http://localhost:11434", "mistral")?;
+    let vectorizer = OllamaProvider::new("http://localhost:11434", "mistral")?;
+
+    let psyche = Psyche::new(Box::new(narrator), Box::new(voice), Box::new(vectorizer));
     psyche.run();
+
+    Ok(())
 }

--- a/psyche/Cargo.toml
+++ b/psyche/Cargo.toml
@@ -4,3 +4,9 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+async-trait = "0.1"
+anyhow = "1"
+ollama-rs = "0.3"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -1,15 +1,24 @@
+pub mod ling;
 use std::thread;
+use ling::{Narrator, Voice, Vectorizer};
 
 /// The core AI engine.
 ///
 /// Currently provides only a skeleton structure for experimentation.
-#[derive(Debug, Default)]
-pub struct Psyche;
+pub struct Psyche {
+    narrator: Box<dyn Narrator>,
+    voice: Box<dyn Voice>,
+    vectorizer: Box<dyn Vectorizer>,
+}
 
 impl Psyche {
     /// Construct a new [`Psyche`].
-    pub fn new() -> Self {
-        Self
+    pub fn new(
+        narrator: Box<dyn Narrator>,
+        voice: Box<dyn Voice>,
+        vectorizer: Box<dyn Vectorizer>,
+    ) -> Self {
+        Self { narrator, voice, vectorizer }
     }
 
     /// Spawn the conversation and experience threads and wait for them to finish.
@@ -34,10 +43,34 @@ impl Psyche {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use async_trait::async_trait;
+
+    struct Dummy;
+
+    #[async_trait]
+    impl Narrator for Dummy {
+        async fn follow(&self, _: &str) -> anyhow::Result<String> {
+            Ok("ok".into())
+        }
+    }
+
+    #[async_trait]
+    impl Voice for Dummy {
+        async fn chat(&self, _: &str, _: &[ling::Message]) -> anyhow::Result<String> {
+            Ok("ok".into())
+        }
+    }
+
+    #[async_trait]
+    impl Vectorizer for Dummy {
+        async fn vectorize(&self, _: &str) -> anyhow::Result<Vec<f32>> {
+            Ok(vec![1.0])
+        }
+    }
 
     #[test]
     fn psyche_runs() {
-        let psyche = Psyche::new();
+        let psyche = Psyche::new(Box::new(Dummy), Box::new(Dummy), Box::new(Dummy));
         psyche.run();
     }
 }

--- a/psyche/src/ling.rs
+++ b/psyche/src/ling.rs
@@ -1,0 +1,154 @@
+//! Language-related helpers and abstractions.
+//!
+//! This module defines traits for interacting with language models and provides
+//! an `OllamaProvider` implementation using the [`ollama-rs`] crate.
+//!
+//! ```no_run
+//! use psyche::ling::{OllamaProvider, Narrator, Voice, Vectorizer};
+//! use psyche::Psyche;
+//!
+//! # async fn try_it() -> anyhow::Result<()> {
+//! let narrator = OllamaProvider::new("http://localhost:11434", "mistral")?;
+//! let voice = OllamaProvider::new("http://localhost:11434", "mistral")?;
+//! let vectorizer = OllamaProvider::new("http://localhost:11434", "mistral")?;
+//! let psyche = Psyche::new(Box::new(narrator), Box::new(voice), Box::new(vectorizer));
+//! psyche.run();
+//! # Ok(()) }
+//! ```
+use async_trait::async_trait;
+use anyhow::Result;
+use ollama_rs::{Ollama, generation::chat::{ChatMessage, request::ChatMessageRequest}, generation::embeddings::{request::{GenerateEmbeddingsRequest, EmbeddingsInput}}};
+
+/// Processes instructions and returns textual responses.
+#[async_trait]
+pub trait Narrator: Send + Sync {
+    async fn follow(&self, instruction: &str) -> Result<String>;
+}
+
+/// Exchanges conversational messages.
+#[derive(Clone, Debug)]
+pub enum Role {
+    Assistant,
+    User,
+}
+
+/// Message in a chat exchange.
+#[derive(Clone, Debug)]
+pub struct Message {
+    pub role: Role,
+    pub content: String,
+}
+
+impl Message {
+    /// Create a new user message.
+    pub fn user(content: impl Into<String>) -> Self {
+        Self { role: Role::User, content: content.into() }
+    }
+
+    /// Create a new assistant message.
+    pub fn assistant(content: impl Into<String>) -> Self {
+        Self { role: Role::Assistant, content: content.into() }
+    }
+}
+
+#[async_trait]
+pub trait Voice: Send + Sync {
+    async fn chat(&self, system_prompt: &str, history: &[Message]) -> Result<String>;
+}
+
+/// Produces vector representations of text.
+#[async_trait]
+pub trait Vectorizer: Send + Sync {
+    async fn vectorize(&self, text: &str) -> Result<Vec<f32>>;
+}
+
+/// Provider backed by an Ollama server.
+#[derive(Clone)]
+pub struct OllamaProvider {
+    client: Ollama,
+    model: String,
+}
+
+impl OllamaProvider {
+    /// Create a new provider for `model` hosted at `host`.
+    pub fn new(host: impl AsRef<str>, model: impl Into<String>) -> Result<Self> {
+        let client = Ollama::try_new(host.as_ref())?;
+        Ok(Self { client, model: model.into() })
+    }
+}
+
+#[async_trait]
+impl Narrator for OllamaProvider {
+    async fn follow(&self, instruction: &str) -> Result<String> {
+        let req = ChatMessageRequest::new(
+            self.model.clone(),
+            vec![ChatMessage::user(instruction.to_string())],
+        );
+        let res = self.client.send_chat_messages(req).await?;
+        Ok(res.message.content)
+    }
+}
+
+#[async_trait]
+impl Voice for OllamaProvider {
+    async fn chat(&self, system_prompt: &str, history: &[Message]) -> Result<String> {
+        let mut msgs = Vec::with_capacity(history.len() + 1);
+        msgs.push(ChatMessage::system(system_prompt.to_string()));
+        for m in history {
+            let converted = match m.role {
+                Role::Assistant => ChatMessage::assistant(m.content.clone()),
+                Role::User => ChatMessage::user(m.content.clone()),
+            };
+            msgs.push(converted);
+        }
+        let req = ChatMessageRequest::new(self.model.clone(), msgs);
+        let res = self.client.send_chat_messages(req).await?;
+        Ok(res.message.content)
+    }
+}
+
+#[async_trait]
+impl Vectorizer for OllamaProvider {
+    async fn vectorize(&self, text: &str) -> Result<Vec<f32>> {
+        let req = GenerateEmbeddingsRequest::new(self.model.clone(), EmbeddingsInput::from(text));
+        let res = self.client.generate_embeddings(req).await?;
+        Ok(res.embeddings.into_iter().next().unwrap_or_default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Dummy;
+
+    #[async_trait]
+    impl Narrator for Dummy {
+        async fn follow(&self, i: &str) -> Result<String> {
+            Ok(format!("f:{i}"))
+        }
+    }
+
+    #[async_trait]
+    impl Voice for Dummy {
+        async fn chat(&self, _s: &str, h: &[Message]) -> Result<String> {
+            Ok(format!("c:{}", h.len()))
+        }
+    }
+
+    #[async_trait]
+    impl Vectorizer for Dummy {
+        async fn vectorize(&self, t: &str) -> Result<Vec<f32>> {
+            Ok(vec![t.len() as f32])
+        }
+    }
+
+    #[tokio::test]
+    async fn traits_work() {
+        let d = Dummy;
+        assert_eq!(d.follow("x").await.unwrap(), "f:x");
+        let hist = vec![Message::user("hi"), Message::assistant("hey")];
+        assert_eq!(d.chat("sys", &hist).await.unwrap(), "c:2");
+        assert_eq!(d.vectorize("ab").await.unwrap(), vec![2.0]);
+    }
+}

--- a/psyche/tests/ling.rs
+++ b/psyche/tests/ling.rs
@@ -1,0 +1,34 @@
+use psyche::ling::{Narrator, Voice, Vectorizer, Message};
+use async_trait::async_trait;
+
+struct Dummy;
+
+#[async_trait]
+impl Narrator for Dummy {
+    async fn follow(&self, i: &str) -> anyhow::Result<String> {
+        Ok(format!("do:{i}"))
+    }
+}
+
+#[async_trait]
+impl Voice for Dummy {
+    async fn chat(&self, _s: &str, h: &[Message]) -> anyhow::Result<String> {
+        Ok(format!("say:{}", h.len()))
+    }
+}
+
+#[async_trait]
+impl Vectorizer for Dummy {
+    async fn vectorize(&self, t: &str) -> anyhow::Result<Vec<f32>> {
+        Ok(vec![t.len() as f32])
+    }
+}
+
+#[tokio::test]
+async fn dummy_traits() {
+    let d = Dummy;
+    assert_eq!(d.follow("a").await.unwrap(), "do:a");
+    let hist = vec![Message::user("hi"), Message::assistant("hey")];
+    assert_eq!(d.chat("sys", &hist).await.unwrap(), "say:2");
+    assert_eq!(d.vectorize("xyz").await.unwrap(), vec![3.0]);
+}


### PR DESCRIPTION
## Summary
- rename `InstructionFollower` to `Narrator` and `Chatter` to `Voice`
- introduce `Message` and `Role` for chat history
- update `OllamaProvider` and Psyche to use the new traits
- adjust tests, examples and binary to use `narrator` and `voice`

## Testing
- `cargo test`



------
https://chatgpt.com/codex/tasks/task_e_684e57274e10832096cb04f45ce22818