### PR TITLE
merge consecutive messages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,3 +29,4 @@ This repository is now a Rust workspace.
 - Compose multiple `Mouth` implementations using `AndMouth` when both audio and
   textual output are required.
 - `ChannelMouth` emits `Event::IntentionToSay` for each parsed sentence.
+- `Conversation::add_*` should merge consecutive messages from the same role.

--- a/lingproc/src/types.rs
+++ b/lingproc/src/types.rs
@@ -10,7 +10,7 @@ pub trait Doer: Send + Sync {
 }
 
 /// Speaker roles for a chat message.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Role {
     Assistant,
     User,


### PR DESCRIPTION
## Summary
- keep conversation log cleaner by merging same-speaker messages
- test Conversation message merging
- derive PartialEq/Eq for `Role`
- document merging rule in `AGENTS.md`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6850b5d1f5348320a515256b3b8d2130