### PR TITLE
Implement tick-based Wit trait

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ This repository is a Rust workspace.
 ## Code Practices
 
 * Prefer traits for abstraction (`Mouth`, `Ear`, `Countenance`, `Wit`).
+* Use `Summarizer` when batching impressions into higher-level summaries.
 * Document new traits with examples and unit tests.
 * Prefer `AndMouth` when composing multiple `Mouth` implementations.
 * Use `TrimMouth` to skip speaking empty/whitespace-only text.
@@ -52,7 +53,8 @@ This repository is a Rust workspace.
 
 ## Specialized Notes
 
-* `Wit` runs asynchronously and infrequently — do not block main loop.
+* `Wit` runs asynchronously and infrequently — do not block main loop. Implement
+  tick-based summarization when possible.
 * Voice should **only** generate dialogue; all decisions routed through `Will`.
 * Memory graph (Neo4j) and embedding DB (Qdrant) must stay in sync.
 * Long-lived impressions are stored as `Impression<T>` with headline, detail, and raw data.

--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ This repository contains a Rust workspace with three crates:
 - **lingproc** – helper LLM abstractions re-exported by `psyche`
 - **pete** – a binary crate depending on `psyche`
 
-The `psyche` crate also defines a `Wit` trait used to build modular
-cognitive layers. Each `Wit` asynchronously digests a batch of lower
-level impressions and produces a higher-level `Impression<T>`.
+The `psyche` crate also defines a `Summarizer` trait used to build modular
+cognitive layers. Each `Summarizer` asynchronously digests a batch of lower
+level impressions and produces a higher-level `Impression<T>`. A lightweight
+`Wit` trait is available for incrementally observing inputs and emitting
+periodic impressions.
 
 `Psyche` starts with a prompt asking the LLM to respond in one or two sentences at most. You can override it with `set_system_prompt`.
 

--- a/psyche/src/heart.rs
+++ b/psyche/src/heart.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Impression, Wit,
+    Impression, Summarizer,
     ling::{Doer, Instruction},
 };
 use async_trait::async_trait;
@@ -13,7 +13,7 @@ use std::sync::Arc;
 ///
 /// # Example
 /// ```no_run
-/// # use psyche::{Heart, ling::{Doer, Instruction}, Impression, Wit};
+/// # use psyche::{Heart, ling::{Doer, Instruction}, Impression, Summarizer};
 /// # use async_trait::async_trait;
 /// # struct Dummy;
 /// # #[async_trait]
@@ -45,7 +45,7 @@ impl Heart {
 }
 
 #[async_trait]
-impl Wit<String, String> for Heart {
+impl Summarizer<String, String> for Heart {
     async fn digest(&self, inputs: &[Impression<String>]) -> anyhow::Result<Impression<String>> {
         let input = inputs
             .last()

--- a/psyche/src/impression.rs
+++ b/psyche/src/impression.rs
@@ -1,6 +1,13 @@
 use serde::{Deserialize, Serialize};
 
-/// A distilled perception captured by a Wit layer.
+/// A structured cognitive unit summarizing Pete's perception at a moment in
+/// time.
+///
+/// This is a memory object suitable for embedding and storage.
+///
+/// - `headline`: one-sentence summary, suitable for Qdrant embedding.
+/// - `details`: optional paragraph summary, used for narrative reflection.
+/// - `raw_data`: arbitrary serializable data, stored in Neo4j.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Impression<T> {
     /// One-sentence summary for vector storage.

--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -17,7 +17,7 @@ pub use impression::Impression;
 pub use memory::Memory;
 pub use trim_mouth::TrimMouth;
 pub use will::Will;
-pub use wit::Wit;
+pub use wit::{Summarizer, Wit};
 
 use async_trait::async_trait;
 use ling::{Chatter, Doer, Message, Role, Vectorizer};

--- a/psyche/src/will.rs
+++ b/psyche/src/will.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Impression, Wit,
+    Impression, Summarizer,
     ling::{Doer, Instruction},
 };
 use async_trait::async_trait;
@@ -14,7 +14,7 @@ use std::sync::Arc;
 ///
 /// # Example
 /// ```no_run
-/// # use psyche::{Will, ling::{Doer, Instruction}, Impression, Wit};
+/// # use psyche::{Will, ling::{Doer, Instruction}, Impression, Summarizer};
 /// # use async_trait::async_trait;
 /// # struct Dummy;
 /// # #[async_trait]
@@ -46,7 +46,7 @@ impl Will {
 }
 
 #[async_trait]
-impl Wit<String, String> for Will {
+impl Summarizer<String, String> for Will {
     async fn digest(&self, inputs: &[Impression<String>]) -> anyhow::Result<Impression<String>> {
         let input = inputs
             .last()

--- a/psyche/tests/heart.rs
+++ b/psyche/tests/heart.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use psyche::ling::{Doer, Instruction};
-use psyche::{Heart, Impression, Wit};
+use psyche::{Heart, Impression, Summarizer};
 
 #[derive(Clone)]
 struct Dummy;

--- a/psyche/tests/will.rs
+++ b/psyche/tests/will.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use psyche::ling::{Doer, Instruction};
-use psyche::{Impression, Will, Wit};
+use psyche::{Impression, Summarizer, Will};
 
 #[derive(Clone)]
 struct Dummy;

--- a/psyche/tests/will_heart_memory.rs
+++ b/psyche/tests/will_heart_memory.rs
@@ -2,7 +2,7 @@
 
 use async_trait::async_trait;
 use psyche::ling::{Chatter, Doer, Instruction, Message};
-use psyche::{Countenance, Ear, Event, Heart, Impression, Memory, Mouth, Will, Wit};
+use psyche::{Countenance, Ear, Event, Heart, Impression, Memory, Mouth, Summarizer, Will};
 use std::sync::Arc;
 use tokio::sync::{Mutex, broadcast};
 

--- a/psyche/tests/wit_behaviour.rs
+++ b/psyche/tests/wit_behaviour.rs
@@ -1,12 +1,12 @@
 use async_trait::async_trait;
-use psyche::{Impression, Wit};
+use psyche::{Impression, Summarizer};
 use std::sync::Arc;
 
 #[derive(Debug)]
 struct DummyWit;
 
 #[async_trait]
-impl Wit<String, String> for DummyWit {
+impl Summarizer<String, String> for DummyWit {
     async fn digest(&self, _inputs: &[Impression<String>]) -> anyhow::Result<Impression<String>> {
         Ok(Impression::new(
             "Dummy headline",
@@ -34,7 +34,7 @@ async fn multiple_wits_should_independently_generate_impressions() {
     struct AnotherDummyWit;
 
     #[async_trait]
-    impl Wit<String, String> for AnotherDummyWit {
+    impl Summarizer<String, String> for AnotherDummyWit {
         async fn digest(
             &self,
             _inputs: &[Impression<String>],
@@ -47,7 +47,7 @@ async fn multiple_wits_should_independently_generate_impressions() {
         }
     }
 
-    let wits: Vec<Arc<dyn Wit<String, String>>> =
+    let wits: Vec<Arc<dyn Summarizer<String, String>>> =
         vec![Arc::new(DummyWit), Arc::new(AnotherDummyWit)];
 
     for wit in wits {

--- a/psyche/tests/wits.rs
+++ b/psyche/tests/wits.rs
@@ -1,5 +1,5 @@
 use psyche::wit::{Instant, MomentWit};
-use psyche::{Impression, Wit};
+use psyche::{Impression, Summarizer};
 
 #[tokio::test]
 async fn synthesizes_moment_from_instants() {


### PR DESCRIPTION
## Summary
- update `Impression` docs to clarify usage
- rename digest-based `Wit` trait to `Summarizer`
- introduce new async `Wit` trait with `observe` and `tick` methods
- adapt all modules and tests to new trait
- document the change in README and AGENTS guidelines

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6851b36243508320a65b7f47d4eeba26