### PR TITLE
Fix chat log list markup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ This repository is now a Rust workspace.
 - Keep `index.html` minimal and updated to connect to `ws://localhost:3000/ws`.
 - Display the WebSocket connection status in the page for debugging.
 - The chat page uses Alpine.js for binding; preserve this dependency when updating `index.html`.
+- Render the chat log as a `<ul>` with `<li>` elements for each message.
 - Run `cargo fetch` before testing to warm the cache.
 - When embedding `index.html` in the `pete` crate, use `include_str!("../../index.html")`.
 - Keep the chat script in `index.html` and `pete/build.rs` in sync.

--- a/index.html
+++ b/index.html
@@ -15,7 +15,11 @@
       <div id="status" x-text="status" class="text-xs font-semibold text-gray-500"></div>
     </aside>
     <main class="flex flex-col flex-1 p-6 space-y-4">
-      <div id="log" x-ref="log" class="chat-log p-2 bg-gray-50 rounded flex flex-col space-y-1 flex-grow"></div>
+      <ul id="log" x-ref="log" class="chat-log p-2 bg-gray-50 rounded flex flex-col space-y-1 flex-grow list-none">
+        <template x-for="(msg, i) in log" :key="i">
+          <li :class="msg.role" x-text="msg.text"></li>
+        </template>
+      </ul>
       <form class="flex gap-2 mt-auto" @submit.prevent="send">
         <label for="input" class="sr-only">Message</label>
         <input type="text" autofocus class="flex-grow border rounded px-3 py-2" placeholder="Say something..." x-model="input" />

--- a/pete/build.rs
+++ b/pete/build.rs
@@ -77,9 +77,9 @@ fn main() {
                 div { id: "status", "x-text": "status", class: "has-text-weight-bold is-size-7" }
             }
             main { class: "column is-flex is-flex-direction-column p-4",
-                div { id: "log", "x-ref": "log", class: "box is-flex is-flex-direction-column space-y-1 is-flex-grow-1",
-                    template { "x-for": "msg in log", ":key": "msg.id",
-                        div { ":class": "msg.role === 'user' ? 'has-text-info has-text-right' : 'has-text-left'", "x-text": "msg.text" }
+                ul { id: "log", "x-ref": "log", class: "box is-flex is-flex-direction-column space-y-1 is-flex-grow-1 list-style-none",
+                    template { "x-for": "(msg, i) in log", ":key": "i",
+                        li { ":class": "msg.role", "x-text": "msg.text" }
                     }
                 }
                 div { class: "field has-addons mt-auto",

--- a/pete/tests/index.rs
+++ b/pete/tests/index.rs
@@ -11,4 +11,6 @@ async fn serves_index_html() {
             .contains("this.log[this.log.length - 1].text += text")
     );
     assert!(resp.0.contains("audioQueue"));
+    assert!(resp.0.contains("<ul id=\"log\""));
+    assert!(resp.0.contains("<li :class=\"msg.role\""));
 }


### PR DESCRIPTION
## Summary
- use `<ul><li>` in chat log so messages display again
- keep build script markup in sync
- test for new markup
- document `<ul>` chat log requirement in AGENTS

## Testing
- `cargo fmt`
- `cargo fetch`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6850a8d888a083209e2f23e866d8f307