### PR TITLE
Expose conversation log endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,18 @@ When the page receives a `pete-says` message it echoes back `{type: "displayed",
 
 The page also opens `ws://localhost:3000/log` to stream server logs. Connection statuses for both sockets are shown in the sidebar.
 
+Fetch the raw conversation log at `/conversation`:
+
+```sh
+curl http://127.0.0.1:3000/conversation
+```
+
+Which returns JSON like:
+
+```json
+[{"role":"user","content":"Hi"}]
+```
+
 ### Logging
 
 Set `RUST_LOG=info` when running the server to enable helpful tracing output.

--- a/pete/src/lib.rs
+++ b/pete/src/lib.rs
@@ -17,4 +17,7 @@ pub use mouth::{ChannelMouth, NoopMouth};
 pub use psyche_factory::{dummy_psyche, ollama_psyche};
 #[cfg(feature = "tts")]
 pub use tts_mouth::{CoquiTts, Tts, TtsMouth};
-pub use web::{AppState, WsRequest, app, index, listen_user_input, log_ws_handler, ws_handler};
+pub use web::{
+    AppState, WsRequest, app, conversation_log, index, listen_user_input, log_ws_handler,
+    ws_handler,
+};

--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -36,9 +36,10 @@ async fn main() -> anyhow::Result<()> {
     let mouth = Arc::new(ChannelMouth::new(psyche.event_sender(), speaking.clone()));
     psyche.set_mouth(mouth.clone());
     let events = Arc::new(psyche.subscribe());
+    let conversation = psyche.conversation();
     let ear = Arc::new(ChannelEar::new(
         psyche.input_sender(),
-        psyche.conversation(),
+        conversation.clone(),
         speaking.clone(),
     ));
     let (user_tx, user_rx) = mpsc::unbounded_channel();
@@ -54,6 +55,7 @@ async fn main() -> anyhow::Result<()> {
         events: events.clone(),
         logs: Arc::new(log_tx.subscribe()),
         ear: ear.clone(),
+        conversation,
     };
     let app = app(state);
 

--- a/pete/tests/conversation.rs
+++ b/pete/tests/conversation.rs
@@ -1,0 +1,31 @@
+use axum::{body, extract::State, response::IntoResponse};
+use pete::{AppState, ChannelEar, conversation_log, dummy_psyche};
+use std::sync::{Arc, atomic::AtomicBool};
+use tokio::sync::{broadcast, mpsc};
+
+#[tokio::test]
+async fn returns_log_json() {
+    let psyche = dummy_psyche();
+    let conversation = psyche.conversation();
+    conversation.lock().await.add_user("hi".into());
+    let ear = Arc::new(ChannelEar::new(
+        psyche.input_sender(),
+        conversation.clone(),
+        Arc::new(AtomicBool::new(false)),
+    ));
+    let (event_tx, _) = broadcast::channel(8);
+    let (log_tx, _) = broadcast::channel(8);
+    let (user_tx, _user_rx) = mpsc::unbounded_channel();
+    let state = AppState {
+        user_input: user_tx,
+        events: Arc::new(event_tx.subscribe()),
+        logs: Arc::new(log_tx.subscribe()),
+        ear,
+        conversation,
+    };
+    let resp = conversation_log(State(state)).await.into_response();
+    let body = body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let msgs: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(msgs[0]["role"], "user");
+    assert_eq!(msgs[0]["content"], "hi");
+}


### PR DESCRIPTION
## Summary
- add `/conversation` route to return conversation log as JSON
- expose new route from library and binary
- document the endpoint in the README
- test the new handler

## Testing
- `cargo fetch`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6850b18e43d08320a894ed0c48c5bb5a