### PR TITLE
Add optional Coqui TTS integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,3 +23,5 @@ This repository is now a Rust workspace.
 - Initialize logging in binaries with `tracing_subscriber::fmt::init()`.
 - When files grow beyond roughly 200 lines, break them into logical modules.
 - Avoid using `echo $?` to verify command success; rely on command output.
+- Prefer lightweight test dependencies; stub heavy external services like TTS
+  engines to keep CI fast.

--- a/index.html
+++ b/index.html
@@ -30,6 +30,8 @@
         status: 'WS: connecting',
         log: [],
         input: '',
+        audioQueue: [],
+        audio: null,
         init() { this.connect(); },
         connect() {
           if (this.ws && (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING)) {
@@ -47,10 +49,25 @@
               if (data.text) {
                 this.append('system', data.text);
               }
+              if (data.audio) {
+                this.audioQueue.push({ audio: data.audio, text: data.text || '' });
+                this.playNext();
+              }
             } catch (_) {
               this.append('system', ev.data);
             }
           };
+        },
+        playNext() {
+          if (this.audio || this.audioQueue.length === 0) return;
+          const { audio, text } = this.audioQueue.shift();
+          this.audio = new Audio('data:audio/wav;base64,' + audio);
+          this.audio.onended = () => {
+            this.audio = null;
+            this.ws.send(JSON.stringify({ type: 'played', text }));
+            this.playNext();
+          };
+          this.audio.play();
         },
         append(role, text) {
           const el = this.$refs.log;

--- a/lingproc/tests/segment.rs
+++ b/lingproc/tests/segment.rs
@@ -1,4 +1,3 @@
-use futures::StreamExt;
 use lingproc::{sentence_stream, word_stream};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 

--- a/pete/Cargo.toml
+++ b/pete/Cargo.toml
@@ -19,6 +19,12 @@ tracing-subscriber = { version = "0.3", features = ["fmt"] }
 pragmatic-segmenter = "0.1"
 dioxus = { version = "0.4.3", default-features = false, features = ["html", "macro"] }
 dioxus-ssr = "0.4.3"
+pyo3 = { version = "0.20", features = ["auto-initialize"], optional = true }
+base64 = { version = "0.21", optional = true }
+
+[features]
+default = []
+tts = ["pyo3", "base64"]
 
 [build-dependencies]
 dioxus = { version = "0.4.3", default-features = false, features = ["html", "macro"] }

--- a/pete/build.rs
+++ b/pete/build.rs
@@ -9,6 +9,8 @@ const SCRIPT: &str = r#"function chatApp() {
     status: 'WS: connecting',
     log: [],
     input: '',
+    audioQueue: [],
+    audio: null,
     init() { this.connect(); },
     connect() {
       if (this.ws && (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING)) {
@@ -26,10 +28,25 @@ const SCRIPT: &str = r#"function chatApp() {
           if (data.text) {
             this.append('system', data.text);
           }
+          if (data.audio) {
+            this.audioQueue.push({ audio: data.audio, text: data.text || '' });
+            this.playNext();
+          }
         } catch (_) {
           this.append('system', ev.data);
         }
       };
+    },
+    playNext() {
+      if (this.audio || this.audioQueue.length === 0) return;
+      const { audio, text } = this.audioQueue.shift();
+      this.audio = new Audio('data:audio/wav;base64,' + audio);
+      this.audio.onended = () => {
+        this.audio = null;
+        this.ws.send(JSON.stringify({ type: 'played', text }));
+        this.playNext();
+      };
+      this.audio.play();
     },
     append(role, text) {
       const el = this.$refs.log;

--- a/pete/src/lib.rs
+++ b/pete/src/lib.rs
@@ -6,9 +6,13 @@
 mod ear;
 mod mouth;
 mod psyche_factory;
+#[cfg(feature = "tts")]
+mod tts_mouth;
 mod web;
 
 pub use ear::{ChannelEar, NoopEar};
 pub use mouth::{ChannelMouth, NoopMouth};
 pub use psyche_factory::{dummy_psyche, ollama_psyche};
+#[cfg(feature = "tts")]
+pub use tts_mouth::{CoquiTts, Tts, TtsMouth};
 pub use web::{AppState, WsRequest, app, index, listen_user_input, ws_handler};

--- a/pete/src/mouth.rs
+++ b/pete/src/mouth.rs
@@ -1,5 +1,4 @@
 use async_trait::async_trait;
-use pragmatic_segmenter::Segmenter;
 use psyche::{Event, Mouth};
 use std::sync::{
     Arc,

--- a/pete/src/tts_mouth.rs
+++ b/pete/src/tts_mouth.rs
@@ -1,0 +1,107 @@
+#![cfg(feature = "tts")]
+use async_trait::async_trait;
+use pragmatic_segmenter::Segmenter;
+use psyche::{Event, Mouth};
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+use tokio::sync::broadcast;
+use tracing::error;
+
+use anyhow::Result;
+use base64::{Engine as _, engine::general_purpose};
+use pyo3::IntoPy;
+
+pub trait Tts: Send + Sync {
+    fn to_wav(&self, text: &str) -> Result<Vec<u8>>;
+}
+
+pub struct CoquiTts {
+    inner: pyo3::Py<pyo3::PyAny>,
+}
+
+impl CoquiTts {
+    pub fn new() -> Result<Self> {
+        use pyo3::types::{PyDict, PyModule};
+        pyo3::Python::with_gil(|py| {
+            let module = PyModule::import(py, "TTS.api")?;
+            let class = module.getattr("TTS")?;
+            let kwargs = PyDict::new(py);
+            kwargs.set_item("progress_bar", false)?;
+            let obj = class.call((), Some(kwargs))?;
+            Ok(Self {
+                inner: obj.into_py(py),
+            })
+        })
+    }
+}
+
+impl Tts for CoquiTts {
+    fn to_wav(&self, text: &str) -> Result<Vec<u8>> {
+        use std::fs;
+        pyo3::Python::with_gil(|py| {
+            let tts = self.inner.as_ref(py);
+            let path = "/tmp/pete_tts.wav";
+            tts.call_method1("tts_to_file", (text, path))?;
+            let data = fs::read(path)?;
+            let _ = fs::remove_file(path);
+            Ok(data)
+        })
+    }
+}
+
+#[derive(Clone)]
+pub struct TtsMouth {
+    events: broadcast::Sender<Event>,
+    speaking: Arc<AtomicBool>,
+    tts: Arc<dyn Tts>,
+}
+
+impl TtsMouth {
+    pub fn new(
+        events: broadcast::Sender<Event>,
+        speaking: Arc<AtomicBool>,
+        tts: Arc<dyn Tts>,
+    ) -> Self {
+        Self {
+            events,
+            speaking,
+            tts,
+        }
+    }
+}
+
+#[async_trait]
+impl Mouth for TtsMouth {
+    async fn speak(&self, text: &str) {
+        self.speaking.store(true, Ordering::SeqCst);
+        let seg = Segmenter::new().expect("segmenter init");
+        for sentence in seg.segment(text) {
+            let sent = sentence.trim();
+            if sent.is_empty() {
+                continue;
+            }
+            match self.tts.to_wav(sent) {
+                Ok(bytes) => {
+                    let b64 = general_purpose::STANDARD.encode(bytes);
+                    if self.events.send(Event::SpeechAudio(b64)).is_err() {
+                        error!("failed sending audio");
+                    }
+                }
+                Err(e) => {
+                    error!(?e, "tts failed");
+                }
+            }
+        }
+        self.speaking.store(false, Ordering::SeqCst);
+    }
+
+    async fn interrupt(&self) {
+        self.speaking.store(false, Ordering::SeqCst);
+    }
+
+    fn speaking(&self) -> bool {
+        self.speaking.load(Ordering::SeqCst)
+    }
+}

--- a/pete/tests/index.rs
+++ b/pete/tests/index.rs
@@ -10,4 +10,5 @@ async fn serves_index_html() {
         resp.0
             .contains("this.log[this.log.length - 1].text += text")
     );
+    assert!(resp.0.contains("audioQueue"));
 }

--- a/pete/tests/tts_mouth.rs
+++ b/pete/tests/tts_mouth.rs
@@ -1,0 +1,29 @@
+#![cfg(feature = "tts")]
+use pete::{Tts, TtsMouth};
+use psyche::Event;
+use psyche::Mouth;
+use std::sync::{Arc, atomic::AtomicBool};
+use tokio::sync::broadcast;
+
+struct DummyTts;
+
+impl Tts for DummyTts {
+    fn to_wav(&self, _text: &str) -> anyhow::Result<Vec<u8>> {
+        Ok(vec![0u8; 4])
+    }
+}
+
+#[tokio::test]
+async fn emits_audio_events() {
+    let (tx, mut rx) = broadcast::channel(8);
+    let mouth = TtsMouth::new(
+        tx.clone(),
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(DummyTts),
+    );
+    mouth.speak("Hello world.").await;
+    if let Ok(Event::SpeechAudio(_)) = rx.recv().await {
+        return;
+    }
+    panic!("no audio event");
+}

--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -14,6 +14,8 @@ pub enum Event {
     StreamChunk(String),
     /// The assistant intends to say the given response.
     IntentionToSay(String),
+    /// Base64-encoded WAV audio representing the spoken sentence.
+    SpeechAudio(String),
 }
 
 /// Inputs that can be sent to a running [`Psyche`].

--- a/psyche/tests/converse.rs
+++ b/psyche/tests/converse.rs
@@ -77,6 +77,7 @@ async fn adds_message_after_voice_heard() {
                 input.send(Sensation::HeardOwnVoice(msg)).unwrap();
                 break;
             }
+            Event::SpeechAudio(_) => {}
         }
     }
 


### PR DESCRIPTION
## Summary
- introduce optional `tts` feature using pyo3
- implement `TtsMouth` with Python-based Coqui TTS
- extend `Event` with `SpeechAudio`
- support audio messages over websocket
- update index page & build script for playback queue
- test new TTS mouth (feature gated)
- document lightweight dependency guidance

## Testing
- `cargo fmt`
- `cargo fetch`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6850a3e022888320ac7e451a1fd8f9e8