### PR TITLE
Switch PETE to natural-tts

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ let display = std::sync::Arc::new(pete::ChannelMouth::new(psyche.event_sender(),
 let tts = std::sync::Arc::new(pete::TtsMouth::new(
     psyche.event_sender(),
     speaking.clone(),
-    std::sync::Arc::new(pete::CoquiTts::new().unwrap()),
+    std::sync::Arc::new(pete::EdgeTts::new()),
 ));
 #[cfg(feature = "tts")]
 let mouth = std::sync::Arc::new(psyche::AndMouth::new(vec![display.clone(), tts]));

--- a/pete/Cargo.toml
+++ b/pete/Cargo.toml
@@ -19,12 +19,12 @@ tracing-subscriber = { version = "0.3", features = ["fmt"] }
 pragmatic-segmenter = "0.1"
 dioxus = { version = "0.4.3", default-features = false, features = ["html", "macro"] }
 dioxus-ssr = "0.4.3"
-pyo3 = { version = "0.20", features = ["auto-initialize"], optional = true }
+natural-tts = { version = "0.2", default-features = false, features = ["msedge"], optional = true }
 base64 = { version = "0.21", optional = true }
 
 [features]
 default = []
-tts = ["pyo3", "base64"]
+tts = ["natural-tts", "base64"]
 
 [build-dependencies]
 dioxus = { version = "0.4.3", default-features = false, features = ["html", "macro"] }

--- a/pete/src/lib.rs
+++ b/pete/src/lib.rs
@@ -16,7 +16,7 @@ pub use logging::init_logging;
 pub use mouth::{ChannelMouth, NoopMouth};
 pub use psyche_factory::{dummy_psyche, ollama_psyche};
 #[cfg(feature = "tts")]
-pub use tts_mouth::{CoquiTts, Tts, TtsMouth};
+pub use tts_mouth::{EdgeTts, Tts, TtsMouth};
 pub use web::{
     AppState, WsRequest, app, conversation_log, index, listen_user_input, log_ws_handler,
     ws_handler,

--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -3,7 +3,7 @@ use pete::{
     AppState, ChannelEar, ChannelMouth, app, init_logging, listen_user_input, ollama_psyche,
 };
 #[cfg(feature = "tts")]
-use pete::{CoquiTts, TtsMouth};
+use pete::{EdgeTts, TtsMouth};
 use psyche::{AndMouth, Mouth};
 use std::{
     net::SocketAddr,
@@ -41,7 +41,7 @@ async fn main() -> anyhow::Result<()> {
     let audio = Arc::new(TtsMouth::new(
         psyche.event_sender(),
         speaking.clone(),
-        Arc::new(CoquiTts::new()?),
+        Arc::new(EdgeTts::new()),
     ));
     #[cfg(feature = "tts")]
     let mouth = Arc::new(AndMouth::new(vec![


### PR DESCRIPTION
## Summary
- swap Python-based TTS for `natural-tts`
- use Edge voice "Anna" by default
- stream wav bytes to the browser

## Testing
- `cargo fetch`
- `cargo fmt`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6850bd45c24c83209d6037c09c692591