### PR TITLE
Implement memory storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ let psyche = Psyche::new(
     Box::new(narrator),
     Box::new(voice),
     Box::new(vectorizer),
+    std::sync::Arc::new(psyche::NoopMemory),
     std::sync::Arc::new(DummyMouth),
     std::sync::Arc::new(DummyEar),
 );

--- a/pete/src/psyche_factory.rs
+++ b/pete/src/psyche_factory.rs
@@ -39,6 +39,7 @@ pub fn dummy_psyche() -> Psyche {
         Box::new(Dummy),
         Box::new(Dummy),
         Box::new(Dummy),
+        Arc::new(psyche::NoopMemory),
         mouth,
         ear,
     );
@@ -65,6 +66,7 @@ pub fn ollama_psyche(host: &str, model: &str) -> anyhow::Result<Psyche> {
         Box::new(narrator),
         Box::new(voice),
         Box::new(vectorizer),
+        Arc::new(psyche::NoopMemory),
         mouth,
         ear,
     );

--- a/pete/tests/psyche_loop.rs
+++ b/pete/tests/psyche_loop.rs
@@ -136,6 +136,7 @@ fn test_psyche(mouth: Arc<dyn Mouth>, ear: Arc<dyn Ear>) -> psyche::Psyche {
         Box::new(DummyLLM),
         Box::new(DummyLLM),
         Box::new(DummyLLM),
+        std::sync::Arc::new(psyche::NoopMemory),
         mouth,
         ear,
     )

--- a/psyche/Cargo.toml
+++ b/psyche/Cargo.toml
@@ -13,6 +13,9 @@ tracing = "0.1"
 lingproc = { path = "../lingproc" }
 futures = "0.3"
 serde = { version = "1", features = ["derive"] }
+uuid = { version = "1", features = ["v4", "serde"] }
+chrono = { version = "0.4", default-features = false, features = ["serde", "clock"] }
+serde_json = "1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/psyche/src/heart.rs
+++ b/psyche/src/heart.rs
@@ -3,7 +3,9 @@ use crate::{
     ling::{Doer, Instruction},
 };
 use async_trait::async_trait;
+use chrono::Utc;
 use std::sync::Arc;
+use uuid::Uuid;
 
 /// Determine the emotional tone of text using an LLM.
 ///
@@ -26,7 +28,7 @@ use std::sync::Arc;
 /// # async fn main() {
 /// let heart = Heart::new(Box::new(Dummy));
 /// let imp = heart
-///     .digest(&[Impression { headline: "".into(), details: None, raw_data: "Great job!".to_string() }])
+///     .digest(&[Impression::new("", Some("Great job!"), "".to_string())])
 ///     .await
 ///     .unwrap();
 /// assert_eq!(imp.raw_data, "😊");
@@ -60,6 +62,8 @@ impl Summarizer<String, String> for Heart {
         let resp = self.doer.follow(instruction).await?;
         let emoji = resp.trim().to_string();
         Ok(Impression {
+            id: Uuid::new_v4(),
+            timestamp: Utc::now(),
             headline: emoji.clone(),
             details: None,
             raw_data: emoji,

--- a/psyche/src/impression.rs
+++ b/psyche/src/impression.rs
@@ -1,4 +1,6 @@
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 /// A structured cognitive unit summarizing Pete's perception at a moment in
 /// time.
@@ -10,6 +12,10 @@ use serde::{Deserialize, Serialize};
 /// - `raw_data`: arbitrary serializable data, stored in Neo4j.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Impression<T> {
+    /// Unique identifier for the impression.
+    pub id: Uuid,
+    /// Timestamp of when the impression was created.
+    pub timestamp: DateTime<Utc>,
     /// One-sentence summary for vector storage.
     pub headline: String,
     /// Optional paragraph providing more detail.
@@ -36,6 +42,8 @@ impl<T> Impression<T> {
         raw_data: T,
     ) -> Self {
         Self {
+            id: Uuid::new_v4(),
+            timestamp: Utc::now(),
             headline: headline.into(),
             details: details.map(|d| d.into()),
             raw_data,

--- a/psyche/src/will.rs
+++ b/psyche/src/will.rs
@@ -3,7 +3,9 @@ use crate::{
     ling::{Doer, Instruction},
 };
 use async_trait::async_trait;
+use chrono::Utc;
 use std::sync::Arc;
+use uuid::Uuid;
 
 /// Decide Pete's next action or speech using a language model.
 ///
@@ -27,7 +29,7 @@ use std::sync::Arc;
 /// # async fn main() {
 /// let will = Will::new(Box::new(Dummy));
 /// let imp = will
-///     .digest(&[Impression { headline: "".into(), details: None, raw_data: "greet the user".to_string() }])
+///     .digest(&[Impression::new("", None::<String>, "greet the user".to_string())])
 ///     .await
 ///     .unwrap();
 /// assert_eq!(imp.raw_data, "Speak.");
@@ -59,6 +61,8 @@ impl Summarizer<String, String> for Will {
         let resp = self.doer.follow(instruction).await?;
         let decision = resp.trim().to_string();
         Ok(Impression {
+            id: Uuid::new_v4(),
+            timestamp: Utc::now(),
             headline: decision.clone(),
             details: None,
             raw_data: decision,

--- a/psyche/tests/converse.rs
+++ b/psyche/tests/converse.rs
@@ -74,6 +74,7 @@ async fn waits_for_user_when_configured() {
         Box::new(Dummy::default()),
         Box::new(chatter.clone()),
         Box::new(Dummy::default()),
+        std::sync::Arc::new(psyche::NoopMemory),
         mouth,
         ear,
     );
@@ -112,6 +113,7 @@ async fn adds_message_after_voice_heard() {
         Box::new(Dummy::default()),
         Box::new(Dummy::default()),
         Box::new(Dummy::default()),
+        std::sync::Arc::new(psyche::NoopMemory),
         mouth,
         ear,
     );
@@ -151,6 +153,7 @@ async fn interrupts_when_user_speaks() {
         Box::new(Dummy::default()),
         Box::new(Dummy::default()),
         Box::new(Dummy::default()),
+        std::sync::Arc::new(psyche::NoopMemory),
         mouth.clone(),
         ear,
     );
@@ -184,6 +187,7 @@ async fn times_out_without_echo() {
         Box::new(Dummy::default()),
         Box::new(Dummy::default()),
         Box::new(Dummy::default()),
+        std::sync::Arc::new(psyche::NoopMemory),
         mouth,
         ear,
     );
@@ -206,6 +210,7 @@ async fn speaking_flag_clears_after_echo() {
         Box::new(Dummy::default()),
         Box::new(Dummy::default()),
         Box::new(Dummy::default()),
+        std::sync::Arc::new(psyche::NoopMemory),
         mouth,
         ear,
     );

--- a/psyche/tests/countenance.rs
+++ b/psyche/tests/countenance.rs
@@ -60,6 +60,7 @@ fn set_emotion_calls_countenance() {
         Box::new(Dummy),
         Box::new(Dummy),
         Box::new(Dummy),
+        Arc::new(psyche::NoopMemory),
         mouth,
         ear,
     );

--- a/psyche/tests/experience.rs
+++ b/psyche/tests/experience.rs
@@ -77,6 +77,7 @@ async fn registered_wit_ticks() {
         Box::new(Dummy::default()),
         Box::new(Dummy::default()),
         Box::new(Dummy::default()),
+        Arc::new(psyche::NoopMemory),
         mouth,
         ear,
     );

--- a/psyche/tests/heart.rs
+++ b/psyche/tests/heart.rs
@@ -1,6 +1,8 @@
 use async_trait::async_trait;
+use chrono::Utc;
 use psyche::ling::{Doer, Instruction};
 use psyche::{Heart, Impression, Summarizer};
+use uuid::Uuid;
 
 #[derive(Clone)]
 struct Dummy;
@@ -17,6 +19,8 @@ async fn returns_emoji_impression() {
     let heart = Heart::new(Box::new(Dummy));
     let imp = heart
         .digest(&[Impression {
+            id: Uuid::new_v4(),
+            timestamp: Utc::now(),
             headline: "".into(),
             details: None,
             raw_data: "hello".to_string(),

--- a/psyche/tests/prompt.rs
+++ b/psyche/tests/prompt.rs
@@ -58,6 +58,7 @@ fn default_prompt_present() {
         Box::new(Dummy::default()),
         Box::new(Dummy::default()),
         Box::new(Dummy::default()),
+        std::sync::Arc::new(psyche::NoopMemory),
         mouth,
         ear,
     );

--- a/psyche/tests/will.rs
+++ b/psyche/tests/will.rs
@@ -1,6 +1,8 @@
 use async_trait::async_trait;
+use chrono::Utc;
 use psyche::ling::{Doer, Instruction};
 use psyche::{Impression, Summarizer, Will};
+use uuid::Uuid;
 
 #[derive(Clone)]
 struct Dummy;
@@ -17,6 +19,8 @@ async fn returns_decision_impression() {
     let will = Will::new(Box::new(Dummy));
     let imp = will
         .digest(&[Impression {
+            id: Uuid::new_v4(),
+            timestamp: Utc::now(),
             headline: "".into(),
             details: None,
             raw_data: "now".to_string(),

--- a/psyche/tests/wits.rs
+++ b/psyche/tests/wits.rs
@@ -1,5 +1,7 @@
+use chrono::Utc;
 use psyche::wit::{Instant, MomentWit};
 use psyche::{Impression, Summarizer};
+use uuid::Uuid;
 
 #[tokio::test]
 async fn synthesizes_moment_from_instants() {
@@ -7,6 +9,8 @@ async fn synthesizes_moment_from_instants() {
 
     let input = vec![
         Impression {
+            id: Uuid::new_v4(),
+            timestamp: Utc::now(),
             headline: "Saw a dog".into(),
             details: Some("At 10:01, a golden retriever barked at Pete.".into()),
             raw_data: Instant {
@@ -14,6 +18,8 @@ async fn synthesizes_moment_from_instants() {
             },
         },
         Impression {
+            id: Uuid::new_v4(),
+            timestamp: Utc::now(),
             headline: "Pete felt startled".into(),
             details: Some("At 10:02, Pete's posture stiffened.".into()),
             raw_data: Instant {


### PR DESCRIPTION
## Summary
- extend `Impression<T>` with `id` and `timestamp`
- introduce `Memory` trait with `BasicMemory` implementation
- connect `Psyche` to an injected `Memory` and persist impressions
- adjust README and tests for new memory API

## Testing
- `cargo test -p psyche --doc`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6851f6d9ef4c8320aa0d6479117a1b9a