### PR TITLE
Add Axum web server

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ Run tests with:
 cargo test
 ```
 
-Run the program with:
+Run the web server with:
 
 ```sh
 cargo run -p pete
 ```
+Then send chat messages by POSTing JSON `{ "message": "hi" }` to `http://127.0.0.1:3000/chat`.

--- a/pete/Cargo.toml
+++ b/pete/Cargo.toml
@@ -8,6 +8,11 @@ psyche = { path = "../psyche" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 anyhow = "1"
 async-trait = "0.1"
+axum = { version = "0.8", features = ["macros", "json", "tokio"] }
+tokio-stream = { version = "0.1", features = ["sync"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+clap = { version = "4", features = ["derive"] }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -1,9 +1,56 @@
 use async_trait::async_trait;
+use axum::{
+    Json, Router,
+    extract::State,
+    response::sse::{Event as SseEvent, Sse},
+    routing::post,
+};
+use clap::Parser;
 use psyche::ling::{Chatter, Doer, Message, Vectorizer};
 use psyche::{Event, Psyche, Sensation};
+use serde::Deserialize;
+use std::{convert::Infallible, net::SocketAddr, sync::Arc};
+use tokio::sync::{broadcast, mpsc};
+use tokio_stream::{Stream, StreamExt, wrappers::BroadcastStream};
+
+#[derive(Parser)]
+#[command(author, version, about)]
+struct Cli {
+    /// Address to bind the HTTP server
+    #[arg(long, default_value = "127.0.0.1:3000")]
+    addr: String,
+}
+
+#[derive(Clone)]
+struct AppState {
+    input: mpsc::UnboundedSender<Sensation>,
+    events: Arc<broadcast::Receiver<Event>>,
+}
+
+#[derive(Deserialize)]
+struct ChatRequest {
+    message: String,
+}
+
+async fn chat(
+    State(state): State<AppState>,
+    Json(payload): Json<ChatRequest>,
+) -> Sse<impl Stream<Item = Result<SseEvent, Infallible>>> {
+    let _ = state.input.send(Sensation::HeardUserVoice(payload.message));
+
+    let rx = state.events.resubscribe();
+    let stream = BroadcastStream::new(rx).filter_map(|res| match res {
+        Ok(Event::StreamChunk(chunk)) => Some(Ok(SseEvent::default().data(chunk))),
+        _ => None,
+    });
+
+    Sse::new(stream)
+}
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+
     #[derive(Clone)]
     struct Dummy;
 
@@ -33,22 +80,22 @@ async fn main() -> anyhow::Result<()> {
     let vectorizer = Dummy;
 
     let mut psyche = Psyche::new(Box::new(narrator), Box::new(voice), Box::new(vectorizer));
-    let mut events = psyche.subscribe();
     let input = psyche.input_sender();
-    let handle = tokio::spawn(async move { psyche.run().await });
+    let events = Arc::new(psyche.subscribe());
 
-    while let Ok(evt) = events.recv().await {
-        match evt {
-            Event::StreamChunk(chunk) => print!("{chunk} "),
-            Event::IntentionToSay(msg) => {
-                println!();
-                input.send(Sensation::HeardOwnVoice(msg)).ok();
-                break;
-            }
-        }
-    }
+    tokio::spawn(async move {
+        psyche.run().await;
+    });
 
-    handle.await?;
+    let state = AppState {
+        input,
+        events: events.clone(),
+    };
+    let app = Router::new().route("/chat", post(chat)).with_state(state);
 
+    let addr: SocketAddr = cli.addr.parse()?;
+    println!("Listening on http://{addr}");
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    axum::serve(listener, app.into_make_service()).await?;
     Ok(())
 }

--- a/pete/tests/smoke.rs
+++ b/pete/tests/smoke.rs
@@ -3,5 +3,5 @@ use assert_cmd::Command;
 #[test]
 fn binary_runs() {
     let mut cmd = Command::cargo_bin("pete").unwrap();
-    cmd.assert().success();
+    cmd.arg("--help").assert().success();
 }


### PR DESCRIPTION
## Summary
- add web dependencies and Clap to pete
- implement Axum server with `/chat` streaming SSE
- adjust smoke test to call `--help`
- document how to use the web server

## Testing
- `cargo test --all --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684eefe20f2883208f1923016c752863