### PR TITLE
Update chat layout with sidebar

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,23 +5,23 @@
   <title>Pete Console</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <style>
-    #log.chat-log { white-space: pre-wrap; max-height: 60vh; overflow-y: auto; }
+    #log.chat-log { white-space: pre-wrap; overflow-y: auto; }
   </style>
   <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
 </head>
 <body class="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100 font-sans text-gray-800">
-  <div x-data="chatApp()" x-init="init()" class="w-full max-w-xl p-6 space-y-4 bg-white rounded-xl shadow">
-    <div id="status" x-text="status" class="text-xs font-semibold text-gray-500"></div>
-    <div id="log" x-ref="log" class="chat-log p-2 bg-gray-50 rounded flex flex-col space-y-1">
-      <template x-for="(msg, i) in log" :key="i">
-        <div :class="msg.role === 'user' ? 'text-blue-600 text-right' : 'text-left'" x-text="msg.text"></div>
-      </template>
-    </div>
-    <form class="flex gap-2"  @submit.prevent="send">
-      <label for="input" class="sr-only">Message</label>
-      <input type="text" autofocus class="flex-grow border rounded px-3 py-2" placeholder="Say something..." x-model="input" />
-      <button type="submit" class="px-4 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-700">Send</button>
-    </form>
+  <div x-data="chatApp()" x-init="init()" class="flex w-full max-w-4xl h-[80vh] bg-white rounded-xl shadow overflow-hidden">
+    <aside class="w-48 p-4 bg-gray-100">
+      <div id="status" x-text="status" class="text-xs font-semibold text-gray-500"></div>
+    </aside>
+    <main class="flex flex-col flex-1 p-6 space-y-4">
+      <div id="log" x-ref="log" class="chat-log p-2 bg-gray-50 rounded flex flex-col space-y-1 flex-grow"></div>
+      <form class="flex gap-2 mt-auto" @submit.prevent="send">
+        <label for="input" class="sr-only">Message</label>
+        <input type="text" autofocus class="flex-grow border rounded px-3 py-2" placeholder="Say something..." x-model="input" />
+        <button type="submit" class="px-4 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-700">Send</button>
+      </form>
+    </main>
   </div>
   <script>
     function chatApp() {

--- a/pete/build.rs
+++ b/pete/build.rs
@@ -55,31 +55,35 @@ const SCRIPT: &str = r#"function chatApp() {
 
 fn main() {
     let body = render_lazy(rsx! {
-        div { "x-data": "chatApp()", "x-init": "init()", class: "section",
-            div { id: "status", "x-text": "status", class: "mb-2 has-text-weight-bold" }
-            div { id: "log", "x-ref": "log", class: "box flex flex-col space-y-1",
-                template { "x-for": "msg in log", ":key": "msg.id",
-                    div { ":class": "msg.role === 'user' ? 'has-text-info has-text-right' : 'has-text-left'", "x-text": "msg.text" }
-                }
+        div { "x-data": "chatApp()", "x-init": "init()", class: "columns is-gapless is-fullheight",
+            aside { class: "column is-one-quarter p-4 has-background-grey-light",
+                div { id: "status", "x-text": "status", class: "has-text-weight-bold is-size-7" }
             }
-            div { class: "field has-addons",
-                div { class: "control is-expanded",
-                    sl-input {
-                      class: "input",
-                      placeholder: "Say something...",
-                      "x-model": "input",
-                      style: "width: 100%;"
+            main { class: "column is-flex is-flex-direction-column p-4",
+                div { id: "log", "x-ref": "log", class: "box is-flex is-flex-direction-column space-y-1 is-flex-grow-1",
+                    template { "x-for": "msg in log", ":key": "msg.id",
+                        div { ":class": "msg.role === 'user' ? 'has-text-info has-text-right' : 'has-text-left'", "x-text": "msg.text" }
                     }
                 }
-                div { class: "control",
-                    sl-button { r#type: "submit", variant: "primary", "@click.prevent": "send", "Send" }
+                div { class: "field has-addons mt-auto",
+                    div { class: "control is-expanded",
+                        sl-input {
+                          class: "input",
+                          placeholder: "Say something...",
+                          "x-model": "input",
+                          style: "width: 100%;",
+                        }
+                    }
+                    div { class: "control",
+                        sl-button { r#type: "submit", variant: "primary", "@click.prevent": "send", "Send" }
+                    }
                 }
             }
         }
     });
 
     let page = format!(
-        "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n  <meta charset=\"utf-8\">\n  <title>Pete Console</title>\n  <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css\">\n  <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/@picocss/pico@1/css/pico.min.css\">\n  <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.3.0/dist/themes/light.css\">\n  <style>#log.chat-log {{ white-space: pre-wrap; max-height: 60vh; overflow-y: auto; }}</style>\n  <script type=\"module\" src=\"https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.3.0/dist/shoelace.js\"></script>\n  <script src=\"https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js\" defer></script>\n</head>\n<body class=\"container\">\n  {body}\n  <script>{SCRIPT}</script>\n</body>\n</html>"
+        "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n  <meta charset=\"utf-8\">\n  <title>Pete Console</title>\n  <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css\">\n  <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/@picocss/pico@1/css/pico.min.css\">\n  <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.3.0/dist/themes/light.css\">\n  <style>#log.chat-log {{ white-space: pre-wrap; overflow-y: auto; }}</style>\n  <script type=\"module\" src=\"https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.3.0/dist/shoelace.js\"></script>\n  <script src=\"https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js\" defer></script>\n</head>\n<body class=\"container\">\n  {body}\n  <script>{SCRIPT}</script>\n</body>\n</html>"
     );
 
     let out = PathBuf::from(env!("CARGO_MANIFEST_DIR"))


### PR DESCRIPTION
## Summary
- expand the chat log to use the available space
- add a sidebar showing the websocket status
- update build script to generate matching layout

## Testing
- `cargo fmt`
- `cargo fetch`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6850a642c30c832097ed32ec4b82e1eb