### PR TITLE
Implement concise default LLM prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This repository contains a Rust workspace with three crates:
 - **lingproc** – helper LLM abstractions re-exported by `psyche`
 - **pete** – a binary crate depending on `psyche`
 
+`Psyche` starts with a prompt asking the LLM to respond in one or two sentences at most. You can override it with `set_system_prompt`.
+
 Example with the `OllamaProvider`:
 
 ```rust,no_run
@@ -43,6 +45,8 @@ let psyche = Psyche::new(
 // replace the dummy mouth with your own implementation
 let mouth = std::sync::Arc::new(DummyMouth);
 psyche.set_mouth(mouth);
+// Customize or replace the default prompt if desired
+psyche.set_system_prompt("Respond with two sentences.");
 psyche.set_echo_timeout(std::time::Duration::from_secs(1));
 psyche.run().await;
 assert!(!psyche.speaking());

--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -7,6 +7,13 @@ use std::time::Duration;
 use tokio::sync::{Mutex, broadcast, mpsc};
 use tracing::{debug, error, info};
 
+/// Default instructions sent to the language model.
+///
+/// The assistant should be concise, replying with no more than two
+/// sentences. It will have additional opportunities to speak. Sending an
+/// empty response indicates a pause where the assistant says nothing.
+pub const DEFAULT_SYSTEM_PROMPT: &str = "Respond with one or two concise sentences at most. You will get another chance to speak. Returning an empty message means you remain silent.";
+
 /// Event types emitted by the [`Psyche`] during conversation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Event {
@@ -110,7 +117,7 @@ impl Psyche {
             vectorizer,
             mouth,
             ear,
-            system_prompt: String::new(),
+            system_prompt: DEFAULT_SYSTEM_PROMPT.to_string(),
             max_history: 8,
             max_turns: 1,
             events_tx,
@@ -125,6 +132,11 @@ impl Psyche {
     /// Change the system prompt.
     pub fn set_system_prompt(&mut self, prompt: impl Into<String>) {
         self.system_prompt = prompt.into();
+    }
+
+    /// Access the current system prompt.
+    pub fn system_prompt(&self) -> &str {
+        &self.system_prompt
     }
 
     /// Limit the number of turns for a run.

--- a/psyche/tests/prompt.rs
+++ b/psyche/tests/prompt.rs
@@ -1,0 +1,65 @@
+use async_trait::async_trait;
+use psyche::ling::{Chatter, Doer, Message, Vectorizer};
+use psyche::{DEFAULT_SYSTEM_PROMPT, Ear, Mouth, Psyche};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+#[derive(Clone, Default)]
+struct Dummy {
+    speaking: std::sync::Arc<AtomicBool>,
+}
+
+#[async_trait]
+impl Mouth for Dummy {
+    async fn speak(&self, _t: &str) {
+        self.speaking.store(true, Ordering::SeqCst);
+    }
+    async fn interrupt(&self) {
+        self.speaking.store(false, Ordering::SeqCst);
+    }
+    fn speaking(&self) -> bool {
+        self.speaking.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl Ear for Dummy {
+    async fn hear_self_say(&self, _t: &str) {
+        self.speaking.store(false, Ordering::SeqCst);
+    }
+    async fn hear_user_say(&self, _t: &str) {}
+}
+
+#[async_trait]
+impl Doer for Dummy {
+    async fn follow(&self, _: &str) -> anyhow::Result<String> {
+        Ok("ok".into())
+    }
+}
+
+#[async_trait]
+impl Chatter for Dummy {
+    async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+        Ok(Box::pin(tokio_stream::once(Ok("hi".to_string()))))
+    }
+}
+
+#[async_trait]
+impl Vectorizer for Dummy {
+    async fn vectorize(&self, _: &str) -> anyhow::Result<Vec<f32>> {
+        Ok(vec![0.0])
+    }
+}
+
+#[test]
+fn default_prompt_present() {
+    let mouth = std::sync::Arc::new(Dummy::default());
+    let ear = mouth.clone();
+    let psyche = Psyche::new(
+        Box::new(Dummy::default()),
+        Box::new(Dummy::default()),
+        Box::new(Dummy::default()),
+        mouth,
+        ear,
+    );
+    assert_eq!(psyche.system_prompt(), DEFAULT_SYSTEM_PROMPT);
+}


### PR DESCRIPTION
## Summary
- introduce `DEFAULT_SYSTEM_PROMPT` and apply it in `Psyche::new`
- expose `system_prompt` getter
- document default behaviour and customization in README
- test that the prompt is applied by default

## Testing
- `cargo fmt`
- `cargo fetch`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6850aacf5c388320b7bdd43c850930cd