### PR TITLE
Implement ChannelCountenance and emotion events

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ This repository is now a Rust workspace.
 - Compose multiple `Mouth` implementations using `AndMouth` when both audio and
   textual output are required.
 - `ChannelMouth` emits `Event::IntentionToSay` for each parsed sentence.
+- `ChannelCountenance` emits `Event::EmotionChanged` when the emotion updates.
 - `Conversation::add_*` should merge consecutive messages from the same role.
 - Use `TrimMouth` to remove whitespace before speaking; skip speech when the
   trimmed text is empty.

--- a/README.md
+++ b/README.md
@@ -71,12 +71,7 @@ let mouth = std::sync::Arc::new(psyche::TrimMouth::new(mouth));
 let mouth = display.clone() as std::sync::Arc<dyn Mouth>;
 let mouth = std::sync::Arc::new(psyche::TrimMouth::new(mouth));
 psyche.set_mouth(mouth);
-#[derive(Default)]
-struct DummyFace;
-impl psyche::Countenance for DummyFace {
-    fn express(&self, _emoji: &str) {}
-}
-let face = std::sync::Arc::new(DummyFace::default());
+let face = std::sync::Arc::new(pete::ChannelCountenance::new(psyche.event_sender()));
 psyche.set_countenance(face);
 psyche.set_emotion("😊");
 // Determine emotion from text using the Heart
@@ -112,6 +107,7 @@ cargo run -p pete -- --ollama-url http://localhost:11434 --model mistral
 
 After starting the server, visit `http://127.0.0.1:3000/` in your browser. The page connects to `ws://localhost:3000/ws` and lets you chat with Pete in real time.
 When the page receives a `pete-says` message it echoes back `{type: "displayed", text}` so the server knows the line was shown. Connection status is shown in the sidebar.
+Emotion updates arrive via `pete-emotion` messages containing an emoji string.
 
 Fetch the raw conversation log at `/conversation`:
 

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
   <div x-data="chatApp()" x-init="init()" class="flex w-full max-w-4xl h-[80vh] bg-white rounded-xl shadow overflow-hidden">
     <aside class="w-48 p-4 bg-gray-100 space-y-2">
       <div id="status" x-text="status" class="text-xs font-semibold text-gray-500"></div>
+      <div id="face" x-text="emotion" class="text-4xl"></div>
       <audio controls x-ref="player" class="w-full"></audio>
     </aside>
     <main class="flex flex-col flex-1 p-6 space-y-4">
@@ -39,6 +40,7 @@
         log: [],
         input: '',
         lastText: '',
+        emotion: '😐',
         audioQueue: [],
         audio: null,
         init() { this.connect(); },
@@ -55,7 +57,9 @@
           this.ws.onmessage = (ev) => {
             try {
               const data = JSON.parse(ev.data);
-              if (data.text) {
+              if (data.kind === 'pete-emotion') {
+                this.emotion = data.text;
+              } else if (data.text) {
                 this.lastText = data.text;
                 this.append('system', data.text);
               }

--- a/pete/src/face.rs
+++ b/pete/src/face.rs
@@ -1,0 +1,29 @@
+use psyche::{Countenance, Event};
+use tokio::sync::broadcast;
+
+/// [`Countenance`] implementation that forwards emoji updates over a broadcast channel.
+#[derive(Clone)]
+pub struct ChannelCountenance {
+    events: broadcast::Sender<Event>,
+}
+
+impl ChannelCountenance {
+    /// Create a new `ChannelCountenance` using the given [`broadcast::Sender`].
+    pub fn new(events: broadcast::Sender<Event>) -> Self {
+        Self { events }
+    }
+}
+
+impl Countenance for ChannelCountenance {
+    fn express(&self, emoji: &str) {
+        let _ = self.events.send(Event::EmotionChanged(emoji.to_string()));
+    }
+}
+
+/// No-op [`Countenance`] used when no feedback channel is available.
+#[derive(Clone, Default)]
+pub struct NoopFace;
+
+impl Countenance for NoopFace {
+    fn express(&self, _emoji: &str) {}
+}

--- a/pete/src/lib.rs
+++ b/pete/src/lib.rs
@@ -4,6 +4,7 @@
 //! interacting with a [`Psyche`](psyche::Psyche) instance.
 
 mod ear;
+mod face;
 mod logging;
 mod mouth;
 mod psyche_factory;
@@ -12,6 +13,7 @@ mod tts_mouth;
 mod web;
 
 pub use ear::{ChannelEar, NoopEar};
+pub use face::{ChannelCountenance, NoopFace};
 pub use logging::init_logging;
 pub use mouth::{ChannelMouth, NoopMouth};
 pub use psyche_factory::{dummy_psyche, ollama_psyche};

--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 use pete::{
-    AppState, ChannelEar, ChannelMouth, app, init_logging, listen_user_input, ollama_psyche,
+    AppState, ChannelCountenance, ChannelEar, ChannelMouth, app, init_logging, listen_user_input,
+    ollama_psyche,
 };
 #[cfg(feature = "tts")]
 use pete::{CoquiTts, TtsMouth};
@@ -44,6 +45,7 @@ async fn main() -> anyhow::Result<()> {
     let speaking = Arc::new(AtomicBool::new(false));
     let connections = Arc::new(AtomicUsize::new(0));
     let display = Arc::new(ChannelMouth::new(psyche.event_sender(), speaking.clone()));
+    let face = Arc::new(ChannelCountenance::new(psyche.event_sender()));
     #[cfg(feature = "tts")]
     let audio = Arc::new(TtsMouth::new(
         psyche.event_sender(),
@@ -58,6 +60,8 @@ async fn main() -> anyhow::Result<()> {
     #[cfg(not(feature = "tts"))]
     let mouth = display.clone() as Arc<dyn Mouth>;
     psyche.set_mouth(mouth.clone());
+    psyche.set_countenance(face.clone());
+    psyche.set_emotion("😐");
     psyche.set_connection_counter(connections.clone());
     let events = Arc::new(psyche.subscribe());
     let conversation = psyche.conversation();

--- a/pete/src/web.rs
+++ b/pete/src/web.rs
@@ -100,6 +100,13 @@ async fn handle_socket(mut socket: WebSocket, state: AppState) {
                             break;
                         }
                     }
+                    Ok(Event::EmotionChanged(emo)) => {
+                        let payload = serde_json::to_string(&WsResponse { kind: "pete-emotion", text: Some(emo), audio: None }).unwrap();
+                        if socket.send(WsMessage::Text(payload.into())).await.is_err() {
+                            error!("failed sending emotion");
+                            break;
+                        }
+                    }
                     Err(broadcast::error::RecvError::Closed) => break,
                     Err(broadcast::error::RecvError::Lagged(_)) => continue,
                 }

--- a/pete/tests/face.rs
+++ b/pete/tests/face.rs
@@ -1,0 +1,11 @@
+use pete::ChannelCountenance;
+use psyche::{Countenance, Event};
+use tokio::sync::broadcast;
+
+#[tokio::test]
+async fn broadcasts_emotion_changes() {
+    let (tx, mut rx) = broadcast::channel(8);
+    let face = ChannelCountenance::new(tx);
+    face.express("😊");
+    assert_eq!(rx.recv().await.unwrap(), Event::EmotionChanged("😊".into()));
+}

--- a/pete/tests/index.rs
+++ b/pete/tests/index.rs
@@ -13,4 +13,6 @@ async fn serves_index_html() {
     assert!(resp.0.contains("audioQueue"));
     assert!(resp.0.contains("<ul id=\"log\""));
     assert!(resp.0.contains("<li :class=\"msg.role\""));
+    assert!(resp.0.contains("id=\"face\""));
+    assert!(resp.0.contains("pete-emotion"));
 }

--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -38,6 +38,8 @@ pub enum Event {
     IntentionToSay(String),
     /// Base64-encoded WAV audio representing the spoken sentence.
     SpeechAudio(String),
+    /// The psyche's emotional expression changed.
+    EmotionChanged(String),
 }
 
 /// Inputs that can be sent to a running [`Psyche`].
@@ -218,6 +220,9 @@ impl Psyche {
     pub fn set_emotion(&mut self, emoji: impl Into<String>) {
         self.emotion = emoji.into();
         self.countenance.express(&self.emotion);
+        let _ = self
+            .events_tx
+            .send(Event::EmotionChanged(self.emotion.clone()));
     }
 
     fn still_conversing(&self, turns: usize) -> bool {

--- a/psyche/tests/converse.rs
+++ b/psyche/tests/converse.rs
@@ -132,6 +132,7 @@ async fn adds_message_after_voice_heard() {
                 break;
             }
             Event::SpeechAudio(_) => {}
+            Event::EmotionChanged(_) => {}
         }
     }
 


### PR DESCRIPTION
## Summary
- add `Event::EmotionChanged` for psyche emotion updates
- emit emotion change events when setting emotion
- add `ChannelCountenance` and connect it in the main server
- update web UI and tests for emotion messages
- document emotion events in README
- note new event behavior in AGENTS.md

## Testing
- `cargo fmt`
- `cargo fetch`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685190b55c748320b660616d24b0fd66