### PR TITLE
Add Heart wit for emotion

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ impl Ear for DummyEar {
     async fn hear_user_say(&self, _t: &str) {}
 }
 
+struct DummyVoice;
+#[async_trait]
+impl psyche::ling::Chatter for DummyVoice {
+    async fn chat(&self, _s: &str, _h: &[psyche::ling::Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+        Ok(Box::pin(tokio_stream::once(Ok("😊".to_string()))))
+    }
+}
+
 let psyche = Psyche::new(
     Box::new(narrator),
     Box::new(voice),
@@ -71,6 +79,10 @@ impl psyche::Countenance for DummyFace {
 let face = std::sync::Arc::new(DummyFace::default());
 psyche.set_countenance(face);
 psyche.set_emotion("😊");
+// Determine emotion from text using the Heart
+let heart = psyche::Heart::new(Box::new(DummyVoice));
+let imp = heart.process("Great!".to_string()).await;
+assert_eq!(imp.raw_data, "😊");
 // Customize or replace the default prompt if desired
 psyche.set_system_prompt("Respond with two sentences.");
 psyche.set_echo_timeout(std::time::Duration::from_secs(1));

--- a/psyche/src/heart.rs
+++ b/psyche/src/heart.rs
@@ -1,0 +1,71 @@
+use crate::{
+    Impression, Wit,
+    ling::{Chatter, Message, Role},
+};
+use async_trait::async_trait;
+use std::sync::Arc;
+use tokio_stream::StreamExt;
+
+/// Determine the emotional tone of text using an LLM.
+///
+/// `Heart` sends the provided text to a [`Chatter`] with a prompt asking
+/// for an emoji summarizing the emotion. The resulting emoji is wrapped
+/// in an [`Impression`].
+///
+/// # Example
+/// ```no_run
+/// # use psyche::{Heart, ling::{Chatter, Message}, Impression, Wit};
+/// # use async_trait::async_trait;
+/// # struct Dummy;
+/// # #[async_trait]
+/// # impl Chatter for Dummy {
+/// #   async fn chat(&self, _s: &str, _h: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+/// #       Ok(Box::pin(tokio_stream::once(Ok("😊".to_string()))))
+/// #   }
+/// # }
+/// # #[tokio::main]
+/// # async fn main() {
+/// let heart = Heart::new(Box::new(Dummy));
+/// let imp = heart.process("Great job!".to_string()).await;
+/// assert_eq!(imp.raw_data, "😊");
+/// # }
+/// ```
+#[derive(Clone)]
+pub struct Heart {
+    chatter: Arc<dyn Chatter>,
+}
+
+impl Heart {
+    /// Create a new `Heart` using the given [`Chatter`].
+    pub fn new(chatter: Box<dyn Chatter>) -> Self {
+        Self {
+            chatter: chatter.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl Wit<String, String> for Heart {
+    async fn process(&self, input: String) -> Impression<String> {
+        let prompt = "Respond with a single emoji describing the overall emotion";
+        let history = [Message {
+            role: Role::User,
+            content: input.clone(),
+        }];
+        let mut stream = self
+            .chatter
+            .chat(prompt, &history)
+            .await
+            .unwrap_or_else(|_| Box::pin(tokio_stream::empty()));
+        let mut resp = String::new();
+        while let Some(chunk) = stream.next().await.transpose().unwrap_or_default() {
+            resp.push_str(&chunk);
+        }
+        let emoji = resp.trim().to_string();
+        Impression {
+            headline: emoji.clone(),
+            details: None,
+            raw_data: emoji,
+        }
+    }
+}

--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -1,11 +1,13 @@
 mod and_mouth;
 mod countenance;
+mod heart;
 mod impression;
 pub mod ling;
 mod trim_mouth;
 mod wit;
 pub use and_mouth::AndMouth;
 pub use countenance::{Countenance, NoopCountenance};
+pub use heart::Heart;
 pub use impression::Impression;
 pub use trim_mouth::TrimMouth;
 pub use wit::Wit;

--- a/psyche/tests/heart.rs
+++ b/psyche/tests/heart.rs
@@ -1,0 +1,22 @@
+use async_trait::async_trait;
+use psyche::ling::{Chatter, Message};
+use psyche::{Heart, Wit};
+use tokio_stream::once;
+
+#[derive(Clone)]
+struct Dummy;
+
+#[async_trait]
+impl Chatter for Dummy {
+    async fn chat(&self, _p: &str, _h: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+        Ok(Box::pin(once(Ok("😊".to_string()))))
+    }
+}
+
+#[tokio::test]
+async fn returns_emoji_impression() {
+    let heart = Heart::new(Box::new(Dummy));
+    let imp = heart.process("hello".to_string()).await;
+    assert_eq!(imp.raw_data, "😊");
+    assert_eq!(imp.headline, "😊");
+}


### PR DESCRIPTION
## Summary
- implement `Heart` Wit for emoji-based emotion detection
- expose `Heart` from `psyche`
- document `Heart` in README example
- add tests for `Heart`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68518b63cedc832099d6c3f2ca70bc8d