### PR TITLE
Improve TTS logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,5 +85,6 @@ This repository is a Rust workspace.
 * Ensure that `Wit<Instant>` is fed only when it has sufficient `Sensation` inputs — fail early otherwise.
 * Be mindful of the single-CPU assumption — prefer concurrency without heavy parallelism.
 * When skipping speech for empty responses, increment the turn counter so the conversation loop can exit.
+* Log Coqui TTS request URLs with `info!(%url, "requesting TTS")` to ease debugging misconfigured endpoints.
 
 This document reflects the current cognitive and runtime architecture of Pete Daringsby. Keep it consistent with the latest design discussions and behavior changes.

--- a/pete/src/tts_mouth.rs
+++ b/pete/src/tts_mouth.rs
@@ -9,7 +9,7 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
 };
 use tokio::sync::broadcast;
-use tracing::error;
+use tracing::{error, info};
 
 use anyhow::Result;
 use base64::{Engine as _, engine::general_purpose};
@@ -68,6 +68,7 @@ impl Tts for CoquiTts {
                 qp.append_pair("language_id", l);
             }
         }
+        info!(%url, "requesting TTS");
         let resp = self.client.get(url).send().await?;
         let stream = resp
             .bytes_stream()

--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -377,18 +377,15 @@ impl Psyche {
                     }
                 }
                 let trimmed = resp.trim();
-                info!("assistant intends to say: {}", trimmed);
-                if !trimmed.is_empty() {
-                    let _ = self
-                        .events_tx
-                        .send(Event::IntentionToSay(trimmed.to_string()));
-                }
                 if trimmed.is_empty() {
-                    warn!("Skipping speech of empty response.");
                     self.pending_user_message = !self.speak_when_spoken_to;
                     turns += 1;
                     continue;
                 }
+                info!("assistant intends to say: {}", trimmed);
+                let _ = self
+                    .events_tx
+                    .send(Event::IntentionToSay(trimmed.to_string()));
                 self.is_speaking = true;
                 self.countenance.express(&self.emotion);
                 debug!("Calling mouth.speak with: '{}'", resp);


### PR DESCRIPTION
## Summary
- log Coqui URL before fetching speech audio
- avoid noisy logs when speech is empty
- note TTS logging hint in `AGENTS.md`

## Testing
- `cargo fmt`
- `cargo fetch`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685230581b388320905d785fb6967359