### PR TITLE
Add speak-when-spoken-to option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ psyche.set_mouth(mouth);
 // Customize or replace the default prompt if desired
 psyche.set_system_prompt("Respond with two sentences.");
 psyche.set_echo_timeout(std::time::Duration::from_secs(1));
+// make Pete wait for you to speak first
+psyche.set_speak_when_spoken_to(true);
 psyche.run().await;
 assert!(!psyche.speaking());
 ```

--- a/psyche/tests/converse.rs
+++ b/psyche/tests/converse.rs
@@ -51,6 +51,60 @@ impl Vectorizer for Dummy {
 }
 
 #[tokio::test]
+async fn waits_for_user_when_configured() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[derive(Clone, Default)]
+    struct CountingChatter {
+        calls: std::sync::Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl Chatter for CountingChatter {
+        async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(Box::pin(tokio_stream::once(Ok("hi".to_string()))))
+        }
+    }
+
+    let mouth = std::sync::Arc::new(Dummy::default());
+    let ear = mouth.clone();
+    let chatter = CountingChatter::default();
+    let mut psyche = Psyche::new(
+        Box::new(Dummy::default()),
+        Box::new(chatter.clone()),
+        Box::new(Dummy::default()),
+        mouth,
+        ear,
+    );
+    psyche.set_turn_limit(1);
+    psyche.set_speak_when_spoken_to(true);
+
+    let mut events = psyche.subscribe();
+    let input = psyche.input_sender();
+
+    let handle = tokio::spawn(async move { psyche.run().await });
+
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    assert_eq!(chatter.calls.load(Ordering::SeqCst), 0);
+
+    input
+        .send(Sensation::HeardUserVoice("hello".into()))
+        .unwrap();
+
+    while let Ok(evt) = events.recv().await {
+        if let Event::IntentionToSay(msg) = evt {
+            input.send(Sensation::HeardOwnVoice(msg)).unwrap();
+            break;
+        }
+    }
+
+    let psyche = handle.await.unwrap();
+    assert_eq!(chatter.calls.load(Ordering::SeqCst), 1);
+    assert!(!psyche.speaking());
+}
+
+#[tokio::test]
 async fn adds_message_after_voice_heard() {
     let mouth = std::sync::Arc::new(Dummy::default());
     let ear = mouth.clone();


### PR DESCRIPTION
## Summary
- add `speak_when_spoken_to` behavior to `Psyche`
- document the option in README
- test the new conversation mode

## Testing
- `cargo fetch`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6850ad910848832099bf17f0fbf348a8