### PR TITLE
Implement MomentWit digest

### DIFF
--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -5,7 +5,7 @@ mod impression;
 pub mod ling;
 mod trim_mouth;
 mod will;
-mod wit;
+pub mod wit;
 pub use and_mouth::AndMouth;
 pub use countenance::{Countenance, NoopCountenance};
 pub use heart::Heart;

--- a/psyche/src/wit.rs
+++ b/psyche/src/wit.rs
@@ -1,5 +1,6 @@
 use crate::{Impression, Sensation};
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 /// A cognitive unit that distills input into an [`Impression`].
@@ -14,19 +15,26 @@ pub trait Wit<I, O>: Send + Sync {
 }
 
 /// A raw observation in time.
-#[derive(Clone, Debug)]
-pub struct Instant;
+/// A raw observation in time.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Instant {
+    /// Description of the sensed event.
+    pub observation: String,
+}
 
-/// A short sequence of instants.
-#[derive(Clone, Debug)]
-pub struct Moment;
+/// A short sequence of instants summarized in text.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Moment {
+    /// Brief textual summary of the moment.
+    pub summary: String,
+}
 
 /// An aggregation of moments providing more context.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Situation;
 
 /// A high level summary of a situation.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Episode;
 
 /// A Wit turning [`Sensation`]s into [`Instant`]s.
@@ -45,14 +53,69 @@ impl Wit<Sensation, Instant> for InstantWit {
 }
 
 /// A Wit summarizing [`Instant`]s into a [`Moment`].
+#[derive(Clone)]
 pub struct MomentWit {
     doer: Arc<dyn crate::ling::Doer>,
 }
 
+impl MomentWit {
+    /// Create a new `MomentWit` using the provided [`Doer`].
+    pub fn new(doer: Box<dyn crate::ling::Doer>) -> Self {
+        Self { doer: doer.into() }
+    }
+}
+
+impl Default for MomentWit {
+    fn default() -> Self {
+        #[derive(Clone)]
+        struct Dummy;
+
+        #[async_trait]
+        impl crate::ling::Doer for Dummy {
+            async fn follow(&self, instruction: &str) -> anyhow::Result<String> {
+                Ok(instruction.to_string())
+            }
+        }
+
+        Self::new(Box::new(Dummy))
+    }
+}
+
 #[async_trait]
 impl Wit<Instant, Moment> for MomentWit {
-    async fn digest(&self, _inputs: &[Impression<Instant>]) -> anyhow::Result<Impression<Moment>> {
-        todo!()
+    async fn digest(&self, inputs: &[Impression<Instant>]) -> anyhow::Result<Impression<Moment>> {
+        // Join headlines, details and observations into one paragraph.
+        let mut combined = String::new();
+        for imp in inputs {
+            if !combined.is_empty() {
+                combined.push(' ');
+            }
+            if !imp.headline.is_empty() {
+                combined.push_str(&imp.headline);
+                combined.push(' ');
+            }
+            if let Some(details) = &imp.details {
+                combined.push_str(details);
+                combined.push(' ');
+            }
+            combined.push_str(&imp.raw_data.observation);
+        }
+        let combined = combined.trim().to_string();
+
+        let prompt = format!(
+            "Summarize the following observations into one short paragraph:\n{}",
+            combined
+        );
+
+        // For now we simply echo the prompt as the model response.
+        let resp = self.doer.follow(&prompt).await?;
+        let summary = resp.trim().to_string();
+
+        Ok(Impression {
+            headline: summary.clone(),
+            details: Some(combined),
+            raw_data: Moment { summary },
+        })
     }
 }
 

--- a/psyche/tests/wits.rs
+++ b/psyche/tests/wits.rs
@@ -1,0 +1,29 @@
+use psyche::wit::{Instant, MomentWit};
+use psyche::{Impression, Wit};
+
+#[tokio::test]
+async fn synthesizes_moment_from_instants() {
+    let wit = MomentWit::default();
+
+    let input = vec![
+        Impression {
+            headline: "Saw a dog".into(),
+            details: Some("At 10:01, a golden retriever barked at Pete.".into()),
+            raw_data: Instant {
+                observation: "a dog barked".into(),
+            },
+        },
+        Impression {
+            headline: "Pete felt startled".into(),
+            details: Some("At 10:02, Pete's posture stiffened.".into()),
+            raw_data: Instant {
+                observation: "Pete was startled".into(),
+            },
+        },
+    ];
+
+    let output = wit.digest(&input).await.unwrap();
+
+    assert_eq!(output.raw_data.summary.contains("dog"), true);
+    assert_eq!(output.raw_data.summary.contains("startled"), true);
+}


### PR DESCRIPTION
## Summary
- expose wit module publicly
- flesh out Instant and Moment structures with serde support
- implement MomentWit with a basic summarization logic
- add a new integration test covering MomentWit

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685198ae84808320baf9854c04baef6d