### PR TITLE
Improve chat page message layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,11 @@
 <body class="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100 font-sans text-gray-800">
   <div x-data="chatApp()" x-init="init()" class="w-full max-w-xl p-6 space-y-4 bg-white rounded-xl shadow">
     <div id="status" x-text="status" class="text-xs font-semibold text-gray-500"></div>
-    <pre id="log" x-ref="log" x-text="log" class="chat-log p-2 bg-gray-50 rounded"></pre>
+    <div id="log" x-ref="log" class="chat-log p-2 bg-gray-50 rounded flex flex-col space-y-1 overflow-y-auto">
+      <template x-for="msg in log" :key="msg.id">
+        <div :class="msg.role === 'user' ? 'text-right text-blue-600' : 'text-left text-gray-800'" x-text="msg.text"></div>
+      </template>
+    </div>
     <div class="flex gap-2">
       <input type="text" class="flex-grow border rounded px-3 py-2" placeholder="Say something..." x-model="input" />
       <button class="px-4 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-700" @click.prevent="send">Send</button>
@@ -23,7 +27,7 @@
       return {
         ws: null,
         status: 'WS: connecting',
-        log: '',
+        log: [],
         input: '',
         init() { this.connect(); },
         connect() {
@@ -40,24 +44,25 @@
             try {
               const data = JSON.parse(ev.data);
               if (data.text) {
-                this.append(data.text);
+                this.append('system', data.text);
               }
             } catch (_) {
-              this.append(ev.data);
+              this.append('system', ev.data);
             }
           };
         },
-        append(text) {
+        append(role, text) {
           const el = this.$refs.log;
           const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 2;
-          this.log += text;
+          this.log.push({ role, text });
           this.$nextTick(() => {
             if (atBottom) el.scrollTop = el.scrollHeight;
-            this.ws.send(JSON.stringify({ type: 'displayed', text }));
+            if (role !== 'user') this.ws.send(JSON.stringify({ type: 'displayed', text }));
           });
         },
         send() {
           if (!this.input) return;
+          this.append('user', this.input);
           this.ws.send(JSON.stringify({ type: 'user', message: this.input }));
           this.input = '';
         }

--- a/pete/build.rs
+++ b/pete/build.rs
@@ -7,7 +7,7 @@ const SCRIPT: &str = r#"function chatApp() {
   return {
     ws: null,
     status: 'WS: connecting',
-    log: '',
+    log: [],
     input: '',
     init() { this.connect(); },
     connect() {
@@ -24,18 +24,25 @@ const SCRIPT: &str = r#"function chatApp() {
         try {
           const data = JSON.parse(ev.data);
           if (data.text) {
-            this.log += data.text;
-            this.$nextTick(() => {
-              this.ws.send(JSON.stringify({ type: 'displayed', text: data.text }));
-            });
+            this.append('system', data.text);
           }
         } catch (_) {
-          this.log += ev.data;
+          this.append('system', ev.data);
         }
       };
     },
+    append(role, text) {
+      const el = this.$refs.log;
+      const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 2;
+      this.log.push({ role, text });
+      this.$nextTick(() => {
+        if (atBottom) el.scrollTop = el.scrollHeight;
+        if (role !== 'user') this.ws.send(JSON.stringify({ type: 'displayed', text }));
+      });
+    },
     send() {
       if (!this.input) return;
+      this.append('user', this.input);
       this.ws.send(JSON.stringify({ type: 'user', message: this.input }));
       this.input = '';
     }
@@ -46,7 +53,11 @@ fn main() {
     let body = render_lazy(rsx! {
         div { "x-data": "chatApp()", "x-init": "init()", class: "section",
             div { id: "status", "x-text": "status", class: "mb-2 has-text-weight-bold" }
-            pre { id: "log", "x-text": "log", class: "box" }
+            div { id: "log", "x-ref": "log", class: "box flex flex-col space-y-1",
+                template { "x-for": "msg in log", ":key": "msg.id",
+                    div { ":class": "msg.role === 'user' ? 'has-text-info has-text-right' : 'has-text-left'", "x-text": "msg.text" }
+                }
+            }
             div { class: "field has-addons",
                 div { class: "control is-expanded",
                     sl-input {
@@ -64,7 +75,7 @@ fn main() {
     });
 
     let page = format!(
-        "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n  <meta charset=\"utf-8\">\n  <title>Pete Console</title>\n  <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css\">\n  <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/@picocss/pico@1/css/pico.min.css\">\n  <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.3.0/dist/themes/light.css\">\n  <style>#log {{ white-space: pre-wrap; }}</style>\n  <script type=\"module\" src=\"https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.3.0/dist/shoelace.js\"></script>\n  <script src=\"https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js\" defer></script>\n</head>\n<body class=\"container\">\n  {body}\n  <script>{SCRIPT}</script>\n</body>\n</html>"
+        "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n  <meta charset=\"utf-8\">\n  <title>Pete Console</title>\n  <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css\">\n  <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/@picocss/pico@1/css/pico.min.css\">\n  <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.3.0/dist/themes/light.css\">\n  <style>#log.chat-log {{ white-space: pre-wrap; max-height: 60vh; overflow-y: auto; }}</style>\n  <script type=\"module\" src=\"https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.3.0/dist/shoelace.js\"></script>\n  <script src=\"https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js\" defer></script>\n</head>\n<body class=\"container\">\n  {body}\n  <script>{SCRIPT}</script>\n</body>\n</html>"
     );
 
     let out = PathBuf::from(env!("CARGO_MANIFEST_DIR"))


### PR DESCRIPTION
## Summary
- show user and system messages in different elements
- sync build script with new chat template

## Testing
- `cargo fmt`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68508620dfd88320886f7a06749b8116