### PR TITLE
Track and interrupt pending speech

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ let psyche = Psyche::new(
 );
 psyche.set_echo_timeout(std::time::Duration::from_secs(1));
 psyche.run().await;
+assert!(!psyche.speaking());
 ```
 
 


### PR DESCRIPTION
## Summary
- track a pending speech state in `Psyche`
- interrupt and clear queues when hearing user input mid-speech
- expose `Psyche::speaking` and test it
- document usage of `speaking` in README

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685083b0c22c8320bdc24b2870c60764