### PR TITLE
Refactor Chatter trait with ChatContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ impl Ear for DummyEar {
 struct DummyVoice;
 #[async_trait]
 impl psyche::ling::Chatter for DummyVoice {
-    async fn chat(&self, _s: &str, _h: &[psyche::ling::Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+    async fn chat(&self, _: psyche::ling::ChatContext<'_>) -> anyhow::Result<psyche::ling::ChatStream> {
         Ok(Box::pin(tokio_stream::once(Ok("😊".to_string()))))
     }
 }

--- a/lingproc/src/provider.rs
+++ b/lingproc/src/provider.rs
@@ -1,6 +1,6 @@
 //! Providers implementing the [`Doer`], [`Chatter`], and [`Vectorizer`] traits.
 
-use crate::types::{ChatStream, Chatter, Doer, Message, Role, Vectorizer};
+use crate::types::{ChatContext, ChatStream, Chatter, Doer, Message, Role, Vectorizer};
 use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use ollama_rs::{
@@ -42,10 +42,10 @@ impl Doer for OllamaProvider {
 
 #[async_trait]
 impl Chatter for OllamaProvider {
-    async fn chat(&self, system_prompt: &str, history: &[Message]) -> Result<ChatStream> {
-        let mut msgs = Vec::with_capacity(history.len() + 1);
-        msgs.push(ChatMessage::system(system_prompt.to_string()));
-        for m in history {
+    async fn chat(&self, ctx: ChatContext<'_>) -> Result<ChatStream> {
+        let mut msgs = Vec::with_capacity(ctx.history.len() + 1);
+        msgs.push(ChatMessage::system(ctx.system_prompt.to_string()));
+        for m in ctx.history {
             let m = match m.role {
                 Role::Assistant => ChatMessage::assistant(m.content.clone()),
                 Role::User => ChatMessage::user(m.content.clone()),

--- a/lingproc/src/types.rs
+++ b/lingproc/src/types.rs
@@ -44,9 +44,23 @@ impl Message {
 /// Stream of chat response chunks.
 pub type ChatStream = Pin<Box<dyn Stream<Item = Result<String>> + Send>>;
 
+/// Context for generating a chat response.
+///
+/// This bundles the system prompt, prior conversation history,
+/// and the speaker's current emotional state.
+#[derive(Debug, Clone)]
+pub struct ChatContext<'a> {
+    /// Instructions guiding the assistant's behavior.
+    pub system_prompt: &'a str,
+    /// Previous dialog turns.
+    pub history: &'a [Message],
+    /// Optional emoji conveying Pete's emotion.
+    pub emotion: Option<&'a str>,
+}
+
 #[async_trait]
 pub trait Chatter: Send + Sync {
-    async fn chat(&self, system_prompt: &str, history: &[Message]) -> Result<ChatStream>;
+    async fn chat(&self, ctx: ChatContext<'_>) -> Result<ChatStream>;
 }
 
 /// Produces vector representations of text.

--- a/pete/src/psyche_factory.rs
+++ b/pete/src/psyche_factory.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use psyche::Psyche;
-use psyche::ling::{Chatter, Doer, Message, Vectorizer};
+use psyche::ling::{ChatContext, Chatter, Doer, Message, Vectorizer};
 use std::sync::Arc;
 use tracing::info;
 
@@ -21,7 +21,7 @@ pub fn dummy_psyche() -> Psyche {
 
     #[async_trait]
     impl Chatter for Dummy {
-        async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+        async fn chat(&self, _: ChatContext<'_>) -> anyhow::Result<psyche::ling::ChatStream> {
             Ok(Box::pin(tokio_stream::once(Ok("hi".to_string()))))
         }
     }

--- a/psyche/src/heart.rs
+++ b/psyche/src/heart.rs
@@ -1,6 +1,6 @@
 use crate::{
     Impression, Wit,
-    ling::{Chatter, Message, Role},
+    ling::{ChatContext, Chatter, Message, Role},
 };
 use async_trait::async_trait;
 use std::sync::Arc;
@@ -14,12 +14,12 @@ use tokio_stream::StreamExt;
 ///
 /// # Example
 /// ```no_run
-/// # use psyche::{Heart, ling::{Chatter, Message}, Impression, Wit};
+/// # use psyche::{Heart, ling::{Chatter, Message, ChatContext}, Impression, Wit};
 /// # use async_trait::async_trait;
 /// # struct Dummy;
 /// # #[async_trait]
 /// # impl Chatter for Dummy {
-/// #   async fn chat(&self, _s: &str, _h: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+/// #   async fn chat(&self, _: ChatContext<'_>) -> anyhow::Result<psyche::ling::ChatStream> {
 /// #       Ok(Box::pin(tokio_stream::once(Ok("😊".to_string()))))
 /// #   }
 /// # }
@@ -52,9 +52,14 @@ impl Wit<String, String> for Heart {
             role: Role::User,
             content: input.clone(),
         }];
+        let ctx = ChatContext {
+            system_prompt: prompt,
+            history: &history,
+            emotion: None,
+        };
         let mut stream = self
             .chatter
-            .chat(prompt, &history)
+            .chat(ctx)
             .await
             .unwrap_or_else(|_| Box::pin(tokio_stream::empty()));
         let mut resp = String::new();

--- a/psyche/src/will.rs
+++ b/psyche/src/will.rs
@@ -1,6 +1,6 @@
 use crate::{
     Impression, Wit,
-    ling::{Chatter, Message, Role},
+    ling::{ChatContext, Chatter, Message, Role},
 };
 use async_trait::async_trait;
 use std::sync::Arc;
@@ -15,12 +15,12 @@ use tokio_stream::StreamExt;
 ///
 /// # Example
 /// ```no_run
-/// # use psyche::{Will, ling::{Chatter, Message}, Impression, Wit};
+/// # use psyche::{Will, ling::{Chatter, Message, ChatContext}, Impression, Wit};
 /// # use async_trait::async_trait;
 /// # struct Dummy;
 /// # #[async_trait]
 /// # impl Chatter for Dummy {
-/// #   async fn chat(&self, _p: &str, _h: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+/// #   async fn chat(&self, _: ChatContext<'_>) -> anyhow::Result<psyche::ling::ChatStream> {
 /// #       Ok(Box::pin(tokio_stream::once(Ok("Speak.".to_string()))))
 /// #   }
 /// # }
@@ -53,9 +53,14 @@ impl Wit<String, String> for Will {
             role: Role::User,
             content: input.clone(),
         }];
+        let ctx = ChatContext {
+            system_prompt: prompt,
+            history: &history,
+            emotion: None,
+        };
         let mut stream = self
             .chatter
-            .chat(prompt, &history)
+            .chat(ctx)
             .await
             .unwrap_or_else(|_| Box::pin(tokio_stream::empty()));
         let mut resp = String::new();

--- a/psyche/tests/converse.rs
+++ b/psyche/tests/converse.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use psyche::ling::{Chatter, Doer, Message, Vectorizer};
+use psyche::ling::{ChatContext, Chatter, Doer, Message, Vectorizer};
 use psyche::{Ear, Event, Mouth, Psyche, Sensation};
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -38,7 +38,7 @@ impl Doer for Dummy {
 
 #[async_trait]
 impl Chatter for Dummy {
-    async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+    async fn chat(&self, _: ChatContext<'_>) -> anyhow::Result<psyche::ling::ChatStream> {
         Ok(Box::pin(tokio_stream::once(Ok("hello world".to_string()))))
     }
 }
@@ -61,7 +61,7 @@ async fn waits_for_user_when_configured() {
 
     #[async_trait]
     impl Chatter for CountingChatter {
-        async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+        async fn chat(&self, _: ChatContext<'_>) -> anyhow::Result<psyche::ling::ChatStream> {
             self.calls.fetch_add(1, Ordering::SeqCst);
             Ok(Box::pin(tokio_stream::once(Ok("hi".to_string()))))
         }

--- a/psyche/tests/countenance.rs
+++ b/psyche/tests/countenance.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use psyche::ling::{Chatter, Doer, Message, Vectorizer};
+use psyche::ling::{ChatContext, Chatter, Doer, Message, Vectorizer};
 use psyche::{Countenance, NoopCountenance, Psyche};
 use psyche::{Ear, Mouth};
 use std::sync::{Arc, Mutex};
@@ -31,7 +31,7 @@ impl Doer for Dummy {
 
 #[async_trait]
 impl Chatter for Dummy {
-    async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+    async fn chat(&self, _: ChatContext<'_>) -> anyhow::Result<psyche::ling::ChatStream> {
         Ok(Box::pin(tokio_stream::empty()))
     }
 }

--- a/psyche/tests/heart.rs
+++ b/psyche/tests/heart.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use psyche::ling::{Chatter, Message};
+use psyche::ling::{ChatContext, Chatter, Message};
 use psyche::{Heart, Wit};
 use tokio_stream::once;
 
@@ -8,7 +8,7 @@ struct Dummy;
 
 #[async_trait]
 impl Chatter for Dummy {
-    async fn chat(&self, _p: &str, _h: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+    async fn chat(&self, _: ChatContext<'_>) -> anyhow::Result<psyche::ling::ChatStream> {
         Ok(Box::pin(once(Ok("😊".to_string()))))
     }
 }

--- a/psyche/tests/prompt.rs
+++ b/psyche/tests/prompt.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use psyche::ling::{Chatter, Doer, Message, Vectorizer};
+use psyche::ling::{ChatContext, Chatter, Doer, Message, Vectorizer};
 use psyche::{DEFAULT_SYSTEM_PROMPT, Ear, Mouth, Psyche};
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -38,7 +38,7 @@ impl Doer for Dummy {
 
 #[async_trait]
 impl Chatter for Dummy {
-    async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+    async fn chat(&self, _: ChatContext<'_>) -> anyhow::Result<psyche::ling::ChatStream> {
         Ok(Box::pin(tokio_stream::once(Ok("hi".to_string()))))
     }
 }

--- a/psyche/tests/will.rs
+++ b/psyche/tests/will.rs
@@ -1,4 +1,4 @@
-use psyche::ling::{Chatter, Message};
+use psyche::ling::{ChatContext, Chatter, Message};
 use psyche::{Will, Wit};
 use tokio_stream::once;
 
@@ -7,7 +7,7 @@ struct Dummy;
 
 #[async_trait::async_trait]
 impl Chatter for Dummy {
-    async fn chat(&self, _p: &str, _h: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+    async fn chat(&self, _: ChatContext<'_>) -> anyhow::Result<psyche::ling::ChatStream> {
         Ok(Box::pin(once(Ok("Do it".to_string()))))
     }
 }


### PR DESCRIPTION
## Summary
- wrap chat arguments into `ChatContext`
- update `OllamaProvider` and `Psyche` to use the new struct
- adjust documentation and examples
- update all tests for `ChatContext`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685194de3e2c832081df6ce672f359a1