### PR TITLE
Add Wit behaviour tests

### DIFF
--- a/psyche/src/impression.rs
+++ b/psyche/src/impression.rs
@@ -12,3 +12,26 @@ pub struct Impression<T> {
     #[serde(rename = "rawData")]
     pub raw_data: T,
 }
+
+impl<T> Impression<T> {
+    /// Construct a new [`Impression`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use psyche::Impression;
+    /// let imp = Impression::new("a" , Some("b"), 42);
+    /// assert_eq!(imp.headline, "a");
+    /// ```
+    pub fn new(
+        headline: impl Into<String>,
+        details: Option<impl Into<String>>,
+        raw_data: T,
+    ) -> Self {
+        Self {
+            headline: headline.into(),
+            details: details.map(|d| d.into()),
+            raw_data,
+        }
+    }
+}

--- a/psyche/tests/wit_behaviour.rs
+++ b/psyche/tests/wit_behaviour.rs
@@ -1,0 +1,57 @@
+use async_trait::async_trait;
+use psyche::{Impression, Wit};
+use std::sync::Arc;
+
+#[derive(Debug)]
+struct DummyWit;
+
+#[async_trait]
+impl Wit<String, String> for DummyWit {
+    async fn digest(&self, _inputs: &[Impression<String>]) -> anyhow::Result<Impression<String>> {
+        Ok(Impression::new(
+            "Dummy headline",
+            Some("This is a dummy impression."),
+            "raw-dummy-data".to_string(),
+        ))
+    }
+}
+
+#[tokio::test]
+async fn wit_should_generate_impression() {
+    let wit = DummyWit;
+    let result = wit.digest(&[]).await.unwrap();
+    assert_eq!(result.headline, "Dummy headline");
+    assert_eq!(
+        result.details.as_deref(),
+        Some("This is a dummy impression.")
+    );
+    assert_eq!(result.raw_data, "raw-dummy-data");
+}
+
+#[tokio::test]
+async fn multiple_wits_should_independently_generate_impressions() {
+    #[derive(Debug)]
+    struct AnotherDummyWit;
+
+    #[async_trait]
+    impl Wit<String, String> for AnotherDummyWit {
+        async fn digest(
+            &self,
+            _inputs: &[Impression<String>],
+        ) -> anyhow::Result<Impression<String>> {
+            Ok(Impression::new(
+                "Another headline",
+                Some("Another impression."),
+                "another-raw".to_string(),
+            ))
+        }
+    }
+
+    let wits: Vec<Arc<dyn Wit<String, String>>> =
+        vec![Arc::new(DummyWit), Arc::new(AnotherDummyWit)];
+
+    for wit in wits {
+        let result = wit.digest(&[]).await.unwrap();
+        assert!(!result.headline.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary
- add convenience constructor `Impression::new`
- test that simple `Wit` implementations produce impressions
- verify that multiple Wits work independently

## Testing
- `cargo fmt`
- `cargo fetch`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68519cc26af88320be40c53c0627ab73