### PR TITLE
Fix camera stream and document TTS build flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ This repository is a Rust workspace.
 
 * The `tts` feature streams audio from Coqui TTS.
 * Configure with `--tts-url` CLI flag.
+* Build the `pete` binary with `--features tts` to enable audio.
 * Stub TTS in tests to avoid delays.
 
 ## Specialized Notes

--- a/README.md
+++ b/README.md
@@ -112,6 +112,15 @@ Run the web server with the built-in Ollama support:
 
 ```sh
 cargo run -p pete -- --ollama-url http://localhost:11434 --model mistral
+
+To enable audio output via Coqui TTS, build with the optional `tts` feature and
+provide the TTS server URL:
+
+```sh
+cargo run -p pete --features tts -- \
+  --ollama-url http://localhost:11434 --model mistral \
+  --tts-url http://localhost:5002/api/tts
+```
 ```
 ## Web Interface
 

--- a/index.html
+++ b/index.html
@@ -45,9 +45,11 @@
         emotion: '😐',
         audioQueue: [],
         playing: false,
+        stream: null,
         init() { this.connect(); this.initCamera(); },
         initCamera() {
           navigator.mediaDevices.getUserMedia({ video: true }).then(s => {
+            this.stream = s;
             this.$refs.video.srcObject = s;
           }).catch(() => {});
         },

--- a/pete/build.rs
+++ b/pete/build.rs
@@ -11,9 +11,11 @@ const SCRIPT: &str = r#"function chatApp() {
       input: '',
     audioQueue: [],
     playing: false,
+    stream: null,
     init() { this.connect(); this.initCamera(); },
     initCamera() {
       navigator.mediaDevices.getUserMedia({ video: true }).then(s => {
+        this.stream = s;
         this.$refs.video.srcObject = s;
       }).catch(() => {});
     },


### PR DESCRIPTION
## Summary
- fix webcam by keeping reference to media stream
- regenerate index.html in build script
- document how to run with TTS
- update AGENTS with build flag note

## Testing
- `cargo fmt`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685220d024a08320b3dd89bfcbcb2d4f