### PR TITLE
Fix WebSocket reconnection logic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,9 +15,11 @@ This repository is now a Rust workspace.
 - The chat page uses Alpine.js for binding; preserve this dependency when updating `index.html`.
 - Run `cargo fetch` before testing to warm the cache.
 - When embedding `index.html` in the `pete` crate, use `include_str!("../../index.html")`.
+- Keep the chat script in `index.html` and `pete/build.rs` in sync.
  - Expose WebSocket chat at `/ws` that forwards psyche events.
  - The server no longer exposes the `/chat` SSE endpoint; real-time events are
    WebSocket-only.
 - Use `tracing` macros for all logging.
 - Initialize logging in binaries with `tracing_subscriber::fmt::init()`.
 - When files grow beyond roughly 200 lines, break them into logical modules.
+- Avoid using `echo $?` to verify command success; rely on command output.

--- a/index.html
+++ b/index.html
@@ -34,6 +34,10 @@
         input: '',
         init() { this.connect(); },
         connect() {
+          if (this.ws && (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING)) {
+            return;
+          }
+          if (this.ws) { this.ws.close(); }
           this.status = 'WS: connecting';
           this.ws = new WebSocket('ws://localhost:3000/ws');
           this.ws.onopen = () => this.status = 'WS: open';

--- a/pete/build.rs
+++ b/pete/build.rs
@@ -11,6 +11,10 @@ const SCRIPT: &str = r#"function chatApp() {
     input: '',
     init() { this.connect(); },
     connect() {
+      if (this.ws && (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING)) {
+        return;
+      }
+      if (this.ws) { this.ws.close(); }
       this.status = 'WS: connecting';
       this.ws = new WebSocket('ws://localhost:3000/ws');
       this.ws.onopen = () => this.status = 'WS: open';

--- a/pete/tests/index.rs
+++ b/pete/tests/index.rs
@@ -5,4 +5,5 @@ async fn serves_index_html() {
     let resp = index().await;
     assert!(resp.0.contains("ws://localhost:3000/ws"));
     assert!(resp.0.contains("WS:"));
+    assert_eq!(resp.0.matches("new WebSocket").count(), 1);
 }


### PR DESCRIPTION
## Summary
- avoid creating multiple websocket connections in `index.html`
- keep `pete` build script in sync
- ensure one websocket appears in generated HTML
- document new rule about script sync and command validation in `AGENTS.md`

## Testing
- `cargo fetch`
- `cargo fmt`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68507dd90a5083208eb6e5f242f1c749