### PR TITLE
Add multimedia instruction support

### DIFF
--- a/lingproc/src/provider.rs
+++ b/lingproc/src/provider.rs
@@ -1,6 +1,6 @@
 //! Providers implementing the [`Doer`], [`Chatter`], and [`Vectorizer`] traits.
 
-use crate::types::{ChatStream, Chatter, Doer, Message, Role, Vectorizer};
+use crate::types::{ChatStream, Chatter, Doer, Instruction, Message, Role, Vectorizer};
 use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use ollama_rs::{
@@ -31,10 +31,10 @@ impl OllamaProvider {
 #[async_trait]
 impl Doer for OllamaProvider {
     /// Follow an instruction via the Ollama API.
-    async fn follow(&self, instruction: &str) -> Result<String> {
+    async fn follow(&self, instruction: Instruction) -> Result<String> {
         let req = ChatMessageRequest::new(
             self.model.clone(),
-            vec![ChatMessage::user(instruction.to_string())],
+            vec![ChatMessage::user(instruction.command)],
         );
         let res = self.client.send_chat_messages(req).await?;
         Ok(res.message.content)

--- a/pete/src/psyche_factory.rs
+++ b/pete/src/psyche_factory.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use psyche::Psyche;
-use psyche::ling::{Chatter, Doer, Message, Vectorizer};
+use psyche::ling::{Chatter, Doer, Instruction, Message, Vectorizer};
 use std::sync::Arc;
 use tracing::info;
 
@@ -14,7 +14,7 @@ pub fn dummy_psyche() -> Psyche {
 
     #[async_trait]
     impl Doer for Dummy {
-        async fn follow(&self, _: &str) -> anyhow::Result<String> {
+        async fn follow(&self, _: Instruction) -> anyhow::Result<String> {
             Ok("ok".into())
         }
     }

--- a/pete/tests/psyche_loop.rs
+++ b/pete/tests/psyche_loop.rs
@@ -102,14 +102,14 @@ async fn test_countenance_sets_emotion() {
 
 fn test_psyche(mouth: Arc<dyn Mouth>, ear: Arc<dyn Ear>) -> psyche::Psyche {
     use futures::stream;
-    use psyche::ling::{ChatStream, Chatter, Doer, Message, Vectorizer};
+    use psyche::ling::{ChatStream, Chatter, Doer, Instruction, Message, Vectorizer};
     use std::pin::Pin;
 
     struct DummyLLM;
 
     #[async_trait]
     impl Doer for DummyLLM {
-        async fn follow(&self, _instruction: &str) -> anyhow::Result<String> {
+        async fn follow(&self, _instruction: Instruction) -> anyhow::Result<String> {
             Ok("Done".into())
         }
     }

--- a/psyche/src/heart.rs
+++ b/psyche/src/heart.rs
@@ -1,4 +1,7 @@
-use crate::{Impression, Wit, ling::Doer};
+use crate::{
+    Impression, Wit,
+    ling::{Doer, Instruction},
+};
 use async_trait::async_trait;
 use std::sync::Arc;
 
@@ -10,12 +13,12 @@ use std::sync::Arc;
 ///
 /// # Example
 /// ```no_run
-/// # use psyche::{Heart, ling::Doer, Impression, Wit};
+/// # use psyche::{Heart, ling::{Doer, Instruction}, Impression, Wit};
 /// # use async_trait::async_trait;
 /// # struct Dummy;
 /// # #[async_trait]
 /// # impl Doer for Dummy {
-/// #   async fn follow(&self, _s: &str) -> anyhow::Result<String> {
+/// #   async fn follow(&self, _i: Instruction) -> anyhow::Result<String> {
 /// #       Ok("😊".to_string())
 /// #   }
 /// # }
@@ -48,9 +51,13 @@ impl Wit<String, String> for Heart {
             .last()
             .map(|i| i.raw_data.clone())
             .unwrap_or_default();
-        let instruction =
-            format!("Respond with a single emoji describing the overall emotion of:\n{input}");
-        let resp = self.doer.follow(&instruction).await?;
+        let instruction = Instruction {
+            command: format!(
+                "Respond with a single emoji describing the overall emotion of:\n{input}"
+            ),
+            images: Vec::new(),
+        };
+        let resp = self.doer.follow(instruction).await?;
         let emoji = resp.trim().to_string();
         Ok(Impression {
             headline: emoji.clone(),

--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -407,7 +407,7 @@ mod tests {
 
     #[async_trait]
     impl Doer for Dummy {
-        async fn follow(&self, _: &str) -> anyhow::Result<String> {
+        async fn follow(&self, _: crate::ling::Instruction) -> anyhow::Result<String> {
             Ok("ok".into())
         }
     }

--- a/psyche/src/will.rs
+++ b/psyche/src/will.rs
@@ -1,4 +1,7 @@
-use crate::{Impression, Wit, ling::Doer};
+use crate::{
+    Impression, Wit,
+    ling::{Doer, Instruction},
+};
 use async_trait::async_trait;
 use std::sync::Arc;
 
@@ -11,12 +14,12 @@ use std::sync::Arc;
 ///
 /// # Example
 /// ```no_run
-/// # use psyche::{Will, ling::Doer, Impression, Wit};
+/// # use psyche::{Will, ling::{Doer, Instruction}, Impression, Wit};
 /// # use async_trait::async_trait;
 /// # struct Dummy;
 /// # #[async_trait]
 /// # impl Doer for Dummy {
-/// #   async fn follow(&self, _s: &str) -> anyhow::Result<String> {
+/// #   async fn follow(&self, _i: Instruction) -> anyhow::Result<String> {
 /// #       Ok("Speak.".to_string())
 /// #   }
 /// # }
@@ -49,9 +52,11 @@ impl Wit<String, String> for Will {
             .last()
             .map(|i| i.raw_data.clone())
             .unwrap_or_default();
-        let instruction =
-            format!("In one short sentence, what should Pete do or say next?\n{input}");
-        let resp = self.doer.follow(&instruction).await?;
+        let instruction = Instruction {
+            command: format!("In one short sentence, what should Pete do or say next?\n{input}"),
+            images: Vec::new(),
+        };
+        let resp = self.doer.follow(instruction).await?;
         let decision = resp.trim().to_string();
         Ok(Impression {
             headline: decision.clone(),

--- a/psyche/src/wit.rs
+++ b/psyche/src/wit.rs
@@ -72,8 +72,11 @@ impl Default for MomentWit {
 
         #[async_trait]
         impl crate::ling::Doer for Dummy {
-            async fn follow(&self, instruction: &str) -> anyhow::Result<String> {
-                Ok(instruction.to_string())
+            async fn follow(
+                &self,
+                instruction: crate::ling::Instruction,
+            ) -> anyhow::Result<String> {
+                Ok(instruction.command)
             }
         }
 
@@ -108,7 +111,13 @@ impl Wit<Instant, Moment> for MomentWit {
         );
 
         // For now we simply echo the prompt as the model response.
-        let resp = self.doer.follow(&prompt).await?;
+        let resp = self
+            .doer
+            .follow(crate::ling::Instruction {
+                command: prompt,
+                images: Vec::new(),
+            })
+            .await?;
         let summary = resp.trim().to_string();
 
         Ok(Impression {

--- a/psyche/tests/converse.rs
+++ b/psyche/tests/converse.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use psyche::ling::{Chatter, Doer, Message, Vectorizer};
+use psyche::ling::{Chatter, Doer, Instruction, Message, Vectorizer};
 use psyche::{Ear, Event, Mouth, Psyche, Sensation};
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -31,7 +31,7 @@ impl Ear for Dummy {
 
 #[async_trait]
 impl Doer for Dummy {
-    async fn follow(&self, _: &str) -> anyhow::Result<String> {
+    async fn follow(&self, _: Instruction) -> anyhow::Result<String> {
         Ok("ok".into())
     }
 }

--- a/psyche/tests/countenance.rs
+++ b/psyche/tests/countenance.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use psyche::ling::{Chatter, Doer, Message, Vectorizer};
+use psyche::ling::{Chatter, Doer, Instruction, Message, Vectorizer};
 use psyche::{Countenance, NoopCountenance, Psyche};
 use psyche::{Ear, Mouth};
 use std::sync::{Arc, Mutex};
@@ -24,7 +24,7 @@ impl Ear for Dummy {
 
 #[async_trait]
 impl Doer for Dummy {
-    async fn follow(&self, _: &str) -> anyhow::Result<String> {
+    async fn follow(&self, _: Instruction) -> anyhow::Result<String> {
         Ok("ok".into())
     }
 }

--- a/psyche/tests/heart.rs
+++ b/psyche/tests/heart.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use psyche::ling::Doer;
+use psyche::ling::{Doer, Instruction};
 use psyche::{Heart, Impression, Wit};
 
 #[derive(Clone)]
@@ -7,7 +7,7 @@ struct Dummy;
 
 #[async_trait]
 impl Doer for Dummy {
-    async fn follow(&self, _: &str) -> anyhow::Result<String> {
+    async fn follow(&self, _: Instruction) -> anyhow::Result<String> {
         Ok("😊".to_string())
     }
 }

--- a/psyche/tests/ling.rs
+++ b/psyche/tests/ling.rs
@@ -1,13 +1,13 @@
 use async_trait::async_trait;
-use psyche::ling::{Chatter, Doer, Message, Vectorizer};
+use psyche::ling::{Chatter, Doer, Instruction, Message, Vectorizer};
 use tokio_stream::StreamExt;
 
 struct Dummy;
 
 #[async_trait]
 impl Doer for Dummy {
-    async fn follow(&self, i: &str) -> anyhow::Result<String> {
-        Ok(format!("do:{i}"))
+    async fn follow(&self, i: Instruction) -> anyhow::Result<String> {
+        Ok(format!("do:{}", i.command))
     }
 }
 
@@ -29,7 +29,15 @@ impl Vectorizer for Dummy {
 #[tokio::test]
 async fn dummy_traits() {
     let d = Dummy;
-    assert_eq!(d.follow("a").await.unwrap(), "do:a");
+    assert_eq!(
+        d.follow(Instruction {
+            command: "a".into(),
+            images: Vec::new()
+        })
+        .await
+        .unwrap(),
+        "do:a"
+    );
     let hist = vec![Message::user("hi"), Message::assistant("hey")];
     let mut stream = d.chat("sys", &hist).await.unwrap();
     let mut res = String::new();

--- a/psyche/tests/prompt.rs
+++ b/psyche/tests/prompt.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use psyche::ling::{Chatter, Doer, Message, Vectorizer};
+use psyche::ling::{Chatter, Doer, Instruction, Message, Vectorizer};
 use psyche::{DEFAULT_SYSTEM_PROMPT, Ear, Mouth, Psyche};
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -31,7 +31,7 @@ impl Ear for Dummy {
 
 #[async_trait]
 impl Doer for Dummy {
-    async fn follow(&self, _: &str) -> anyhow::Result<String> {
+    async fn follow(&self, _: Instruction) -> anyhow::Result<String> {
         Ok("ok".into())
     }
 }

--- a/psyche/tests/will.rs
+++ b/psyche/tests/will.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use psyche::ling::Doer;
+use psyche::ling::{Doer, Instruction};
 use psyche::{Impression, Will, Wit};
 
 #[derive(Clone)]
@@ -7,7 +7,7 @@ struct Dummy;
 
 #[async_trait]
 impl Doer for Dummy {
-    async fn follow(&self, _: &str) -> anyhow::Result<String> {
+    async fn follow(&self, _: Instruction) -> anyhow::Result<String> {
         Ok("Do it".to_string())
     }
 }

--- a/psyche/tests/will_heart_memory.rs
+++ b/psyche/tests/will_heart_memory.rs
@@ -1,7 +1,7 @@
 //! Integration tests exercising Will, Heart and Memory together.
 
 use async_trait::async_trait;
-use psyche::ling::{Chatter, Doer, Message};
+use psyche::ling::{Chatter, Doer, Instruction, Message};
 use psyche::{Countenance, Ear, Event, Heart, Impression, Memory, Mouth, Will, Wit};
 use std::sync::Arc;
 use tokio::sync::{Mutex, broadcast};
@@ -55,7 +55,7 @@ struct DummyDoer;
 
 #[async_trait]
 impl Doer for DummyDoer {
-    async fn follow(&self, _instruction: &str) -> anyhow::Result<String> {
+    async fn follow(&self, _instruction: Instruction) -> anyhow::Result<String> {
         Ok("Executed".to_string())
     }
 }


### PR DESCRIPTION
## Summary
- support structured Instruction with optional images
- document image handling and streaming pipeline
- update Ollama provider and Doer callers
- fix docs and tests for new API

## Testing
- `cargo test -p lingproc --doc`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6851ae876e5083209e659e793bb81fda