### PR TITLE
Run Psyche tasks using multi-thread runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@ This repository is now a Rust workspace.
 - Install the stable Rust toolchain before running tests.
 - Run tests with `cargo test` from the repository root.
 - Format with `cargo fmt` when possible.
+- Ensure the `rustfmt` component is installed so formatting can run offline.
 - Crate `pete` depends on the local `psyche` crate.
 - Keep examples and inline docs up to date with code changes.
 - When adding binary arguments or library APIs, update tests accordingly.

--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -2,7 +2,7 @@ use psyche::{Psyche, PsycheEvent, PsycheInput};
 use psyche::ling::{Chatter, InstructionFollower, Message, Vectorizer};
 use async_trait::async_trait;
 
-#[tokio::main]
+#[tokio::main(flavor = "multi_thread")]
 async fn main() -> anyhow::Result<()> {
     #[derive(Clone)]
     struct Dummy;

--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -113,8 +113,8 @@ impl Psyche {
         &self.conversation
     }
 
-    /// Run the conversation loop and return the updated [`Psyche`].
-    pub async fn run(mut self) -> Self {
+    /// Main loop that handles the conversation with the assistant.
+    async fn converse(mut self) -> Self {
         let mut turns = 0;
         while self.still_conversing(turns) {
             let history = self.conversation.tail(self.max_history);
@@ -143,6 +143,23 @@ impl Psyche {
             turns += 1;
         }
         self
+    }
+
+    /// Background task processing non-conversational experience.
+    async fn experience() {
+        // Placeholder for future sensory processing.
+        tokio::task::yield_now().await;
+    }
+
+    /// Run `converse` and `experience` concurrently and return the updated [`Psyche`].
+    pub async fn run(self) -> Self {
+        let converse_handle = tokio::spawn(self.converse());
+        let experience_handle = tokio::spawn(Self::experience());
+        let psyche = converse_handle.await.expect("converse task panicked");
+        experience_handle
+            .await
+            .expect("experience task panicked");
+        psyche
     }
 }
 


### PR DESCRIPTION
## Summary
- run `converse` and `experience` concurrently via `tokio::spawn`
- switch binary to `#[tokio::main(flavor = "multi_thread")]`
- document need for `rustfmt` component

## Testing
- `cargo test`
- `cargo fmt` *(fails: component missing)*

------
https://chatgpt.com/codex/tasks/task_e_684ee8f2f97483208d75f8f9288ff74b