### PR TITLE
Add logging for speech events

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,6 +72,7 @@
               }
               if (data.audio) {
                 this.audioQueue.push({ audio: data.audio, text: this.lastText });
+                console.log('queued audio', this.audioQueue.length);
                 this.playNext();
               }
             } catch (_) {

--- a/pete/Cargo.toml
+++ b/pete/Cargo.toml
@@ -21,6 +21,7 @@ dioxus = { version = "0.4.3", default-features = false, features = ["html", "mac
 dioxus-ssr = "0.4.3"
 reqwest = { version = "0.11", features = ["stream"] }
 base64 = { version = "0.21" }
+futures = "0.3"
 
 [features]
 default = []
@@ -33,3 +34,4 @@ dioxus-ssr = "0.4.3"
 [dev-dependencies]
 assert_cmd = "2"
 futures = "0.3"
+tokio-tungstenite = "0.27"

--- a/pete/src/lib.rs
+++ b/pete/src/lib.rs
@@ -19,7 +19,7 @@ pub use mouth::{ChannelMouth, NoopMouth};
 pub use psyche_factory::{dummy_psyche, ollama_psyche};
 pub use sensor::eye::EyeSensor;
 #[cfg(feature = "tts")]
-pub use tts_mouth::{CoquiTts, Tts, TtsMouth};
+pub use tts_mouth::{CoquiTts, Tts, TtsMouth, TtsStream};
 pub use web::{
     AppState, WsRequest, app, conversation_log, index, listen_user_input, log_ws_handler,
     ws_handler,

--- a/pete/src/web.rs
+++ b/pete/src/web.rs
@@ -94,6 +94,7 @@ async fn handle_socket(mut socket: WebSocket, state: AppState) {
                     }
                     Ok(Event::IntentionToSay(text)) => {
                         let payload = serde_json::to_string(&WsResponse { kind: "pete-says", text: Some(text.clone()), audio: None }).unwrap();
+                        debug!("ws dispatch say: {}", text);
                         if socket.send(WsMessage::Text(payload.into())).await.is_err() {
                             error!("failed sending intention");
                             break;
@@ -101,6 +102,7 @@ async fn handle_socket(mut socket: WebSocket, state: AppState) {
                     }
                     Ok(Event::SpeechAudio(data)) => {
                         let payload = serde_json::to_string(&WsResponse { kind: "pete-audio", text: None, audio: Some(data) }).unwrap();
+                        debug!("ws dispatch audio chunk");
                         if socket.send(WsMessage::Text(payload.into())).await.is_err() {
                             error!("failed sending audio");
                             break;

--- a/psyche/src/and_mouth.rs
+++ b/psyche/src/and_mouth.rs
@@ -56,6 +56,12 @@ impl AndMouth {
 #[async_trait]
 impl Mouth for AndMouth {
     async fn speak(&self, text: &str) {
+        tracing::debug!(
+            targets = "and_mouth",
+            text,
+            mouths = self.mouths.len(),
+            "broadcasting speech"
+        );
         self.for_each_async(|m| Box::pin(m.speak(text))).await;
     }
 


### PR DESCRIPTION
## Summary
- log each AndMouth invocation
- log websocket dispatch of say/audio messages
- surface TtsStream type and futures dependency
- show audio queue length in the web UI

## Testing
- `cargo test --all-features`

------
https://chatgpt.com/codex/tasks/task_e_685217998788832081b49430a77f0515