### PR TITLE
Add Ollama chatter option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ Run tests with:
 cargo test
 ```
 
-Run the web server with:
+Run the web server with the built-in Ollama support:
 
 ```sh
-cargo run -p pete
+cargo run -p pete -- --ollama-url http://localhost:11434 --model mistral
 ```
 ## Web Interface
 

--- a/pete/src/lib.rs
+++ b/pete/src/lib.rs
@@ -277,3 +277,29 @@ pub fn dummy_psyche() -> Psyche {
     info!("created dummy psyche");
     psyche
 }
+
+/// Create a psyche backed by an Ollama server.
+///
+/// This uses [`OllamaProvider`](psyche::ling::OllamaProvider) for all language
+/// capabilities and the no-op ear and mouth implementations.
+pub fn ollama_psyche(host: &str, model: &str) -> anyhow::Result<Psyche> {
+    use psyche::ling::OllamaProvider;
+
+    let narrator = OllamaProvider::new(host, model)?;
+    let voice = OllamaProvider::new(host, model)?;
+    let vectorizer = OllamaProvider::new(host, model)?;
+
+    let mouth = Arc::new(NoopMouth::default());
+    let ear = Arc::new(NoopEar);
+
+    let mut psyche = Psyche::new(
+        Box::new(narrator),
+        Box::new(voice),
+        Box::new(vectorizer),
+        mouth,
+        ear,
+    );
+    psyche.set_turn_limit(usize::MAX);
+    info!(%host, %model, "created ollama psyche");
+    Ok(psyche)
+}

--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use pete::{AppState, ChannelEar, app, dummy_psyche, listen_user_input};
+use pete::{AppState, ChannelEar, app, listen_user_input, ollama_psyche};
 use std::{
     net::SocketAddr,
     sync::{Arc, atomic::AtomicBool},
@@ -14,6 +14,12 @@ struct Cli {
     /// Address to bind the HTTP server
     #[arg(long, default_value = "127.0.0.1:3000")]
     addr: String,
+    /// URL of the Ollama server
+    #[arg(long, default_value = "http://localhost:11434")]
+    ollama_url: String,
+    /// Model name to use with Ollama
+    #[arg(long, default_value = "mistral")]
+    model: String,
 }
 
 #[tokio::main(flavor = "multi_thread")]
@@ -23,7 +29,7 @@ async fn main() -> anyhow::Result<()> {
 
     info!(%cli.addr, "starting server");
 
-    let mut psyche = dummy_psyche();
+    let mut psyche = ollama_psyche(&cli.ollama_url, &cli.model)?;
     let events = Arc::new(psyche.subscribe());
     let speaking = Arc::new(AtomicBool::new(false));
     let ear = Arc::new(ChannelEar::new(

--- a/pete/tests/ollama.rs
+++ b/pete/tests/ollama.rs
@@ -1,0 +1,7 @@
+use pete::ollama_psyche;
+
+#[tokio::test]
+async fn creates_psyche() {
+    let psyche = ollama_psyche("http://localhost:11434", "mistral").unwrap();
+    assert_eq!(psyche.conversation().lock().await.all().len(), 0);
+}


### PR DESCRIPTION
## Summary
- implement `ollama_psyche` using ollama-rs
- expose `--ollama-url` and `--model` CLI options
- document new server invocation
- test creating Ollama-backed psyche

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684fad3b97448320b480cf446a93496a