### PR TITLE
Add Will wit

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ psyche.set_emotion("😊");
 let heart = psyche::Heart::new(Box::new(DummyVoice));
 let imp = heart.process("Great!".to_string()).await;
 assert_eq!(imp.raw_data, "😊");
+// Ask the Will what to do next
+let will = psyche::Will::new(Box::new(DummyVoice));
+let decision = will.process("say hi".to_string()).await;
+assert_eq!(decision.headline, "Speak.");
 // Customize or replace the default prompt if desired
 psyche.set_system_prompt("Respond with two sentences.");
 psyche.set_echo_timeout(std::time::Duration::from_secs(1));

--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -4,12 +4,14 @@ mod heart;
 mod impression;
 pub mod ling;
 mod trim_mouth;
+mod will;
 mod wit;
 pub use and_mouth::AndMouth;
 pub use countenance::{Countenance, NoopCountenance};
 pub use heart::Heart;
 pub use impression::Impression;
 pub use trim_mouth::TrimMouth;
+pub use will::Will;
 pub use wit::Wit;
 
 use async_trait::async_trait;

--- a/psyche/src/will.rs
+++ b/psyche/src/will.rs
@@ -1,0 +1,72 @@
+use crate::{
+    Impression, Wit,
+    ling::{Chatter, Message, Role},
+};
+use async_trait::async_trait;
+use std::sync::Arc;
+use tokio_stream::StreamExt;
+
+/// Decide Pete's next action or speech using a language model.
+///
+/// `Will` sends the given situation summary to a [`Chatter`] with a
+/// brief prompt asking for a single sentence describing what Pete
+/// should do or say next. The decision is returned as an
+/// [`Impression`].
+///
+/// # Example
+/// ```no_run
+/// # use psyche::{Will, ling::{Chatter, Message}, Impression, Wit};
+/// # use async_trait::async_trait;
+/// # struct Dummy;
+/// # #[async_trait]
+/// # impl Chatter for Dummy {
+/// #   async fn chat(&self, _p: &str, _h: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+/// #       Ok(Box::pin(tokio_stream::once(Ok("Speak.".to_string()))))
+/// #   }
+/// # }
+/// # #[tokio::main]
+/// # async fn main() {
+/// let will = Will::new(Box::new(Dummy));
+/// let imp = will.process("greet the user".to_string()).await;
+/// assert_eq!(imp.raw_data, "Speak.");
+/// # }
+/// ```
+#[derive(Clone)]
+pub struct Will {
+    chatter: Arc<dyn Chatter>,
+}
+
+impl Will {
+    /// Create a new `Will` using the provided [`Chatter`].
+    pub fn new(chatter: Box<dyn Chatter>) -> Self {
+        Self {
+            chatter: chatter.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl Wit<String, String> for Will {
+    async fn process(&self, input: String) -> Impression<String> {
+        let prompt = "In one short sentence, what should Pete do or say next?";
+        let history = [Message {
+            role: Role::User,
+            content: input.clone(),
+        }];
+        let mut stream = self
+            .chatter
+            .chat(prompt, &history)
+            .await
+            .unwrap_or_else(|_| Box::pin(tokio_stream::empty()));
+        let mut resp = String::new();
+        while let Some(chunk) = stream.next().await.transpose().unwrap_or_default() {
+            resp.push_str(&chunk);
+        }
+        let decision = resp.trim().to_string();
+        Impression {
+            headline: decision.clone(),
+            details: None,
+            raw_data: decision,
+        }
+    }
+}

--- a/psyche/tests/will.rs
+++ b/psyche/tests/will.rs
@@ -1,0 +1,21 @@
+use psyche::ling::{Chatter, Message};
+use psyche::{Will, Wit};
+use tokio_stream::once;
+
+#[derive(Clone)]
+struct Dummy;
+
+#[async_trait::async_trait]
+impl Chatter for Dummy {
+    async fn chat(&self, _p: &str, _h: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+        Ok(Box::pin(once(Ok("Do it".to_string()))))
+    }
+}
+
+#[tokio::test]
+async fn returns_decision_impression() {
+    let will = Will::new(Box::new(Dummy));
+    let imp = will.process("now".to_string()).await;
+    assert_eq!(imp.raw_data, "Do it");
+    assert_eq!(imp.headline, "Do it");
+}


### PR DESCRIPTION
## Summary
- expose a new `Will` Wit for deciding Pete's next action
- export `Will` in the psyche crate
- document using `Will` in the README
- test `Will`

## Testing
- `cargo fmt`
- `cargo fetch`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68518e9ee0ac8320bafd577f888636fc