### PR TITLE
Add workspace Rustdoc

### DIFF
--- a/lingproc/src/provider.rs
+++ b/lingproc/src/provider.rs
@@ -30,6 +30,7 @@ impl OllamaProvider {
 
 #[async_trait]
 impl Doer for OllamaProvider {
+    /// Follow an instruction via the Ollama API.
     async fn follow(&self, instruction: &str) -> Result<String> {
         let req = ChatMessageRequest::new(
             self.model.clone(),
@@ -67,6 +68,7 @@ impl Chatter for OllamaProvider {
 
 #[async_trait]
 impl Vectorizer for OllamaProvider {
+    /// Request text embeddings from Ollama.
     async fn vectorize(&self, text: &str) -> Result<Vec<f32>> {
         let req = GenerateEmbeddingsRequest::new(self.model.clone(), EmbeddingsInput::from(text));
         let res = self.client.generate_embeddings(req).await?;

--- a/lingproc/src/types.rs
+++ b/lingproc/src/types.rs
@@ -6,6 +6,9 @@ use tokio_stream::Stream;
 /// Processes instructions and returns textual responses.
 #[async_trait]
 pub trait Doer: Send + Sync {
+    /// Execute the given instruction and return the textual result.
+    ///
+    /// Implementors may call an external LLM or other service.
     async fn follow(&self, instruction: &str) -> Result<String>;
 }
 
@@ -46,11 +49,15 @@ pub type ChatStream = Pin<Box<dyn Stream<Item = Result<String>> + Send>>;
 
 #[async_trait]
 pub trait Chatter: Send + Sync {
+    /// Start a chat session using `system_prompt` and `history`.
+    ///
+    /// Returns a stream of response chunks from the language model.
     async fn chat(&self, system_prompt: &str, history: &[Message]) -> Result<ChatStream>;
 }
 
 /// Produces vector representations of text.
 #[async_trait]
 pub trait Vectorizer: Send + Sync {
+    /// Convert `text` into a vector representation suitable for similarity search.
     async fn vectorize(&self, text: &str) -> Result<Vec<f32>>;
 }

--- a/pete/src/ear.rs
+++ b/pete/src/ear.rs
@@ -7,6 +7,7 @@ use std::sync::{
 use tokio::sync::{Mutex, mpsc};
 use tracing::debug;
 
+/// [`Ear`] implementation that forwards heard text through a channel.
 #[derive(Clone)]
 pub struct ChannelEar {
     forward: mpsc::UnboundedSender<Sensation>,
@@ -15,6 +16,7 @@ pub struct ChannelEar {
 }
 
 impl ChannelEar {
+    /// Create a new `ChannelEar` wired to the given channels.
     pub fn new(
         forward: mpsc::UnboundedSender<Sensation>,
         conversation: Arc<Mutex<psyche::Conversation>>,
@@ -48,6 +50,7 @@ impl Ear for ChannelEar {
     }
 }
 
+/// [`Ear`] implementation that ignores all input.
 #[derive(Clone)]
 pub struct NoopEar;
 

--- a/pete/src/lib.rs
+++ b/pete/src/lib.rs
@@ -1,7 +1,6 @@
 //! Pete web server library.
 //!
-//! This crate exposes helpers for running the Pete chatbot server and
-//! interacting with a [`Psyche`](psyche::Psyche) instance.
+//! This crate exposes helpers for running the Pete chatbot server and interacting with a [`psyche::Psyche`] instance. It wires HTTP and WebSocket endpoints to the psyche and provides mouth/ear implementations.
 
 mod ear;
 mod face;

--- a/pete/src/mouth.rs
+++ b/pete/src/mouth.rs
@@ -19,6 +19,7 @@ pub struct ChannelMouth {
 }
 
 impl ChannelMouth {
+    /// Create a new `ChannelMouth` that sends events on `events`.
     pub fn new(events: broadcast::Sender<Event>, speaking: Arc<AtomicBool>) -> Self {
         Self { events, speaking }
     }
@@ -48,6 +49,7 @@ impl Mouth for ChannelMouth {
     }
 }
 
+/// [`Mouth`] implementation that only toggles a speaking flag.
 #[derive(Clone)]
 pub struct NoopMouth {
     speaking: Arc<AtomicBool>,

--- a/pete/src/web.rs
+++ b/pete/src/web.rs
@@ -17,6 +17,7 @@ use tracing::{debug, error, info};
 
 use psyche::{Ear, Event, ling::Role};
 
+/// State shared across HTTP handlers and WebSocket tasks.
 #[derive(Clone)]
 pub struct AppState {
     pub user_input: mpsc::UnboundedSender<String>,
@@ -58,11 +59,13 @@ pub async fn index() -> Html<&'static str> {
     Html(include_str!("../../index.html"))
 }
 
+/// Upgrade the request to a WebSocket connection and forward events.
 pub async fn ws_handler(ws: WebSocketUpgrade, State(state): State<AppState>) -> impl IntoResponse {
     info!("websocket upgrade initiated");
     ws.on_upgrade(move |socket| async move { handle_socket(socket, state).await })
 }
 
+/// Upgrade to a WebSocket streaming log output.
 pub async fn log_ws_handler(
     ws: WebSocketUpgrade,
     State(state): State<AppState>,


### PR DESCRIPTION
## Summary
- document the `psyche` crate and public APIs
- expand docs for web server types in `pete`
- clarify provider and core traits in `lingproc`
- generate and inspect documentation

## Testing
- `cargo test`
- `cargo doc --workspace --no-deps --open`
- `cargo doc --workspace --no-deps --target-dir ./docs`


------
https://chatgpt.com/codex/tasks/task_e_68519fe649348320ae25882d5e4354fb