### PR TITLE
Fix browser audio auto-play

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,7 +97,18 @@
             this.ws.send(JSON.stringify({ type: 'played', text }));
             this.playNext();
           };
-          this.audio.play();
+          const p = this.audio.play();
+          if (p !== undefined) {
+            p.catch(err => {
+              if (err.name === 'NotAllowedError') {
+                const resume = () => {
+                  document.removeEventListener('click', resume);
+                  this.audio.play();
+                };
+                document.addEventListener('click', resume);
+              }
+            });
+          }
         },
         append(role, text) {
           const el = this.$refs.log;

--- a/pete/build.rs
+++ b/pete/build.rs
@@ -63,7 +63,18 @@ const SCRIPT: &str = r#"function chatApp() {
         this.ws.send(JSON.stringify({ type: 'played', text }));
         this.playNext();
       };
-      this.audio.play();
+      const p = this.audio.play();
+      if (p !== undefined) {
+        p.catch(err => {
+          if (err.name === 'NotAllowedError') {
+            const resume = () => {
+              document.removeEventListener('click', resume);
+              this.audio.play();
+            };
+            document.addEventListener('click', resume);
+          }
+        });
+      }
     },
     append(role, text) {
       const el = this.$refs.log;


### PR DESCRIPTION
## Summary
- handle autoplay restrictions by deferring audio playback until user interaction
- keep `index.html` and `pete/build.rs` chat scripts in sync

## Testing
- `cargo fetch`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6850c7b1c85483208928e34ee11efa88