### PR TITLE
Add speaker and language options to TTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,11 @@ let display = std::sync::Arc::new(pete::ChannelMouth::new(psyche.event_sender(),
 let tts = std::sync::Arc::new(pete::TtsMouth::new(
     psyche.event_sender(),
     speaking.clone(),
-    std::sync::Arc::new(pete::CoquiTts::new("http://localhost:5002/api/tts")),
+    std::sync::Arc::new(pete::CoquiTts::new(
+        "http://localhost:5002/api/tts",
+        Some("p376".into()),
+        None,
+    )),
 ));
 #[cfg(feature = "tts")]
 let mouth = std::sync::Arc::new(psyche::AndMouth::new(vec![display.clone(), tts]));
@@ -114,13 +118,13 @@ Run the web server with the built-in Ollama support:
 cargo run -p pete -- --ollama-url http://localhost:11434 --model mistral
 
 To enable audio output via Coqui TTS, build with the optional `tts` feature and
-provide the TTS server URL:
+provide the TTS server URL and optional voice parameters:
 
 ```sh
 cargo run -p pete --features tts -- \
   --ollama-url http://localhost:11434 --model mistral \
-  --tts-url http://localhost:5002/api/tts
-```
+  --tts-url http://localhost:5002/api/tts \
+  --tts-speaker-id p376
 ```
 ## Web Interface
 

--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -32,6 +32,12 @@ struct Cli {
     /// URL of the Coqui TTS server
     #[arg(long, default_value = "http://localhost:5002/api/tts")]
     tts_url: String,
+    /// Optional speaker ID for the TTS voice
+    #[arg(long)]
+    tts_speaker_id: Option<String>,
+    /// Optional language ID for the TTS voice
+    #[arg(long)]
+    tts_language_id: Option<String>,
 }
 
 #[tokio::main(flavor = "multi_thread")]
@@ -51,7 +57,11 @@ async fn main() -> anyhow::Result<()> {
     let audio = Arc::new(TtsMouth::new(
         psyche.event_sender(),
         speaking.clone(),
-        Arc::new(CoquiTts::new(cli.tts_url)),
+        Arc::new(CoquiTts::new(
+            cli.tts_url,
+            cli.tts_speaker_id,
+            cli.tts_language_id,
+        )),
     ));
     #[cfg(feature = "tts")]
     let mouth = Arc::new(AndMouth::new(vec![


### PR DESCRIPTION
## Summary
- allow configuring Coqui TTS speaker and language
- expose new options via CLI
- document usage in README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68522952f10c8320851c248fde1461fa