### PR TITLE
Improve echo handling for empty speech

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,5 +79,6 @@ This repository is a Rust workspace.
 * Consider adding CLI test scaffolding for mocking TTS/Neo4j/Qdrant.
 * Ensure that `Wit<Instant>` is fed only when it has sufficient `Sensation` inputs — fail early otherwise.
 * Be mindful of the single-CPU assumption — prefer concurrency without heavy parallelism.
+* When skipping speech for empty responses, increment the turn counter so the conversation loop can exit.
 
 This document reflects the current cognitive and runtime architecture of Pete Daringsby. Keep it consistent with the latest design discussions and behavior changes.


### PR DESCRIPTION
## Summary
- add logging for `HeardOwnVoice` messages
- skip speaking empty responses and debug log mouth invocation
- prevent infinite loop by incrementing turns when empty text is skipped
- test that empty responses don't trigger echo timeouts
- document turn counter note in `AGENTS.md`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6851fb4e46648320be5802b8d1bf2e5b