### PR TITLE
Fix duplicate final message

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ This repository is a Rust workspace.
 * Style user and system messages distinctly for clarity.
 * Keep `index.html` and `pete/build.rs` in sync.
 * Front-end tests live under `frontend/` and run with `npm test`.
+* Run `npm install` first if dependencies are missing.
 
 ## Communication
 

--- a/pete/src/web.rs
+++ b/pete/src/web.rs
@@ -92,13 +92,12 @@ async fn handle_socket(mut socket: WebSocket, state: AppState) {
                             break;
                         }
                     }
-                    Ok(Event::IntentionToSay(text)) => {
-                        let payload = serde_json::to_string(&WsResponse { kind: "pete-says", text: Some(text.clone()), audio: None }).unwrap();
-                        debug!("ws dispatch say: {}", text);
-                        if socket.send(WsMessage::Text(payload.into())).await.is_err() {
-                            error!("failed sending intention");
-                            break;
-                        }
+                    Ok(Event::IntentionToSay(_)) => {
+                        // Intention events are used internally to trigger audio
+                        // playback. The user already received the text via
+                        // `StreamChunk` messages, so skip forwarding this final
+                        // repetition to avoid duplicate lines in the chat log.
+                        debug!("ws skipping IntentionToSay");
                     }
                     Ok(Event::SpeechAudio(data)) => {
                         let payload = serde_json::to_string(&WsResponse { kind: "pete-audio", text: None, audio: Some(data) }).unwrap();


### PR DESCRIPTION
## Summary
- avoid forwarding IntentionToSay text over websocket
- note that `npm install` may be required before running frontend tests

## Testing
- `cargo test`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852366c268c8320b06ee41c15eb2a4f