### PR TITLE
Implement websocket handler for Pete

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,3 +12,4 @@ This repository is now a Rust workspace.
 - Keep `index.html` minimal and updated to connect to `ws://localhost:3000/ws`.
 - Run `cargo fetch` before testing to warm the cache.
 - When embedding `index.html` in the `pete` crate, use `include_str!("../../index.html")`.
+- Expose WebSocket chat at `/ws` that forwards psyche events.

--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ Run the web server with:
 ```sh
 cargo run -p pete
 ```
-Then send chat messages by POSTing JSON `{ "message": "hi" }` to `http://127.0.0.1:3000/chat`.
+You can POST JSON `{ "message": "hi" }` to `http://127.0.0.1:3000/chat` and receive an SSE stream in response.
 
 ## Web Interface
 
 After starting the server, visit `http://127.0.0.1:3000/` in your browser. The page connects to `ws://localhost:3000/ws` and lets you chat with Pete in real time.
+The same events are also available via server-sent events at `POST /chat`.

--- a/pete/Cargo.toml
+++ b/pete/Cargo.toml
@@ -8,7 +8,7 @@ psyche = { path = "../psyche" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 anyhow = "1"
 async-trait = "0.1"
-axum = { version = "0.8", features = ["macros", "json", "tokio"] }
+axum = { version = "0.8", features = ["macros", "json", "tokio", "ws"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
## Summary
- add websocket instructions to AGENTS
- describe SSE endpoint in README
- enable `ws` feature in pete and implement websocket route
- connect websocket events to `Psyche`

## Testing
- `cargo fmt`
- `cargo fetch`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684ef61330a08320ad34625032c823d0