### PR TITLE
Add frontend audio tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ Cargo.lock
 /ollama
 .env
 debug.log
+frontend/node_modules
+frontend/package-lock.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ This repository is a Rust workspace.
 * Use Alpine.js for client binding.
 * Render chat log as `<ul>` with `<li>` per message.
 * Keep `index.html` and `pete/build.rs` in sync.
+* Front-end tests live under `frontend/` and run with `npm test`.
 
 ## Communication
 

--- a/frontend/__tests__/audio.test.js
+++ b/frontend/__tests__/audio.test.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+function loadApp() {
+  const html = fs.readFileSync(path.join(__dirname, '../..', 'index.html'), 'utf8');
+  const dom = new JSDOM(html, { runScripts: 'dangerously' });
+  const { window } = dom;
+  global.document = window.document;
+  global.window = window;
+  window.navigator.mediaDevices = { getUserMedia: () => Promise.resolve({}) };
+  const app = window.chatApp();
+  app.$refs = { player: { src: '', play: jest.fn(() => Promise.resolve()), onended: null }, log: document.createElement('div'), video: {} };
+  app.ws = { send: jest.fn() };
+  return app;
+}
+
+test('playNext loads audio and sends ack', () => {
+  const app = loadApp();
+  app.audioQueue.push({ audio: 'UklGRg==', text: 'hi' });
+  app.playNext();
+  expect(app.$refs.player.src).toBe('data:audio/wav;base64,UklGRg==');
+  expect(app.playing).toBe(true);
+  app.$refs.player.onended();
+  expect(app.ws.send).toHaveBeenCalledWith(JSON.stringify({ type: 'played', text: 'hi' }));
+  expect(app.playing).toBe(false);
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^30.0.0",
+    "jsdom": "^26.1.0"
+  }
+}

--- a/pete/tests/ws_audio.rs
+++ b/pete/tests/ws_audio.rs
@@ -1,0 +1,53 @@
+use axum::{Router, routing::get, serve};
+use futures::StreamExt;
+use pete::{AppState, ChannelEar, EyeSensor, dummy_psyche, ws_handler};
+use psyche::Event;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, AtomicUsize},
+};
+use tokio::sync::{broadcast, mpsc};
+
+#[tokio::test]
+async fn websocket_forwards_audio() {
+    let psyche = dummy_psyche();
+    let conversation = psyche.conversation();
+    let ear = Arc::new(ChannelEar::new(
+        psyche.input_sender(),
+        conversation.clone(),
+        Arc::new(AtomicBool::new(false)),
+    ));
+    let eye = Arc::new(EyeSensor::new(psyche.input_sender()));
+    let (event_tx, _) = broadcast::channel(8);
+    let (log_tx, _) = broadcast::channel(8);
+    let (user_tx, _user_rx) = mpsc::unbounded_channel();
+    let state = AppState {
+        user_input: user_tx,
+        events: Arc::new(event_tx.subscribe()),
+        logs: Arc::new(log_tx.subscribe()),
+        ear,
+        eye,
+        conversation,
+        connections: Arc::new(AtomicUsize::new(0)),
+    };
+    let app = Router::new()
+        .route("/ws", get(ws_handler))
+        .with_state(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        serve(listener, app.into_make_service()).await.unwrap();
+    });
+
+    let (mut socket, _) = tokio_tungstenite::connect_async(format!("ws://{}/ws", addr))
+        .await
+        .unwrap();
+    event_tx
+        .send(Event::SpeechAudio("UklGRg==".into()))
+        .unwrap();
+    let msg = socket.next().await.unwrap().unwrap();
+    let value: serde_json::Value = serde_json::from_str(msg.to_text().unwrap()).unwrap();
+    assert_eq!(value["type"], "pete-audio");
+    assert_eq!(value["audio"], "UklGRg==");
+    server.abort();
+}


### PR DESCRIPTION
## Summary
- ignore frontend node artifacts
- document front-end tests
- add Jest test for audio playback queue
- send audio chunks via websocket in tests

## Testing
- `cargo test`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685224b87e2883209c42fb9d4c27a18c