### PR TITLE
Implement EmojiMouth for emotive output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ This repository is a Rust workspace.
 * Document new traits with examples and unit tests.
 * Prefer `AndMouth` when composing multiple `Mouth` implementations.
 * Use `TrimMouth` to skip speaking empty/whitespace-only text.
+* Use `EmojiMouth` to route emoji to the countenance instead of speaking them.
 * Do **not** emit `Event::IntentionToSay` for empty or whitespace-only text.
 * Skip sending `Event::StreamChunk` when the chunk is empty or whitespace.
 * Build prompts using dedicated structs like `WillPrompt` and `HeartPrompt`.

--- a/README.md
+++ b/README.md
@@ -77,8 +77,9 @@ let mouth = std::sync::Arc::new(psyche::TrimMouth::new(mouth));
 #[cfg(not(feature = "tts"))]
 let mouth = display.clone() as std::sync::Arc<dyn Mouth>;
 let mouth = std::sync::Arc::new(psyche::TrimMouth::new(mouth));
-psyche.set_mouth(mouth);
 let face = std::sync::Arc::new(pete::ChannelCountenance::new(psyche.event_sender()));
+let mouth = std::sync::Arc::new(psyche::EmojiMouth::new(mouth, face.clone()));
+psyche.set_mouth(mouth);
 psyche.set_countenance(face);
 psyche.set_emotion("😊");
 // Determine emotion from text using the Heart

--- a/psyche/Cargo.toml
+++ b/psyche/Cargo.toml
@@ -16,6 +16,8 @@ serde = { version = "1", features = ["derive"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", default-features = false, features = ["serde", "clock"] }
 serde_json = "1"
+unicode-segmentation = "1"
+emojis = "0.6"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/psyche/src/emoji_mouth.rs
+++ b/psyche/src/emoji_mouth.rs
@@ -1,0 +1,72 @@
+//! Mouth wrapper that routes emoji characters to a [`Countenance`].
+//!
+//! `EmojiMouth` strips emoji graphemes from the provided text before forwarding
+//! it to the inner [`Mouth`]. Any removed emojis are sent to the associated
+//! [`Countenance`] in the order they appear.
+//!
+//! ```no_run
+//! use psyche::{EmojiMouth, Mouth, Countenance};
+//! use std::sync::Arc;
+//!
+//! # struct DummyMouth;
+//! # #[async_trait::async_trait]
+//! # impl Mouth for DummyMouth {
+//! #     async fn speak(&self, _t: &str) {}
+//! #     async fn interrupt(&self) {}
+//! #     fn speaking(&self) -> bool { false }
+//! # }
+//! # #[derive(Clone)]
+//! # struct DummyFace;
+//! # impl Countenance for DummyFace { fn express(&self, _emoji: &str) {} }
+//! let mouth = Arc::new(DummyMouth) as Arc<dyn Mouth>;
+//! let face = Arc::new(DummyFace) as Arc<dyn Countenance>;
+//! let mouth = EmojiMouth::new(mouth, face);
+//! ```
+use crate::{Countenance, Mouth};
+use async_trait::async_trait;
+use std::sync::Arc;
+use unicode_segmentation::UnicodeSegmentation;
+
+/// [`Mouth`] implementation that filters emoji out of spoken text.
+#[derive(Clone)]
+pub struct EmojiMouth {
+    inner: Arc<dyn Mouth>,
+    face: Arc<dyn Countenance>,
+}
+
+impl EmojiMouth {
+    /// Create a new [`EmojiMouth`] wrapping `inner` and updating `face`.
+    pub fn new(inner: Arc<dyn Mouth>, face: Arc<dyn Countenance>) -> Self {
+        Self { inner, face }
+    }
+}
+
+#[async_trait]
+impl Mouth for EmojiMouth {
+    async fn speak(&self, text: &str) {
+        let mut plain = String::new();
+        let mut emoji = String::new();
+        for g in UnicodeSegmentation::graphemes(text, true) {
+            if emojis::get(g).is_some() {
+                emoji.push_str(g);
+            } else {
+                plain.push_str(g);
+            }
+        }
+        if !emoji.is_empty() {
+            self.face.express(&emoji);
+        }
+        let trimmed = plain.trim();
+        if !trimmed.is_empty() {
+            self.inner.speak(trimmed).await;
+        }
+    }
+
+    async fn interrupt(&self) {
+        self.inner.interrupt().await;
+    }
+
+    fn speaking(&self) -> bool {
+        self.inner.speaking()
+    }
+}

--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -3,6 +3,7 @@
 //! The `psyche` crate coordinates conversation with language models. It exposes the [`Psyche`] struct along with traits and helpers for building mouth, ear, countenance, and wit components.
 mod and_mouth;
 mod countenance;
+mod emoji_mouth;
 mod heart;
 mod impression;
 pub mod ling;
@@ -16,6 +17,7 @@ mod will;
 pub mod wit;
 pub use and_mouth::AndMouth;
 pub use countenance::{Countenance, NoopCountenance};
+pub use emoji_mouth::EmojiMouth;
 pub use heart::Heart;
 pub use impression::Impression;
 pub use memory::{BasicMemory, GraphStore, Memory, Neo4jClient, NoopMemory, QdrantClient};

--- a/psyche/tests/emoji_mouth.rs
+++ b/psyche/tests/emoji_mouth.rs
@@ -1,0 +1,50 @@
+use async_trait::async_trait;
+use psyche::{Countenance, EmojiMouth, Mouth};
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone, Default)]
+struct RecordingMouth(Arc<Mutex<Option<String>>>);
+
+#[async_trait]
+impl Mouth for RecordingMouth {
+    async fn speak(&self, text: &str) {
+        *self.0.lock().unwrap() = Some(text.to_string());
+    }
+    async fn interrupt(&self) {}
+    fn speaking(&self) -> bool {
+        false
+    }
+}
+
+#[derive(Clone, Default)]
+struct RecordingFace(Arc<Mutex<Option<String>>>);
+
+impl Countenance for RecordingFace {
+    fn express(&self, emoji: &str) {
+        *self.0.lock().unwrap() = Some(emoji.to_string());
+    }
+}
+
+#[tokio::test]
+async fn routes_emoji_to_face() {
+    let mouth = Arc::new(RecordingMouth::default());
+    let face = Arc::new(RecordingFace::default());
+    let em = EmojiMouth::new(mouth.clone() as Arc<dyn Mouth>, face.clone());
+
+    em.speak("hi 😊").await;
+
+    assert_eq!(mouth.0.lock().unwrap().as_deref(), Some("hi"));
+    assert_eq!(face.0.lock().unwrap().as_deref(), Some("😊"));
+}
+
+#[tokio::test]
+async fn only_emoji_updates_face() {
+    let mouth = Arc::new(RecordingMouth::default());
+    let face = Arc::new(RecordingFace::default());
+    let em = EmojiMouth::new(mouth.clone() as Arc<dyn Mouth>, face.clone());
+
+    em.speak("😊😊").await;
+
+    assert!(mouth.0.lock().unwrap().is_none());
+    assert_eq!(face.0.lock().unwrap().as_deref(), Some("😊😊"));
+}


### PR DESCRIPTION
## Summary
- add `EmojiMouth` that filters emojis from speech and forwards them to the countenance
- expose the new mouth in `psyche` and update docs
- document usage in AGENTS.md and README
- test emoji routing logic

## Testing
- `cargo fetch`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685237a3049c8320879af89b68259348