### PR TITLE
Fix mouth interrupt by wiring ChannelMouth

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ let psyche = Psyche::new(
     std::sync::Arc::new(DummyMouth),
     std::sync::Arc::new(DummyEar),
 );
+// replace the dummy mouth with your own implementation
+let mouth = std::sync::Arc::new(DummyMouth);
+psyche.set_mouth(mouth);
 psyche.set_echo_timeout(std::time::Duration::from_secs(1));
 psyche.run().await;
 assert!(!psyche.speaking());

--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use pete::{AppState, ChannelEar, app, listen_user_input, ollama_psyche};
+use pete::{AppState, ChannelEar, ChannelMouth, app, listen_user_input, ollama_psyche};
 use std::{
     net::SocketAddr,
     sync::{Arc, atomic::AtomicBool},
@@ -30,8 +30,10 @@ async fn main() -> anyhow::Result<()> {
     info!(%cli.addr, "starting server");
 
     let mut psyche = ollama_psyche(&cli.ollama_url, &cli.model)?;
-    let events = Arc::new(psyche.subscribe());
     let speaking = Arc::new(AtomicBool::new(false));
+    let mouth = Arc::new(ChannelMouth::new(psyche.event_sender(), speaking.clone()));
+    psyche.set_mouth(mouth.clone());
+    let events = Arc::new(psyche.subscribe());
     let ear = Arc::new(ChannelEar::new(
         psyche.input_sender(),
         psyche.conversation(),

--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -145,6 +145,16 @@ impl Psyche {
         self.input_tx.clone()
     }
 
+    /// Broadcast channel for conversation events.
+    pub fn event_sender(&self) -> broadcast::Sender<Event> {
+        self.events_tx.clone()
+    }
+
+    /// Replace the current [`Mouth`] implementation.
+    pub fn set_mouth(&mut self, mouth: Arc<dyn Mouth>) {
+        self.mouth = mouth;
+    }
+
     fn still_conversing(&self, turns: usize) -> bool {
         turns < self.max_turns
     }


### PR DESCRIPTION
## Summary
- expose event sender and mouth setter on `Psyche`
- use `ChannelMouth` in the `pete` binary
- show how to swap mouths in the README

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68508de263988320843f21ab63729ba3