### PR TITLE
Add TrimMouth wrapper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,3 +30,5 @@ This repository is now a Rust workspace.
   textual output are required.
 - `ChannelMouth` emits `Event::IntentionToSay` for each parsed sentence.
 - `Conversation::add_*` should merge consecutive messages from the same role.
+- Use `TrimMouth` to remove whitespace before speaking; skip speech when the
+  trimmed text is empty.

--- a/README.md
+++ b/README.md
@@ -53,8 +53,11 @@ let tts = std::sync::Arc::new(pete::TtsMouth::new(
 ));
 #[cfg(feature = "tts")]
 let mouth = std::sync::Arc::new(psyche::AndMouth::new(vec![display.clone(), tts]));
+#[cfg(feature = "tts")]
+let mouth = std::sync::Arc::new(psyche::TrimMouth::new(mouth));
 #[cfg(not(feature = "tts"))]
 let mouth = display.clone() as std::sync::Arc<dyn Mouth>;
+let mouth = std::sync::Arc::new(psyche::TrimMouth::new(mouth));
 psyche.set_mouth(mouth);
 // Customize or replace the default prompt if desired
 psyche.set_system_prompt("Respond with two sentences.");

--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -1,6 +1,8 @@
 mod and_mouth;
 pub mod ling;
+mod trim_mouth;
 pub use and_mouth::AndMouth;
+pub use trim_mouth::TrimMouth;
 
 use async_trait::async_trait;
 use ling::{Chatter, Doer, Message, Role, Vectorizer};

--- a/psyche/src/trim_mouth.rs
+++ b/psyche/src/trim_mouth.rs
@@ -1,0 +1,56 @@
+//! Mouth wrapper that trims leading and trailing whitespace.
+//!
+//! `TrimMouth` forwards speech to an inner [`Mouth`] only if the
+//! trimmed text is not empty. This helps avoid speaking stray
+//! whitespace emitted by language models.
+//!
+//! ```no_run
+//! use psyche::{TrimMouth, Mouth};
+//! use std::sync::Arc;
+//!
+//! # struct Dummy;
+//! # #[async_trait::async_trait]
+//! # impl Mouth for Dummy {
+//! #     async fn speak(&self, _t: &str) {}
+//! #     async fn interrupt(&self) {}
+//! #     fn speaking(&self) -> bool { false }
+//! # }
+//! let inner = Arc::new(Dummy) as Arc<dyn Mouth>;
+//! let mouth = TrimMouth::new(inner);
+//! mouth.speak("  hello  ");
+//! ```
+use crate::Mouth;
+use async_trait::async_trait;
+use std::sync::Arc;
+
+/// [`Mouth`] implementation that trims text before speaking.
+#[derive(Clone)]
+pub struct TrimMouth {
+    inner: Arc<dyn Mouth>,
+}
+
+impl TrimMouth {
+    /// Create a new [`TrimMouth`] wrapping `inner`.
+    pub fn new(inner: Arc<dyn Mouth>) -> Self {
+        Self { inner }
+    }
+}
+
+#[async_trait]
+impl Mouth for TrimMouth {
+    async fn speak(&self, text: &str) {
+        let trimmed = text.trim();
+        if trimmed.is_empty() {
+            return;
+        }
+        self.inner.speak(trimmed).await;
+    }
+
+    async fn interrupt(&self) {
+        self.inner.interrupt().await;
+    }
+
+    fn speaking(&self) -> bool {
+        self.inner.speaking()
+    }
+}

--- a/psyche/tests/trim_mouth.rs
+++ b/psyche/tests/trim_mouth.rs
@@ -1,0 +1,37 @@
+use async_trait::async_trait;
+use psyche::{Mouth, TrimMouth};
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicUsize, Ordering},
+};
+
+#[derive(Clone, Default)]
+struct RecordingMouth {
+    count: Arc<AtomicUsize>,
+    last: Arc<Mutex<Option<String>>>,
+}
+
+#[async_trait]
+impl Mouth for RecordingMouth {
+    async fn speak(&self, text: &str) {
+        self.count.fetch_add(1, Ordering::SeqCst);
+        *self.last.lock().unwrap() = Some(text.to_string());
+    }
+    async fn interrupt(&self) {}
+    fn speaking(&self) -> bool {
+        false
+    }
+}
+
+#[tokio::test]
+async fn trims_and_skips_empty() {
+    let inner = Arc::new(RecordingMouth::default());
+    let mouth = TrimMouth::new(inner.clone() as Arc<dyn Mouth>);
+
+    mouth.speak("  hi  ").await;
+    assert_eq!(inner.count.load(Ordering::SeqCst), 1);
+    assert_eq!(inner.last.lock().unwrap().as_deref(), Some("hi"));
+
+    mouth.speak("   ").await;
+    assert_eq!(inner.count.load(Ordering::SeqCst), 1);
+}


### PR DESCRIPTION
## Summary
- add `TrimMouth` to trim whitespace before speaking
- wrap mouth with `TrimMouth` in README example
- document `TrimMouth` usage in AGENTS.md
- test trimming behaviour

## Testing
- `cargo fmt`
- `cargo fetch`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6850bfa133408320b25f2cbf732b12ed