### PR TITLE
Add websocket log streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ cargo run -p pete -- --ollama-url http://localhost:11434 --model mistral
 After starting the server, visit `http://127.0.0.1:3000/` in your browser. The page connects to `ws://localhost:3000/ws` and lets you chat with Pete in real time.
 When the page receives a `pete-says` message it echoes back `{type: "displayed", text}` so the server knows the line was shown.
 
+The page also opens `ws://localhost:3000/log` to stream server logs. Connection statuses for both sockets are shown in the sidebar.
+
 ### Logging
 
 Set `RUST_LOG=info` when running the server to enable helpful tracing output.

--- a/index.html
+++ b/index.html
@@ -11,11 +11,17 @@
 </head>
 <body class="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-50 to-slate-100 font-sans text-gray-800">
   <div x-data="chatApp()" x-init="init()" class="flex w-full max-w-4xl h-[80vh] bg-white rounded-xl shadow overflow-hidden">
-    <aside class="w-48 p-4 bg-gray-100">
+    <aside class="w-48 p-4 bg-gray-100 space-y-2">
       <div id="status" x-text="status" class="text-xs font-semibold text-gray-500"></div>
+      <div id="log-status" x-text="logStatus" class="text-xs font-semibold text-gray-500"></div>
     </aside>
     <main class="flex flex-col flex-1 p-6 space-y-4">
       <div id="log" x-ref="log" class="chat-log p-2 bg-gray-50 rounded flex flex-col space-y-1 flex-grow"></div>
+      <div id="trace" x-ref="trace" class="chat-log p-2 bg-gray-900 text-gray-100 text-xs font-mono rounded flex flex-col space-y-1 h-40 overflow-y-auto">
+        <template x-for="(l, idx) in logs" :key="idx">
+          <div :class="l.level === 'error' ? 'text-red-400' : l.level === 'warn' ? 'text-yellow-300' : l.level === 'debug' ? 'text-gray-400' : 'text-white'" x-text="l.text"></div>
+        </template>
+      </div>
       <form class="flex gap-2 mt-auto" @submit.prevent="send">
         <label for="input" class="sr-only">Message</label>
         <input type="text" autofocus class="flex-grow border rounded px-3 py-2" placeholder="Say something..." x-model="input" />
@@ -27,12 +33,15 @@
     function chatApp() {
       return {
         ws: null,
+        logWs: null,
         status: 'WS: connecting',
+        logStatus: 'LOG: connecting',
         log: [],
+        logs: [],
         input: '',
         audioQueue: [],
         audio: null,
-        init() { this.connect(); },
+        init() { this.connect(); this.connectLog(); },
         connect() {
           if (this.ws && (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING)) {
             return;
@@ -58,6 +67,20 @@
             }
           };
         },
+        connectLog() {
+          if (this.logWs && (this.logWs.readyState === WebSocket.OPEN || this.logWs.readyState === WebSocket.CONNECTING)) {
+            return;
+          }
+          if (this.logWs) { this.logWs.close(); }
+          this.logStatus = 'LOG: connecting';
+          this.logWs = new WebSocket('ws://localhost:3000/log');
+          this.logWs.onopen = () => this.logStatus = 'LOG: open';
+          this.logWs.onclose = () => { this.logStatus = 'LOG: closed'; setTimeout(() => this.connectLog(), 1000); };
+          this.logWs.onerror = () => this.logStatus = 'LOG: error';
+          this.logWs.onmessage = (ev) => {
+            this.appendLog(ev.data);
+          };
+        },
         playNext() {
           if (this.audio || this.audioQueue.length === 0) return;
           const { audio, text } = this.audioQueue.shift();
@@ -81,6 +104,16 @@
             if (atBottom) el.scrollTop = el.scrollHeight;
             if (role !== 'user') this.ws.send(JSON.stringify({ type: 'displayed', text }));
           });
+        },
+        appendLog(line) {
+          const el = this.$refs.trace;
+          const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 2;
+          let level = 'info';
+          if (line.startsWith('ERROR')) level = 'error';
+          else if (line.startsWith('WARN')) level = 'warn';
+          else if (line.startsWith('DEBUG')) level = 'debug';
+          this.logs.push({ text: line, level });
+          this.$nextTick(() => { if (atBottom) el.scrollTop = el.scrollHeight; });
         },
         send() {
           if (!this.input) return;

--- a/pete/src/lib.rs
+++ b/pete/src/lib.rs
@@ -4,6 +4,7 @@
 //! interacting with a [`Psyche`](psyche::Psyche) instance.
 
 mod ear;
+mod logging;
 mod mouth;
 mod psyche_factory;
 #[cfg(feature = "tts")]
@@ -11,8 +12,9 @@ mod tts_mouth;
 mod web;
 
 pub use ear::{ChannelEar, NoopEar};
+pub use logging::init_logging;
 pub use mouth::{ChannelMouth, NoopMouth};
 pub use psyche_factory::{dummy_psyche, ollama_psyche};
 #[cfg(feature = "tts")]
 pub use tts_mouth::{CoquiTts, Tts, TtsMouth};
-pub use web::{AppState, WsRequest, app, index, listen_user_input, ws_handler};
+pub use web::{AppState, WsRequest, app, index, listen_user_input, log_ws_handler, ws_handler};

--- a/pete/src/logging.rs
+++ b/pete/src/logging.rs
@@ -1,0 +1,32 @@
+use std::io::{self, Write};
+use tokio::sync::broadcast;
+use tracing_subscriber::{fmt, util::SubscriberInitExt};
+
+/// Initialize logging to stdout and broadcast log lines over the provided channel.
+pub fn init_logging(tx: broadcast::Sender<String>) {
+    fmt()
+        .with_writer(move || TeeWriter {
+            stdout: std::io::stdout(),
+            tx: tx.clone(),
+        })
+        .init();
+}
+
+struct TeeWriter {
+    stdout: std::io::Stdout,
+    tx: broadcast::Sender<String>,
+}
+
+impl Write for TeeWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let n = self.stdout.write(buf)?;
+        if let Ok(s) = std::str::from_utf8(buf) {
+            let _ = self.tx.send(s.trim_end().to_string());
+        }
+        Ok(n)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.stdout.flush()
+    }
+}

--- a/pete/tests/index.rs
+++ b/pete/tests/index.rs
@@ -4,8 +4,9 @@ use pete::index;
 async fn serves_index_html() {
     let resp = index().await;
     assert!(resp.0.contains("ws://localhost:3000/ws"));
+    assert!(resp.0.contains("ws://localhost:3000/log"));
     assert!(resp.0.contains("WS:"));
-    assert_eq!(resp.0.matches("new WebSocket").count(), 1);
+    assert_eq!(resp.0.matches("new WebSocket").count(), 2);
     assert!(
         resp.0
             .contains("this.log[this.log.length - 1].text += text")


### PR DESCRIPTION
## Summary
- expose websocket log stream at `/log`
- update web client to show logs and connection status
- mirror web changes in build script
- pipe tracing output to websocket listeners
- document new log websocket

## Testing
- `cargo fmt`
- `cargo fetch`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6850a9c10bb08320b920e5fdf17f9362