### PR TITLE
Rename types to Sensation, Event, Doer

### DIFF
--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -1,6 +1,6 @@
-use psyche::{Psyche, PsycheEvent, PsycheInput};
-use psyche::ling::{Chatter, InstructionFollower, Message, Vectorizer};
 use async_trait::async_trait;
+use psyche::ling::{Chatter, Doer, Message, Vectorizer};
+use psyche::{Event, Psyche, Sensation};
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> anyhow::Result<()> {
@@ -8,18 +8,24 @@ async fn main() -> anyhow::Result<()> {
     struct Dummy;
 
     #[async_trait]
-    impl InstructionFollower for Dummy {
-        async fn follow(&self, _: &str) -> anyhow::Result<String> { Ok("ok".into()) }
+    impl Doer for Dummy {
+        async fn follow(&self, _: &str) -> anyhow::Result<String> {
+            Ok("ok".into())
+        }
     }
 
     #[async_trait]
     impl Chatter for Dummy {
-        async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<String> { Ok("hi".into()) }
+        async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<String> {
+            Ok("hi".into())
+        }
     }
 
     #[async_trait]
     impl Vectorizer for Dummy {
-        async fn vectorize(&self, _: &str) -> anyhow::Result<Vec<f32>> { Ok(vec![0.0]) }
+        async fn vectorize(&self, _: &str) -> anyhow::Result<Vec<f32>> {
+            Ok(vec![0.0])
+        }
     }
 
     let narrator = Dummy;
@@ -33,10 +39,10 @@ async fn main() -> anyhow::Result<()> {
 
     while let Ok(evt) = events.recv().await {
         match evt {
-            PsycheEvent::StreamChunk(chunk) => print!("{chunk} "),
-            PsycheEvent::IntentionToSay(msg) => {
+            Event::StreamChunk(chunk) => print!("{chunk} "),
+            Event::IntentionToSay(msg) => {
                 println!();
-                input.send(PsycheInput::HeardOwnVoice(msg)).ok();
+                input.send(Sensation::HeardOwnVoice(msg)).ok();
                 break;
             }
         }

--- a/psyche/src/ling.rs
+++ b/psyche/src/ling.rs
@@ -4,7 +4,7 @@
 //! an `OllamaProvider` implementation using the [`ollama-rs`] crate.
 //!
 //! ```no_run
-//! use psyche::ling::{OllamaProvider, InstructionFollower, Chatter, Vectorizer};
+//! use psyche::ling::{OllamaProvider, Doer, Chatter, Vectorizer};
 //! use psyche::Psyche;
 //!
 //! # async fn try_it() -> anyhow::Result<()> {
@@ -25,7 +25,7 @@ use ollama_rs::{
 
 /// Processes instructions and returns textual responses.
 #[async_trait]
-pub trait InstructionFollower: Send + Sync {
+pub trait Doer: Send + Sync {
     async fn follow(&self, instruction: &str) -> Result<String>;
 }
 
@@ -91,7 +91,7 @@ impl OllamaProvider {
 }
 
 #[async_trait]
-impl InstructionFollower for OllamaProvider {
+impl Doer for OllamaProvider {
     async fn follow(&self, instruction: &str) -> Result<String> {
         let req = ChatMessageRequest::new(
             self.model.clone(),
@@ -136,7 +136,7 @@ mod tests {
     struct Dummy;
 
     #[async_trait]
-    impl InstructionFollower for Dummy {
+    impl Doer for Dummy {
         async fn follow(&self, i: &str) -> Result<String> {
             Ok(format!("f:{i}"))
         }

--- a/psyche/tests/converse.rs
+++ b/psyche/tests/converse.rs
@@ -1,22 +1,28 @@
 use async_trait::async_trait;
-use psyche::{Psyche, PsycheEvent, PsycheInput};
-use psyche::ling::{Chatter, InstructionFollower, Message, Vectorizer};
+use psyche::ling::{Chatter, Doer, Message, Vectorizer};
+use psyche::{Event, Psyche, Sensation};
 
 struct Dummy;
 
 #[async_trait]
-impl InstructionFollower for Dummy {
-    async fn follow(&self, _: &str) -> anyhow::Result<String> { Ok("ok".into()) }
+impl Doer for Dummy {
+    async fn follow(&self, _: &str) -> anyhow::Result<String> {
+        Ok("ok".into())
+    }
 }
 
 #[async_trait]
 impl Chatter for Dummy {
-    async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<String> { Ok("hello world".into()) }
+    async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<String> {
+        Ok("hello world".into())
+    }
 }
 
 #[async_trait]
 impl Vectorizer for Dummy {
-    async fn vectorize(&self, _: &str) -> anyhow::Result<Vec<f32>> { Ok(vec![0.0]) }
+    async fn vectorize(&self, _: &str) -> anyhow::Result<Vec<f32>> {
+        Ok(vec![0.0])
+    }
 }
 
 #[tokio::test]
@@ -33,9 +39,9 @@ async fn adds_message_after_voice_heard() {
     let mut saw_chunk = false;
     while let Ok(evt) = events.recv().await {
         match evt {
-            PsycheEvent::StreamChunk(_) => saw_chunk = true,
-            PsycheEvent::IntentionToSay(msg) => {
-                input.send(PsycheInput::HeardOwnVoice(msg)).unwrap();
+            Event::StreamChunk(_) => saw_chunk = true,
+            Event::IntentionToSay(msg) => {
+                input.send(Sensation::HeardOwnVoice(msg)).unwrap();
                 break;
             }
         }

--- a/psyche/tests/ling.rs
+++ b/psyche/tests/ling.rs
@@ -1,10 +1,10 @@
 use async_trait::async_trait;
-use psyche::ling::{Chatter, InstructionFollower, Message, Vectorizer};
+use psyche::ling::{Chatter, Doer, Message, Vectorizer};
 
 struct Dummy;
 
 #[async_trait]
-impl InstructionFollower for Dummy {
+impl Doer for Dummy {
     async fn follow(&self, i: &str) -> anyhow::Result<String> {
         Ok(format!("do:{i}"))
     }


### PR DESCRIPTION
## Summary
- rename `PsycheInput` -> `Sensation`
- rename `PsycheEvent` -> `Event`
- rename `InstructionFollower` -> `Doer`
- update references across examples, tests and binary

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684eee9c227c8320ba43b1b5d69aeca4