### PR TITLE
Stream responses from LLM

### DIFF
--- a/pete/src/lib.rs
+++ b/pete/src/lib.rs
@@ -234,8 +234,8 @@ pub fn dummy_psyche() -> Psyche {
 
     #[async_trait]
     impl Chatter for Dummy {
-        async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<String> {
-            Ok("hi".into())
+        async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+            Ok(Box::pin(tokio_stream::once(Ok("hi".to_string()))))
         }
     }
 

--- a/psyche/Cargo.toml
+++ b/psyche/Cargo.toml
@@ -6,8 +6,9 @@ edition = "2024"
 [dependencies]
 async-trait = "0.1"
 anyhow = "1"
-ollama-rs = "0.3"
+ollama-rs = { version = "0.3", features = ["stream"] }
 tokio = { version = "1", features = ["sync"] }
+tokio-stream = { version = "0.1", features = ["sync"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/psyche/tests/converse.rs
+++ b/psyche/tests/converse.rs
@@ -38,8 +38,8 @@ impl Doer for Dummy {
 
 #[async_trait]
 impl Chatter for Dummy {
-    async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<String> {
-        Ok("hello world".into())
+    async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+        Ok(Box::pin(tokio_stream::once(Ok("hello world".to_string()))))
     }
 }
 

--- a/psyche/tests/ling.rs
+++ b/psyche/tests/ling.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use psyche::ling::{Chatter, Doer, Message, Vectorizer};
+use tokio_stream::StreamExt;
 
 struct Dummy;
 
@@ -12,8 +13,9 @@ impl Doer for Dummy {
 
 #[async_trait]
 impl Chatter for Dummy {
-    async fn chat(&self, _s: &str, h: &[Message]) -> anyhow::Result<String> {
-        Ok(format!("say:{}", h.len()))
+    async fn chat(&self, _s: &str, h: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+        let msg = format!("say:{}", h.len());
+        Ok(Box::pin(tokio_stream::once(Ok(msg))))
     }
 }
 
@@ -29,6 +31,11 @@ async fn dummy_traits() {
     let d = Dummy;
     assert_eq!(d.follow("a").await.unwrap(), "do:a");
     let hist = vec![Message::user("hi"), Message::assistant("hey")];
-    assert_eq!(d.chat("sys", &hist).await.unwrap(), "say:2");
+    let mut stream = d.chat("sys", &hist).await.unwrap();
+    let mut res = String::new();
+    while let Some(chunk) = stream.next().await.transpose().unwrap() {
+        res.push_str(&chunk);
+    }
+    assert_eq!(res, "say:2");
     assert_eq!(d.vectorize("xyz").await.unwrap(), vec![3.0]);
 }


### PR DESCRIPTION
## Summary
- introduce `ChatStream` type alias and update `Chatter` trait to return streams
- adapt `OllamaProvider` and `Psyche` to handle streaming tokens
- adjust dummy implementations and tests for streaming API
- update workspace crates accordingly

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684f9f8ed6b08320be8e55fa118a01a0