### PR TITLE
Accumulate Pete responses on frontend

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,11 @@
         append(role, text) {
           const el = this.$refs.log;
           const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 2;
-          this.log.push({ role, text });
+          if (role === 'system' && this.log.length && this.log[this.log.length - 1].role === 'system') {
+            this.log[this.log.length - 1].text += text;
+          } else {
+            this.log.push({ role, text });
+          }
           this.$nextTick(() => {
             if (atBottom) el.scrollTop = el.scrollHeight;
             if (role !== 'user') this.ws.send(JSON.stringify({ type: 'displayed', text }));

--- a/pete/build.rs
+++ b/pete/build.rs
@@ -34,7 +34,11 @@ const SCRIPT: &str = r#"function chatApp() {
     append(role, text) {
       const el = this.$refs.log;
       const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 2;
-      this.log.push({ role, text });
+      if (role === 'system' && this.log.length && this.log[this.log.length - 1].role === 'system') {
+        this.log[this.log.length - 1].text += text;
+      } else {
+        this.log.push({ role, text });
+      }
       this.$nextTick(() => {
         if (atBottom) el.scrollTop = el.scrollHeight;
         if (role !== 'user') this.ws.send(JSON.stringify({ type: 'displayed', text }));

--- a/pete/tests/index.rs
+++ b/pete/tests/index.rs
@@ -6,4 +6,8 @@ async fn serves_index_html() {
     assert!(resp.0.contains("ws://localhost:3000/ws"));
     assert!(resp.0.contains("WS:"));
     assert_eq!(resp.0.matches("new WebSocket").count(), 1);
+    assert!(
+        resp.0
+            .contains("this.log[this.log.length - 1].text += text")
+    );
 }


### PR DESCRIPTION
## Summary
- accumulate system messages client-side so streaming text concatenates
- update `index.html` and embedded script in `pete` crate
- check for new accumulation logic in index test

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68508a0a4bd88320a07ff68eb9ab34dc