### PR TITLE
Add Countenance support

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ let mouth = std::sync::Arc::new(psyche::TrimMouth::new(mouth));
 let mouth = display.clone() as std::sync::Arc<dyn Mouth>;
 let mouth = std::sync::Arc::new(psyche::TrimMouth::new(mouth));
 psyche.set_mouth(mouth);
+#[derive(Default)]
+struct DummyFace;
+impl psyche::Countenance for DummyFace {
+    fn express(&self, _emoji: &str) {}
+}
+let face = std::sync::Arc::new(DummyFace::default());
+psyche.set_countenance(face);
+psyche.set_emotion("😊");
 // Customize or replace the default prompt if desired
 psyche.set_system_prompt("Respond with two sentences.");
 psyche.set_echo_timeout(std::time::Duration::from_secs(1));

--- a/psyche/Cargo.toml
+++ b/psyche/Cargo.toml
@@ -12,6 +12,7 @@ tokio-stream = { version = "0.1", features = ["sync"] }
 tracing = "0.1"
 lingproc = { path = "../lingproc" }
 futures = "0.3"
+serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/psyche/src/countenance.rs
+++ b/psyche/src/countenance.rs
@@ -1,0 +1,16 @@
+/// Emotional display output.
+///
+/// Implementations update some representation of Pete's face or
+/// an external UI element with an emoji.
+pub trait Countenance: Send + Sync {
+    /// Express the provided emoji, e.g. "😊".
+    fn express(&self, emoji: &str);
+}
+
+/// [`Countenance`] implementation that does nothing.
+#[derive(Clone, Default)]
+pub struct NoopCountenance;
+
+impl Countenance for NoopCountenance {
+    fn express(&self, _emoji: &str) {}
+}

--- a/psyche/src/impression.rs
+++ b/psyche/src/impression.rs
@@ -1,0 +1,14 @@
+use serde::{Deserialize, Serialize};
+
+/// A distilled perception captured by a Wit layer.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Impression<T> {
+    /// One-sentence summary for vector storage.
+    pub headline: String,
+    /// Optional paragraph providing more detail.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub details: Option<String>,
+    /// Serializable raw payload saved in the graph database.
+    #[serde(rename = "rawData")]
+    pub raw_data: T,
+}

--- a/psyche/tests/countenance.rs
+++ b/psyche/tests/countenance.rs
@@ -1,0 +1,70 @@
+use async_trait::async_trait;
+use psyche::ling::{Chatter, Doer, Message, Vectorizer};
+use psyche::{Countenance, NoopCountenance, Psyche};
+use psyche::{Ear, Mouth};
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone, Default)]
+struct Dummy;
+
+#[async_trait]
+impl Mouth for Dummy {
+    async fn speak(&self, _t: &str) {}
+    async fn interrupt(&self) {}
+    fn speaking(&self) -> bool {
+        false
+    }
+}
+
+#[async_trait]
+impl Ear for Dummy {
+    async fn hear_self_say(&self, _t: &str) {}
+    async fn hear_user_say(&self, _t: &str) {}
+}
+
+#[async_trait]
+impl Doer for Dummy {
+    async fn follow(&self, _: &str) -> anyhow::Result<String> {
+        Ok("ok".into())
+    }
+}
+
+#[async_trait]
+impl Chatter for Dummy {
+    async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+        Ok(Box::pin(tokio_stream::empty()))
+    }
+}
+
+#[async_trait]
+impl Vectorizer for Dummy {
+    async fn vectorize(&self, _: &str) -> anyhow::Result<Vec<f32>> {
+        Ok(vec![0.0])
+    }
+}
+
+#[derive(Clone, Default)]
+struct RecordingFace(Arc<Mutex<Option<String>>>);
+
+impl Countenance for RecordingFace {
+    fn express(&self, emoji: &str) {
+        *self.0.lock().unwrap() = Some(emoji.to_string());
+    }
+}
+
+#[test]
+fn set_emotion_calls_countenance() {
+    let mouth = Arc::new(Dummy);
+    let ear = Arc::new(Dummy);
+    let mut psyche = Psyche::new(
+        Box::new(Dummy),
+        Box::new(Dummy),
+        Box::new(Dummy),
+        mouth,
+        ear,
+    );
+    let face = Arc::new(RecordingFace::default());
+    psyche.set_countenance(face.clone());
+    psyche.set_emotion("😠");
+    assert_eq!(face.0.lock().unwrap().as_deref(), Some("😠"));
+}


### PR DESCRIPTION
## Summary
- introduce `Countenance` trait and `Impression` struct
- expose APIs for setting emotion in `Psyche`
- update README example to show emotional API usage
- add serde dependency and tests for countenance

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6850fbb54a88832099bb2d76f60dcb3b