### PR TITLE
Implement user input listener

### DIFF
--- a/pete/tests/input_listener.rs
+++ b/pete/tests/input_listener.rs
@@ -1,0 +1,18 @@
+use pete::{dummy_psyche, listen_user_input};
+use tokio::sync::mpsc;
+
+#[tokio::test]
+async fn records_user_input() {
+    let mut psyche = dummy_psyche();
+    let input = psyche.input_sender();
+    let conv = psyche.conversation();
+    let (tx, rx) = mpsc::unbounded_channel();
+
+    tokio::spawn(listen_user_input(rx, input, conv.clone()));
+
+    tx.send("hello".to_string()).unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+    let log_len = { conv.lock().await.all().len() };
+    assert_eq!(log_len, 1);
+}

--- a/psyche/tests/converse.rs
+++ b/psyche/tests/converse.rs
@@ -49,5 +49,7 @@ async fn adds_message_after_voice_heard() {
 
     let psyche = handle.await.unwrap();
     assert!(saw_chunk);
-    assert_eq!(psyche.conversation().all().len(), 1);
+    let conv = psyche.conversation();
+    let log_len = { conv.lock().await.all().len() };
+    assert_eq!(log_len, 1);
 }


### PR DESCRIPTION
## Summary
- expose `Conversation::add_user` so other crates can log user input
- share `Conversation` via `Arc<Mutex<_>>` and listen for incoming messages
- update `pete` to spawn an input listener and handle new user input
- add example and unit test for the listener

## Testing
- `cargo fmt`
- `cargo fetch`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684f21e40d9c83208a746d69ad912160