### PR TITLE
Add Mouth and Ear traits

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
           const data = JSON.parse(event.data);
           if (data.type === 'pete-says') {
             this.log.push(`Pete: ${data.text}`);
+            this.ws.send(JSON.stringify({ type: 'displayed', text: data.text }));
           } else if (data.type === 'pete-feels') {
             this.feeling = data.text;
           }
@@ -47,7 +48,7 @@
       },
       send() {
         if (!this.input) return;
-        const payload = { name: this.name, message: this.input };
+        const payload = { type: 'user', name: this.name, message: this.input };
         this.ws.send(JSON.stringify(payload));
         this.log.push(`${this.name || 'User'}: ${this.input}`);
         this.input = '';

--- a/pete/src/lib.rs
+++ b/pete/src/lib.rs
@@ -9,22 +9,28 @@ use axum::{
     routing::get,
 };
 use psyche::ling::{Chatter, Doer, Message, Vectorizer};
-use psyche::{Event, Psyche, Sensation};
+use psyche::{Ear, Event, Mouth, Psyche, Sensation};
 use std::sync::Arc;
 use tokio::sync::{Mutex, broadcast, mpsc};
 
 #[derive(Clone)]
 pub struct AppState {
-    pub input: mpsc::UnboundedSender<Sensation>,
     pub user_input: mpsc::UnboundedSender<String>,
     pub events: Arc<broadcast::Receiver<Event>>,
+    pub ear: Arc<dyn Ear>,
 }
 
 #[derive(serde::Deserialize)]
-pub struct WsRequest {
-    message: String,
-    #[allow(dead_code)]
-    name: Option<String>,
+#[serde(tag = "type", rename_all = "kebab-case")]
+pub enum WsRequest {
+    /// A message from the user.
+    User {
+        message: String,
+        #[allow(dead_code)]
+        name: Option<String>,
+    },
+    /// Confirmation that a line was displayed to the user.
+    Displayed { text: String },
 }
 
 #[derive(serde::Serialize)]
@@ -32,6 +38,70 @@ struct WsResponse<'a> {
     #[serde(rename = "type")]
     kind: &'a str,
     text: String,
+}
+
+#[derive(Clone)]
+pub struct ChannelEar {
+    forward: mpsc::UnboundedSender<Sensation>,
+    conversation: Arc<Mutex<psyche::Conversation>>, // share log from psyche
+}
+
+impl ChannelEar {
+    pub fn new(
+        forward: mpsc::UnboundedSender<Sensation>,
+        conversation: Arc<Mutex<psyche::Conversation>>,
+    ) -> Self {
+        Self {
+            forward,
+            conversation,
+        }
+    }
+}
+
+#[async_trait]
+impl Ear for ChannelEar {
+    async fn hear_self_say(&self, text: &str) {
+        let _ = self
+            .forward
+            .send(Sensation::HeardOwnVoice(text.to_string()));
+    }
+
+    async fn hear_user_say(&self, text: &str) {
+        let _ = self
+            .forward
+            .send(Sensation::HeardUserVoice(text.to_string()));
+        let mut conv = self.conversation.lock().await;
+        conv.add_user(text.to_string());
+    }
+}
+
+#[derive(Clone)]
+pub struct ChannelMouth {
+    events: broadcast::Sender<Event>,
+}
+
+#[async_trait]
+impl Mouth for ChannelMouth {
+    async fn speak(&self, text: &str) {
+        let _ = self.events.send(Event::IntentionToSay(text.to_string()));
+    }
+}
+
+#[derive(Clone)]
+pub struct NoopMouth;
+
+#[async_trait]
+impl Mouth for NoopMouth {
+    async fn speak(&self, _text: &str) {}
+}
+
+#[derive(Clone)]
+pub struct NoopEar;
+
+#[async_trait]
+impl Ear for NoopEar {
+    async fn hear_self_say(&self, _text: &str) {}
+    async fn hear_user_say(&self, _text: &str) {}
 }
 
 /// Serve the embedded `index.html`.
@@ -55,8 +125,7 @@ async fn handle_socket(mut socket: WebSocket, state: AppState) {
                         if socket.send(WsMessage::Text(payload.into())).await.is_err() { break; }
                     }
                     Ok(Event::IntentionToSay(text)) => {
-                        let _ = state.input.send(Sensation::HeardOwnVoice(text.clone()));
-                        let payload = serde_json::to_string(&WsResponse { kind: "pete-says", text }).unwrap();
+                        let payload = serde_json::to_string(&WsResponse { kind: "pete-says", text: text.clone() }).unwrap();
                         if socket.send(WsMessage::Text(payload.into())).await.is_err() { break; }
                     }
                     Err(broadcast::error::RecvError::Closed) => break,
@@ -67,7 +136,14 @@ async fn handle_socket(mut socket: WebSocket, state: AppState) {
                 match msg {
                     Some(Ok(WsMessage::Text(text))) => {
                         if let Ok(req) = serde_json::from_str::<WsRequest>(&text) {
-                            let _ = state.user_input.send(req.message);
+                            match req {
+                                WsRequest::User { message, .. } => {
+                                    let _ = state.user_input.send(message);
+                                }
+                                WsRequest::Displayed { text } => {
+                                    state.ear.hear_self_say(&text).await;
+                                }
+                            }
                         }
                     }
                     Some(Ok(WsMessage::Close(_))) | None => break,
@@ -85,25 +161,19 @@ async fn handle_socket(mut socket: WebSocket, state: AppState) {
 ///
 /// ```no_run
 /// # tokio::runtime::Runtime::new().unwrap().block_on(async {
-/// # use pete::{dummy_psyche, listen_user_input};
+/// # use pete::{dummy_psyche, listen_user_input, ChannelEar};
 /// # use tokio::sync::mpsc;
 /// let mut psyche = dummy_psyche();
-/// let input = psyche.input_sender();
 /// let conv = psyche.conversation();
+/// let ear = std::sync::Arc::new(ChannelEar::new(psyche.input_sender(), conv.clone()));
 /// let (tx, rx) = mpsc::unbounded_channel();
-/// tokio::spawn(listen_user_input(rx, input, conv));
+/// tokio::spawn(listen_user_input(rx, ear));
 /// # tx.send("hi".into()).unwrap();
 /// # });
 /// ```
-pub async fn listen_user_input(
-    mut rx: mpsc::UnboundedReceiver<String>,
-    forward: mpsc::UnboundedSender<Sensation>,
-    conversation: Arc<Mutex<psyche::Conversation>>, // use psyche::Conversation
-) {
+pub async fn listen_user_input(mut rx: mpsc::UnboundedReceiver<String>, ear: Arc<dyn Ear>) {
     while let Some(msg) = rx.recv().await {
-        let _ = forward.send(Sensation::HeardUserVoice(msg.clone()));
-        let mut conv = conversation.lock().await;
-        conv.add_user(msg);
+        ear.hear_user_say(&msg).await;
     }
 }
 
@@ -141,7 +211,15 @@ pub fn dummy_psyche() -> Psyche {
         }
     }
 
-    let mut psyche = Psyche::new(Box::new(Dummy), Box::new(Dummy), Box::new(Dummy));
+    let mouth = Arc::new(NoopMouth);
+    let ear = Arc::new(NoopEar);
+    let mut psyche = Psyche::new(
+        Box::new(Dummy),
+        Box::new(Dummy),
+        Box::new(Dummy),
+        mouth,
+        ear,
+    );
     psyche.set_turn_limit(10);
     psyche
 }

--- a/pete/tests/input_listener.rs
+++ b/pete/tests/input_listener.rs
@@ -1,14 +1,14 @@
-use pete::{dummy_psyche, listen_user_input};
+use pete::{ChannelEar, dummy_psyche, listen_user_input};
 use tokio::sync::mpsc;
 
 #[tokio::test]
 async fn records_user_input() {
     let mut psyche = dummy_psyche();
-    let input = psyche.input_sender();
     let conv = psyche.conversation();
+    let ear = std::sync::Arc::new(ChannelEar::new(psyche.input_sender(), conv.clone()));
     let (tx, rx) = mpsc::unbounded_channel();
 
-    tokio::spawn(listen_user_input(rx, input, conv.clone()));
+    tokio::spawn(listen_user_input(rx, ear));
 
     tx.send("hello".to_string()).unwrap();
     tokio::time::sleep(std::time::Duration::from_millis(10)).await;

--- a/psyche/src/ling.rs
+++ b/psyche/src/ling.rs
@@ -11,7 +11,22 @@
 //! let narrator = OllamaProvider::new("http://localhost:11434", "mistral")?;
 //! let voice = OllamaProvider::new("http://localhost:11434", "mistral")?;
 //! let vectorizer = OllamaProvider::new("http://localhost:11434", "mistral")?;
-//! let psyche = Psyche::new(Box::new(narrator), Box::new(voice), Box::new(vectorizer));
+//! # struct DummyMouth;
+//! # #[async_trait::async_trait]
+//! # impl psyche::Mouth for DummyMouth { async fn speak(&self, _t: &str) {} }
+//! # struct DummyEar;
+//! # #[async_trait::async_trait]
+//! # impl psyche::Ear for DummyEar {
+//! #   async fn hear_self_say(&self, _t: &str) {}
+//! #   async fn hear_user_say(&self, _t: &str) {}
+//! # }
+//! let psyche = Psyche::new(
+//!     Box::new(narrator),
+//!     Box::new(voice),
+//!     Box::new(vectorizer),
+//!     std::sync::Arc::new(DummyMouth),
+//!     std::sync::Arc::new(DummyEar),
+//! );
 //! psyche.run().await;
 //! # Ok(()) }
 //! ```

--- a/psyche/tests/converse.rs
+++ b/psyche/tests/converse.rs
@@ -1,8 +1,19 @@
 use async_trait::async_trait;
 use psyche::ling::{Chatter, Doer, Message, Vectorizer};
-use psyche::{Event, Psyche, Sensation};
+use psyche::{Ear, Event, Mouth, Psyche, Sensation};
 
 struct Dummy;
+
+#[async_trait]
+impl Mouth for Dummy {
+    async fn speak(&self, _t: &str) {}
+}
+
+#[async_trait]
+impl Ear for Dummy {
+    async fn hear_self_say(&self, _t: &str) {}
+    async fn hear_user_say(&self, _t: &str) {}
+}
 
 #[async_trait]
 impl Doer for Dummy {
@@ -27,7 +38,15 @@ impl Vectorizer for Dummy {
 
 #[tokio::test]
 async fn adds_message_after_voice_heard() {
-    let mut psyche = Psyche::new(Box::new(Dummy), Box::new(Dummy), Box::new(Dummy));
+    let mouth = std::sync::Arc::new(Dummy);
+    let ear = mouth.clone();
+    let mut psyche = Psyche::new(
+        Box::new(Dummy),
+        Box::new(Dummy),
+        Box::new(Dummy),
+        mouth,
+        ear,
+    );
     psyche.set_turn_limit(1);
     psyche.set_system_prompt("sys");
 


### PR DESCRIPTION
## Summary
- define `Mouth` and `Ear` traits in psyche
- store `Mouth` and `Ear` in `Psyche` and connect to conversation flow
- implement websocket `ChannelMouth` and `ChannelEar` in pete
- update example and docs for the new traits
- adjust tests for the new interface
- delay self heard confirmation until websocket send
- wait for client confirmation before logging self-speech

## Testing
- `cargo fetch`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_684f5fad53c88320b43a9f65cb635fdc