### PR TITLE
Implement mouth interruption

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ use async_trait::async_trait;
 
 struct DummyMouth;
 #[async_trait]
-impl Mouth for DummyMouth { async fn speak(&self, _t: &str) {} }
+impl Mouth for DummyMouth {
+    async fn speak(&self, _t: &str) {}
+    async fn interrupt(&self) {}
+    fn speaking(&self) -> bool { false }
+}
 
 struct DummyEar;
 #[async_trait]

--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -1,6 +1,9 @@
 use clap::Parser;
 use pete::{AppState, ChannelEar, app, dummy_psyche, listen_user_input};
-use std::{net::SocketAddr, sync::Arc};
+use std::{
+    net::SocketAddr,
+    sync::{Arc, atomic::AtomicBool},
+};
 use tokio::sync::mpsc;
 
 #[derive(Parser)]
@@ -17,9 +20,11 @@ async fn main() -> anyhow::Result<()> {
 
     let mut psyche = dummy_psyche();
     let events = Arc::new(psyche.subscribe());
+    let speaking = Arc::new(AtomicBool::new(false));
     let ear = Arc::new(ChannelEar::new(
         psyche.input_sender(),
         psyche.conversation(),
+        speaking.clone(),
     ));
     let (user_tx, user_rx) = mpsc::unbounded_channel();
 

--- a/pete/tests/input_listener.rs
+++ b/pete/tests/input_listener.rs
@@ -1,11 +1,17 @@
 use pete::{ChannelEar, dummy_psyche, listen_user_input};
+use std::sync::atomic::AtomicBool;
 use tokio::sync::mpsc;
 
 #[tokio::test]
 async fn records_user_input() {
     let mut psyche = dummy_psyche();
     let conv = psyche.conversation();
-    let ear = std::sync::Arc::new(ChannelEar::new(psyche.input_sender(), conv.clone()));
+    let speaking = std::sync::Arc::new(AtomicBool::new(false));
+    let ear = std::sync::Arc::new(ChannelEar::new(
+        psyche.input_sender(),
+        conv.clone(),
+        speaking,
+    ));
     let (tx, rx) = mpsc::unbounded_channel();
 
     tokio::spawn(listen_user_input(rx, ear));

--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -28,6 +28,10 @@ pub enum Sensation {
 pub trait Mouth: Send + Sync {
     /// Speak the provided text.
     async fn speak(&self, text: &str);
+    /// Immediately stop saying anything queued or in progress.
+    async fn interrupt(&self);
+    /// Whether the mouth is currently speaking.
+    fn speaking(&self) -> bool;
 }
 
 /// Something that can register what was said.
@@ -160,6 +164,9 @@ impl Psyche {
                             break;
                         }
                         Some(Sensation::HeardUserVoice(msg)) => {
+                            if self.mouth.speaking() {
+                                self.mouth.interrupt().await;
+                            }
                             self.ear.hear_user_say(&msg).await;
                             let mut conv = self.conversation.lock().await;
                             conv.add_user(msg);

--- a/psyche/src/ling.rs
+++ b/psyche/src/ling.rs
@@ -13,7 +13,11 @@
 //! let vectorizer = OllamaProvider::new("http://localhost:11434", "mistral")?;
 //! # struct DummyMouth;
 //! # #[async_trait::async_trait]
-//! # impl psyche::Mouth for DummyMouth { async fn speak(&self, _t: &str) {} }
+//! # impl psyche::Mouth for DummyMouth {
+//! #     async fn speak(&self, _t: &str) {}
+//! #     async fn interrupt(&self) {}
+//! #     fn speaking(&self) -> bool { false }
+//! # }
 //! # struct DummyEar;
 //! # #[async_trait::async_trait]
 //! # impl psyche::Ear for DummyEar {


### PR DESCRIPTION
## Summary
- add `interrupt` and `speaking` to the `Mouth` trait
- update `Psyche` to interrupt when user speaks
- track speaking state in `ChannelMouth` and `NoopMouth`
- propagate speaking state through `ChannelEar`
- adjust examples and tests

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684f6b4644a883208b8502a3385aa26c