### PR TITLE
Serve index.html from pete

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,3 +11,4 @@ This repository is now a Rust workspace.
 - When adding binary arguments or library APIs, update tests accordingly.
 - Keep `index.html` minimal and updated to connect to `ws://localhost:3000/ws`.
 - Run `cargo fetch` before testing to warm the cache.
+- When embedding `index.html` in the `pete` crate, use `include_str!("../../index.html")`.

--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ Then send chat messages by POSTing JSON `{ "message": "hi" }` to `http://127.0.0
 
 ## Web Interface
 
-Open `index.html` in your browser after running the server. The page connects to `ws://localhost:3000/ws` and lets you chat with Pete in real time.
+After starting the server, visit `http://127.0.0.1:3000/` in your browser. The page connects to `ws://localhost:3000/ws` and lets you chat with Pete in real time.

--- a/pete/src/lib.rs
+++ b/pete/src/lib.rs
@@ -1,0 +1,84 @@
+use async_trait::async_trait;
+use axum::{
+    Json, Router,
+    extract::State,
+    response::{
+        Html,
+        sse::{Event as SseEvent, Sse},
+    },
+    routing::{get, post},
+};
+use psyche::ling::{Chatter, Doer, Message, Vectorizer};
+use psyche::{Event, Psyche, Sensation};
+use std::{convert::Infallible, sync::Arc};
+use tokio::sync::{broadcast, mpsc};
+use tokio_stream::{Stream, StreamExt, wrappers::BroadcastStream};
+
+#[derive(Clone)]
+pub struct AppState {
+    pub input: mpsc::UnboundedSender<Sensation>,
+    pub events: Arc<broadcast::Receiver<Event>>,
+}
+
+#[derive(serde::Deserialize)]
+struct ChatRequest {
+    message: String,
+}
+
+/// Serve the embedded `index.html`.
+pub async fn index() -> Html<&'static str> {
+    static INDEX: &str = include_str!("../../index.html");
+    Html(INDEX)
+}
+
+pub async fn chat(
+    State(state): State<AppState>,
+    Json(payload): Json<ChatRequest>,
+) -> Sse<impl Stream<Item = Result<SseEvent, Infallible>>> {
+    let _ = state.input.send(Sensation::HeardUserVoice(payload.message));
+
+    let rx = state.events.resubscribe();
+    let stream = BroadcastStream::new(rx).filter_map(|res| match res {
+        Ok(Event::StreamChunk(chunk)) => Some(Ok(SseEvent::default().data(chunk))),
+        _ => None,
+    });
+
+    Sse::new(stream)
+}
+
+/// Build the application router with the provided state.
+pub fn app(state: AppState) -> Router {
+    Router::new()
+        .route("/", get(index))
+        .route("/chat", post(chat))
+        .with_state(state)
+}
+
+/// Create a psyche with dummy providers for demos/tests.
+pub fn dummy_psyche() -> Psyche {
+    #[derive(Clone)]
+    struct Dummy;
+
+    #[async_trait]
+    impl Doer for Dummy {
+        async fn follow(&self, _: &str) -> anyhow::Result<String> {
+            Ok("ok".into())
+        }
+    }
+
+    #[async_trait]
+    impl Chatter for Dummy {
+        async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<String> {
+            Ok("hi".into())
+        }
+    }
+
+    #[async_trait]
+    impl Vectorizer for Dummy {
+        async fn vectorize(&self, _: &str) -> anyhow::Result<Vec<f32>> {
+            Ok(vec![0.0])
+        }
+    }
+
+    Psyche::new(Box::new(Dummy), Box::new(Dummy), Box::new(Dummy))
+}

--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -1,17 +1,6 @@
-use async_trait::async_trait;
-use axum::{
-    Json, Router,
-    extract::State,
-    response::sse::{Event as SseEvent, Sse},
-    routing::post,
-};
 use clap::Parser;
-use psyche::ling::{Chatter, Doer, Message, Vectorizer};
-use psyche::{Event, Psyche, Sensation};
-use serde::Deserialize;
-use std::{convert::Infallible, net::SocketAddr, sync::Arc};
-use tokio::sync::{broadcast, mpsc};
-use tokio_stream::{Stream, StreamExt, wrappers::BroadcastStream};
+use pete::{AppState, app, dummy_psyche};
+use std::{net::SocketAddr, sync::Arc};
 
 #[derive(Parser)]
 #[command(author, version, about)]
@@ -21,65 +10,11 @@ struct Cli {
     addr: String,
 }
 
-#[derive(Clone)]
-struct AppState {
-    input: mpsc::UnboundedSender<Sensation>,
-    events: Arc<broadcast::Receiver<Event>>,
-}
-
-#[derive(Deserialize)]
-struct ChatRequest {
-    message: String,
-}
-
-async fn chat(
-    State(state): State<AppState>,
-    Json(payload): Json<ChatRequest>,
-) -> Sse<impl Stream<Item = Result<SseEvent, Infallible>>> {
-    let _ = state.input.send(Sensation::HeardUserVoice(payload.message));
-
-    let rx = state.events.resubscribe();
-    let stream = BroadcastStream::new(rx).filter_map(|res| match res {
-        Ok(Event::StreamChunk(chunk)) => Some(Ok(SseEvent::default().data(chunk))),
-        _ => None,
-    });
-
-    Sse::new(stream)
-}
-
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
-    #[derive(Clone)]
-    struct Dummy;
-
-    #[async_trait]
-    impl Doer for Dummy {
-        async fn follow(&self, _: &str) -> anyhow::Result<String> {
-            Ok("ok".into())
-        }
-    }
-
-    #[async_trait]
-    impl Chatter for Dummy {
-        async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<String> {
-            Ok("hi".into())
-        }
-    }
-
-    #[async_trait]
-    impl Vectorizer for Dummy {
-        async fn vectorize(&self, _: &str) -> anyhow::Result<Vec<f32>> {
-            Ok(vec![0.0])
-        }
-    }
-
-    let narrator = Dummy;
-    let voice = Dummy;
-    let vectorizer = Dummy;
-
-    let mut psyche = Psyche::new(Box::new(narrator), Box::new(voice), Box::new(vectorizer));
+    let mut psyche = dummy_psyche();
     let input = psyche.input_sender();
     let events = Arc::new(psyche.subscribe());
 
@@ -91,7 +26,7 @@ async fn main() -> anyhow::Result<()> {
         input,
         events: events.clone(),
     };
-    let app = Router::new().route("/chat", post(chat)).with_state(state);
+    let app = app(state);
 
     let addr: SocketAddr = cli.addr.parse()?;
     println!("Listening on http://{addr}");

--- a/pete/tests/index.rs
+++ b/pete/tests/index.rs
@@ -1,0 +1,7 @@
+use pete::index;
+
+#[tokio::test]
+async fn serves_index_html() {
+    let resp = index().await;
+    assert!(resp.0.contains("Chat with Pete"));
+}


### PR DESCRIPTION
## Summary
- expose router in a new `pete` library
- serve the workspace `index.html` at `/`
- test that the new handler returns the page
- document how to reach the page
- note how to embed `index.html` in AGENTS instructions

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684ef46dc9648320b87acfb0ccdb6e57