### PR TITLE
Introduce Wit trait

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ This repository is now a Rust workspace.
 - Crate `pete` depends on the local `psyche` crate.
 - Keep examples and inline docs up to date with code changes.
 - Update README examples whenever new public APIs are added.
+- Document new traits like `Wit` with examples and tests.
 - When adding binary arguments or library APIs, update tests accordingly.
 - Keep `index.html` minimal and updated to connect to `ws://localhost:3000/ws`.
 - Display the WebSocket connection status in the page for debugging.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ This repository contains a Rust workspace with three crates:
 - **lingproc** – helper LLM abstractions re-exported by `psyche`
 - **pete** – a binary crate depending on `psyche`
 
+The `psyche` crate also defines a `Wit` trait used to build modular
+cognitive layers. Each `Wit` asynchronously processes input and
+produces an `Impression<T>` summarizing its observation.
+
 `Psyche` starts with a prompt asking the LLM to respond in one or two sentences at most. You can override it with `set_system_prompt`.
 
 Example with the `OllamaProvider`:

--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -3,10 +3,12 @@ mod countenance;
 mod impression;
 pub mod ling;
 mod trim_mouth;
+mod wit;
 pub use and_mouth::AndMouth;
 pub use countenance::{Countenance, NoopCountenance};
 pub use impression::Impression;
 pub use trim_mouth::TrimMouth;
+pub use wit::Wit;
 
 use async_trait::async_trait;
 use ling::{Chatter, Doer, Message, Role, Vectorizer};

--- a/psyche/src/wit.rs
+++ b/psyche/src/wit.rs
@@ -1,0 +1,43 @@
+use crate::Impression;
+use async_trait::async_trait;
+
+/// A cognitive unit that distills input into an [`Impression`].
+///
+/// Wits operate asynchronously and may be chained together to form
+/// layered cognition. The `process` method consumes input and returns
+/// an impression summarizing it.
+#[async_trait]
+pub trait Wit<I, O>: Send + Sync {
+    /// Process the input and produce an impression.
+    async fn process(&self, input: I) -> Impression<O>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+
+    #[derive(Default)]
+    struct EchoWit;
+
+    /// A trivial [`Wit`] used for tests that wraps the input string
+    /// into an [`Impression`].
+    #[async_trait]
+    impl Wit<String, String> for EchoWit {
+        async fn process(&self, input: String) -> Impression<String> {
+            Impression {
+                headline: input.clone(),
+                details: None,
+                raw_data: input,
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn echo_wit_returns_impression() {
+        let wit = EchoWit::default();
+        let imp = wit.process("hi".to_string()).await;
+        assert_eq!(imp.headline, "hi");
+        assert_eq!(imp.raw_data, "hi");
+    }
+}


### PR DESCRIPTION
## Summary
- add new `Wit` trait for modular cognition with example test
- document the trait in README
- note to document new traits in `AGENTS.md`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68517dcdf9688320b73814c2a2b4883c