### PR TITLE
Scaffold Wit trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This repository contains a Rust workspace with three crates:
 - **pete** – a binary crate depending on `psyche`
 
 The `psyche` crate also defines a `Wit` trait used to build modular
-cognitive layers. Each `Wit` asynchronously processes input and
-produces an `Impression<T>` summarizing its observation.
+cognitive layers. Each `Wit` asynchronously digests a batch of lower
+level impressions and produces a higher-level `Impression<T>`.
 
 `Psyche` starts with a prompt asking the LLM to respond in one or two sentences at most. You can override it with `set_system_prompt`.
 
@@ -76,11 +76,15 @@ psyche.set_countenance(face);
 psyche.set_emotion("😊");
 // Determine emotion from text using the Heart
 let heart = psyche::Heart::new(Box::new(DummyVoice));
-let imp = heart.process("Great!".to_string()).await;
+let imp = heart
+    .digest(&[psyche::Impression { headline: "".into(), details: None, raw_data: "Great!".to_string() }])
+    .await?;
 assert_eq!(imp.raw_data, "😊");
 // Ask the Will what to do next
 let will = psyche::Will::new(Box::new(DummyVoice));
-let decision = will.process("say hi".to_string()).await;
+let decision = will
+    .digest(&[psyche::Impression { headline: "".into(), details: None, raw_data: "say hi".to_string() }])
+    .await?;
 assert_eq!(decision.headline, "Speak.");
 // Customize or replace the default prompt if desired
 psyche.set_system_prompt("Respond with two sentences.");

--- a/psyche/src/will.rs
+++ b/psyche/src/will.rs
@@ -1,72 +1,62 @@
-use crate::{
-    Impression, Wit,
-    ling::{Chatter, Message, Role},
-};
+use crate::{Impression, Wit, ling::Doer};
 use async_trait::async_trait;
 use std::sync::Arc;
-use tokio_stream::StreamExt;
 
 /// Decide Pete's next action or speech using a language model.
 ///
-/// `Will` sends the given situation summary to a [`Chatter`] with a
+/// `Will` sends the given situation summary to a [`Doer`] with a
 /// brief prompt asking for a single sentence describing what Pete
 /// should do or say next. The decision is returned as an
 /// [`Impression`].
 ///
 /// # Example
 /// ```no_run
-/// # use psyche::{Will, ling::{Chatter, Message}, Impression, Wit};
+/// # use psyche::{Will, ling::Doer, Impression, Wit};
 /// # use async_trait::async_trait;
 /// # struct Dummy;
 /// # #[async_trait]
-/// # impl Chatter for Dummy {
-/// #   async fn chat(&self, _p: &str, _h: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
-/// #       Ok(Box::pin(tokio_stream::once(Ok("Speak.".to_string()))))
+/// # impl Doer for Dummy {
+/// #   async fn follow(&self, _s: &str) -> anyhow::Result<String> {
+/// #       Ok("Speak.".to_string())
 /// #   }
 /// # }
 /// # #[tokio::main]
 /// # async fn main() {
 /// let will = Will::new(Box::new(Dummy));
-/// let imp = will.process("greet the user".to_string()).await;
+/// let imp = will
+///     .digest(&[Impression { headline: "".into(), details: None, raw_data: "greet the user".to_string() }])
+///     .await
+///     .unwrap();
 /// assert_eq!(imp.raw_data, "Speak.");
 /// # }
 /// ```
 #[derive(Clone)]
 pub struct Will {
-    chatter: Arc<dyn Chatter>,
+    doer: Arc<dyn Doer>,
 }
 
 impl Will {
-    /// Create a new `Will` using the provided [`Chatter`].
-    pub fn new(chatter: Box<dyn Chatter>) -> Self {
-        Self {
-            chatter: chatter.into(),
-        }
+    /// Create a new `Will` using the provided [`Doer`].
+    pub fn new(doer: Box<dyn Doer>) -> Self {
+        Self { doer: doer.into() }
     }
 }
 
 #[async_trait]
 impl Wit<String, String> for Will {
-    async fn process(&self, input: String) -> Impression<String> {
-        let prompt = "In one short sentence, what should Pete do or say next?";
-        let history = [Message {
-            role: Role::User,
-            content: input.clone(),
-        }];
-        let mut stream = self
-            .chatter
-            .chat(prompt, &history)
-            .await
-            .unwrap_or_else(|_| Box::pin(tokio_stream::empty()));
-        let mut resp = String::new();
-        while let Some(chunk) = stream.next().await.transpose().unwrap_or_default() {
-            resp.push_str(&chunk);
-        }
+    async fn digest(&self, inputs: &[Impression<String>]) -> anyhow::Result<Impression<String>> {
+        let input = inputs
+            .last()
+            .map(|i| i.raw_data.clone())
+            .unwrap_or_default();
+        let instruction =
+            format!("In one short sentence, what should Pete do or say next?\n{input}");
+        let resp = self.doer.follow(&instruction).await?;
         let decision = resp.trim().to_string();
-        Impression {
+        Ok(Impression {
             headline: decision.clone(),
             details: None,
             raw_data: decision,
-        }
+        })
     }
 }

--- a/psyche/src/wit.rs
+++ b/psyche/src/wit.rs
@@ -1,15 +1,89 @@
-use crate::Impression;
+use crate::{Impression, Sensation};
 use async_trait::async_trait;
+use std::sync::Arc;
 
 /// A cognitive unit that distills input into an [`Impression`].
 ///
 /// Wits operate asynchronously and may be chained together to form
-/// layered cognition. The `process` method consumes input and returns
-/// an impression summarizing it.
+/// layered cognition. The `digest` method consumes a batch of lower level
+/// impressions and produces a higher level [`Impression`].
 #[async_trait]
 pub trait Wit<I, O>: Send + Sync {
-    /// Process the input and produce an impression.
-    async fn process(&self, input: I) -> Impression<O>;
+    /// Digest `inputs` into a single summarizing [`Impression`].
+    async fn digest(&self, inputs: &[Impression<I>]) -> anyhow::Result<Impression<O>>;
+}
+
+/// A raw observation in time.
+#[derive(Clone, Debug)]
+pub struct Instant;
+
+/// A short sequence of instants.
+#[derive(Clone, Debug)]
+pub struct Moment;
+
+/// An aggregation of moments providing more context.
+#[derive(Clone, Debug)]
+pub struct Situation;
+
+/// A high level summary of a situation.
+#[derive(Clone, Debug)]
+pub struct Episode;
+
+/// A Wit turning [`Sensation`]s into [`Instant`]s.
+pub struct InstantWit {
+    doer: Arc<dyn crate::ling::Doer>,
+}
+
+#[async_trait]
+impl Wit<Sensation, Instant> for InstantWit {
+    async fn digest(
+        &self,
+        _inputs: &[Impression<Sensation>],
+    ) -> anyhow::Result<Impression<Instant>> {
+        todo!()
+    }
+}
+
+/// A Wit summarizing [`Instant`]s into a [`Moment`].
+pub struct MomentWit {
+    doer: Arc<dyn crate::ling::Doer>,
+}
+
+#[async_trait]
+impl Wit<Instant, Moment> for MomentWit {
+    async fn digest(&self, _inputs: &[Impression<Instant>]) -> anyhow::Result<Impression<Moment>> {
+        todo!()
+    }
+}
+
+/// A Wit distilling [`Moment`]s into a [`Situation`].
+pub struct SituationWit {
+    doer: Arc<dyn crate::ling::Doer>,
+}
+
+#[async_trait]
+impl Wit<Moment, Situation> for SituationWit {
+    async fn digest(
+        &self,
+        _inputs: &[Impression<Moment>],
+    ) -> anyhow::Result<Impression<Situation>> {
+        todo!()
+    }
+}
+
+/// A Wit summarizing [`Situation`]s into an [`Episode`].
+pub struct EpisodeWit {
+    doer: Arc<dyn crate::ling::Doer>,
+}
+
+#[async_trait]
+impl Wit<Situation, Episode> for EpisodeWit {
+    async fn digest(
+        &self,
+        _inputs: &[Impression<Situation>],
+    ) -> anyhow::Result<Impression<Episode>> {
+        todo!()
+    }
 }
 
 #[cfg(test)]
@@ -20,23 +94,37 @@ mod tests {
     #[derive(Default)]
     struct EchoWit;
 
-    /// A trivial [`Wit`] used for tests that wraps the input string
+    /// A trivial [`Wit`] used for tests that wraps the last input string
     /// into an [`Impression`].
     #[async_trait]
     impl Wit<String, String> for EchoWit {
-        async fn process(&self, input: String) -> Impression<String> {
-            Impression {
+        async fn digest(
+            &self,
+            inputs: &[Impression<String>],
+        ) -> anyhow::Result<Impression<String>> {
+            let input = inputs
+                .last()
+                .map(|i| i.raw_data.clone())
+                .unwrap_or_default();
+            Ok(Impression {
                 headline: input.clone(),
                 details: None,
                 raw_data: input,
-            }
+            })
         }
     }
 
     #[tokio::test]
     async fn echo_wit_returns_impression() {
         let wit = EchoWit::default();
-        let imp = wit.process("hi".to_string()).await;
+        let imp = wit
+            .digest(&[Impression {
+                headline: "hi".into(),
+                details: None,
+                raw_data: "hi".to_string(),
+            }])
+            .await
+            .unwrap();
         assert_eq!(imp.headline, "hi");
         assert_eq!(imp.raw_data, "hi");
     }

--- a/psyche/tests/heart.rs
+++ b/psyche/tests/heart.rs
@@ -1,22 +1,28 @@
 use async_trait::async_trait;
-use psyche::ling::{Chatter, Message};
-use psyche::{Heart, Wit};
-use tokio_stream::once;
+use psyche::ling::Doer;
+use psyche::{Heart, Impression, Wit};
 
 #[derive(Clone)]
 struct Dummy;
 
 #[async_trait]
-impl Chatter for Dummy {
-    async fn chat(&self, _p: &str, _h: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
-        Ok(Box::pin(once(Ok("😊".to_string()))))
+impl Doer for Dummy {
+    async fn follow(&self, _: &str) -> anyhow::Result<String> {
+        Ok("😊".to_string())
     }
 }
 
 #[tokio::test]
 async fn returns_emoji_impression() {
     let heart = Heart::new(Box::new(Dummy));
-    let imp = heart.process("hello".to_string()).await;
+    let imp = heart
+        .digest(&[Impression {
+            headline: "".into(),
+            details: None,
+            raw_data: "hello".to_string(),
+        }])
+        .await
+        .unwrap();
     assert_eq!(imp.raw_data, "😊");
     assert_eq!(imp.headline, "😊");
 }

--- a/psyche/tests/will.rs
+++ b/psyche/tests/will.rs
@@ -1,21 +1,28 @@
-use psyche::ling::{Chatter, Message};
-use psyche::{Will, Wit};
-use tokio_stream::once;
+use async_trait::async_trait;
+use psyche::ling::Doer;
+use psyche::{Impression, Will, Wit};
 
 #[derive(Clone)]
 struct Dummy;
 
-#[async_trait::async_trait]
-impl Chatter for Dummy {
-    async fn chat(&self, _p: &str, _h: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
-        Ok(Box::pin(once(Ok("Do it".to_string()))))
+#[async_trait]
+impl Doer for Dummy {
+    async fn follow(&self, _: &str) -> anyhow::Result<String> {
+        Ok("Do it".to_string())
     }
 }
 
 #[tokio::test]
 async fn returns_decision_impression() {
     let will = Will::new(Box::new(Dummy));
-    let imp = will.process("now".to_string()).await;
+    let imp = will
+        .digest(&[Impression {
+            headline: "".into(),
+            details: None,
+            raw_data: "now".to_string(),
+        }])
+        .await
+        .unwrap();
     assert_eq!(imp.raw_data, "Do it");
     assert_eq!(imp.headline, "Do it");
 }


### PR DESCRIPTION
## Summary
- add a generic `Wit` trait that digests impressions
- stub InstantWit, MomentWit, SituationWit and EpisodeWit
- update Heart and Will to use `Doer` and implement `digest`
- adjust tests for the new API
- document updated `Wit` usage in the README

## Testing
- `cargo fmt`
- `cargo fetch`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685195529dec83209ae95fb18bf70559