### PR TITLE
Add lingproc crate for reactive text processing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["psyche", "pete"]
+members = ["psyche", "pete", "lingproc"]
 resolver = "2"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Daringsby Workspace
 
-This repository contains a Rust workspace with two crates:
+This repository contains a Rust workspace with multiple crates:
 
 - **psyche** – a library crate providing the `Psyche` type
 - **ling** – helper LLM abstractions exposed through the `psyche` crate
+- **lingproc** – streaming text utilities built with `rxrs`
 - **pete** – a binary crate depending on `psyche`
 
 Example with the `OllamaProvider`:

--- a/lingproc/Cargo.toml
+++ b/lingproc/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "lingproc"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+rxrust = "1.0.0-beta.9"
+sentence_segmentation = "1.2.0"
+unicode-segmentation = "1.12"

--- a/lingproc/src/lib.rs
+++ b/lingproc/src/lib.rs
@@ -1,0 +1,94 @@
+//! Reactive text processing utilities.
+//!
+//! This crate provides stream-based helpers built on [`rxrust`].
+//! The functions emit sentences or words as soon as they can be
+//! determined reliably. See the tests for usage examples.
+
+use rxrust::prelude::*;
+use sentence_segmentation::processor;
+use std::{cell::RefCell, rc::Rc};
+use unicode_segmentation::UnicodeSegmentation;
+
+/// Create a pair of subjects for streaming sentence segmentation.
+///
+/// Feed text fragments into the returned `Subject`. Every time at
+/// least two complete sentences are present in the internal buffer,
+/// the first is emitted on the output `Subject`.
+///
+/// ```rust,ignore
+/// use lingproc::sentence_pipe;
+/// use rxrust::prelude::*;
+///
+/// let (mut input, out) = sentence_pipe();
+/// let mut got = Vec::new();
+/// out.subscribe(|s: String| got.push(s));
+/// input.next("Hello world.".to_string());
+/// input.next(" How are you?".to_string());
+/// assert_eq!(got, vec!["Hello world.".to_string()]);
+/// ```
+use std::convert::Infallible;
+
+pub fn sentence_pipe() -> (
+    Subject<'static, String, Infallible>,
+    Subject<'static, String, Infallible>,
+) {
+    let mut input: Subject<'static, String, Infallible> = Subject::default();
+    let mut output: Subject<'static, String, Infallible> = Subject::default();
+    let buffer = Rc::new(RefCell::new(String::new()));
+    let mut out_clone = output.clone();
+    let buf_clone = buffer.clone();
+    input.clone().subscribe(move |chunk: String| {
+        let mut buf = buf_clone.borrow_mut();
+        buf.push_str(&chunk);
+        let segs = processor::english(&buf);
+        if segs.len() >= 2 {
+            let first = segs[0].clone();
+            out_clone.next(first.clone());
+            if let Some(pos) = buf.find(&first) {
+                let rest = buf[pos + first.len()..].to_string();
+                *buf = rest;
+            } else {
+                buf.clear();
+            }
+        }
+    });
+    (input, output)
+}
+
+/// Create a pair of subjects for streaming word segmentation.
+///
+/// Feed text fragments into the returned `Subject`. Complete words
+/// are emitted on the output `Subject` as soon as they are recognized.
+pub fn word_pipe() -> (
+    Subject<'static, String, Infallible>,
+    Subject<'static, String, Infallible>,
+) {
+    let mut input: Subject<'static, String, Infallible> = Subject::default();
+    let mut output: Subject<'static, String, Infallible> = Subject::default();
+    let buffer = Rc::new(RefCell::new(String::new()));
+    let mut out_clone = output.clone();
+    let buf_clone = buffer.clone();
+    input.clone().subscribe(move |chunk: String| {
+        let mut buf = buf_clone.borrow_mut();
+        buf.push_str(&chunk);
+        let mut last = 0;
+        for (idx, word) in buf.unicode_word_indices() {
+            if idx + word.len() == buf.len()
+                && buf
+                    .chars()
+                    .last()
+                    .map(|c| c.is_alphanumeric())
+                    .unwrap_or(false)
+            {
+                break;
+            }
+            out_clone.next(word.to_string());
+            last = idx + word.len();
+        }
+        if last > 0 {
+            let rest = buf[last..].to_string();
+            *buf = rest;
+        }
+    });
+    (input, output)
+}

--- a/lingproc/tests/sentence.rs
+++ b/lingproc/tests/sentence.rs
@@ -1,0 +1,20 @@
+use lingproc::sentence_pipe;
+use rxrust::prelude::*;
+use std::{cell::RefCell, rc::Rc};
+
+#[test]
+fn splits_sentences_with_buffering() {
+    let (mut input, out) = sentence_pipe();
+    let got = Rc::new(RefCell::new(Vec::new()));
+    let got_clone = got.clone();
+    out.subscribe(move |s: String| got_clone.borrow_mut().push(s));
+
+    input.next("Hello world.".to_string());
+    input.next(" How are you? I'm fine.".to_string());
+    assert_eq!(got.borrow().len(), 1);
+    assert_eq!(got.borrow()[0], "Hello world.");
+
+    input.next(" Thanks.".to_string());
+    assert_eq!(got.borrow().len(), 2);
+    assert_eq!(got.borrow()[1], "How are you?");
+}

--- a/lingproc/tests/word.rs
+++ b/lingproc/tests/word.rs
@@ -1,0 +1,29 @@
+use lingproc::word_pipe;
+use rxrust::prelude::*;
+use std::{cell::RefCell, rc::Rc};
+
+#[test]
+fn splits_words_streaming() {
+    let (mut input, out) = word_pipe();
+    let got = Rc::new(RefCell::new(Vec::new()));
+    let got_clone = got.clone();
+    out.subscribe(move |w: String| got_clone.borrow_mut().push(w));
+
+    input.next("hello wor".to_string());
+    assert_eq!(*got.borrow(), vec!["hello".to_string()]);
+
+    input.next("ld friend".to_string());
+    assert_eq!(
+        *got.borrow(),
+        vec!["hello".to_string(), "world".to_string()]
+    );
+    input.next(" ".to_string());
+    assert_eq!(
+        *got.borrow(),
+        vec![
+            "hello".to_string(),
+            "world".to_string(),
+            "friend".to_string()
+        ]
+    );
+}


### PR DESCRIPTION
## Summary
- introduce new `lingproc` crate
- implement sentence and word stream utilities using `rxrust`
- add unit tests for sentence and word splitting
- document new crate in README

## Testing
- `cargo test`
- `cargo test -p lingproc --doc`

------
https://chatgpt.com/codex/tasks/task_e_685036fc245083209506dd77787a34f0