### PR TITLE
Add prehension buffering wit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,7 @@ This repository is a Rust workspace.
 * Voice should **only** generate dialogue; all decisions routed through `Will`.
 * Memory graph (Neo4j) and embedding DB (Qdrant) must stay in sync.
 * Long-lived impressions are stored as `Impression<T>` with headline, detail, and raw data.
+* Use `Prehension` when buffering impressions for summarization. `Wit` is generic over input and output types.
 
 ## Contributor Notes
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ This repository contains a Rust workspace with three crates:
 The `psyche` crate also defines a `Summarizer` trait used to build modular
 cognitive layers. Each `Summarizer` asynchronously digests a batch of lower
 level impressions and produces a higher-level `Impression<T>`. A lightweight
-`Wit` trait is available for incrementally observing inputs and emitting
-periodic impressions.
+`Wit<I, O>` trait is available for incrementally observing inputs and emitting
+periodic impressions of type `O`. The `Prehension` helper buffers incoming
+impressions and summarizes them using a `Summarizer`.
 
 `Psyche` starts with a prompt asking the LLM to respond in one or two sentences at most. You can override it with `set_system_prompt`.
 

--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -9,6 +9,7 @@ mod impression;
 pub mod ling;
 mod memory;
 mod plain_mouth;
+mod prehension;
 mod prompt;
 mod sensor;
 mod trim_mouth;
@@ -23,6 +24,7 @@ pub use heart::Heart;
 pub use impression::Impression;
 pub use memory::{BasicMemory, GraphStore, Memory, Neo4jClient, NoopMemory, QdrantClient};
 pub use plain_mouth::PlainMouth;
+pub use prehension::Prehension;
 pub use prompt::{HeartPrompt, PromptBuilder, VoicePrompt, WillPrompt};
 pub use sensor::Sensor;
 pub use trim_mouth::TrimMouth;
@@ -39,7 +41,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 use tokio::sync::{Mutex, broadcast, mpsc};
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info};
 
 /// Default instructions sent to the language model.
 ///
@@ -283,7 +285,7 @@ impl Psyche {
     /// # let mut psyche: psyche::Psyche = todo!();
     /// struct MyWit;
     /// # #[async_trait]
-    /// # impl Wit<()> for MyWit {
+    /// # impl Wit<(), ()> for MyWit {
     /// #   async fn observe(&self, _: ()) {}
     /// #   async fn tick(&self) -> Option<psyche::Impression<()>> { None }
     /// # }
@@ -295,9 +297,10 @@ impl Psyche {
     }
 
     /// Convenience to register a typed [`Wit`] without manual boxing.
-    pub fn register_typed_wit<T>(&mut self, wit: Arc<dyn Wit<T> + Send + Sync>)
+    pub fn register_typed_wit<I, O>(&mut self, wit: Arc<dyn Wit<I, O> + Send + Sync>)
     where
-        T: Serialize + Send + Sync + 'static,
+        I: 'static,
+        O: Serialize + Send + Sync + 'static,
     {
         self.wits
             .push(Arc::new(wit::WitAdapter::new(wit)) as Arc<dyn ErasedWit + Send + Sync>);

--- a/psyche/src/prehension.rs
+++ b/psyche/src/prehension.rs
@@ -1,0 +1,80 @@
+use crate::{
+    Impression,
+    wit::{Summarizer, Wit},
+};
+use async_trait::async_trait;
+use std::marker::PhantomData;
+use std::sync::Mutex;
+use tracing::debug;
+
+/// Collects impressions in a buffer and periodically summarizes them.
+///
+/// `Prehension` forms the glue between multiple [`Wit`] stages. It buffers
+/// incoming impressions and, on [`tick`], uses a [`Summarizer`] to produce a
+/// higher-level impression.
+///
+/// # Example
+/// ```
+/// use psyche::{Prehension, wit::Summarizer};
+/// use psyche::Impression;
+/// use async_trait::async_trait;
+///
+/// struct Echo;
+/// #[async_trait]
+/// impl Summarizer<String, String> for Echo {
+///     async fn digest(
+///         &self,
+///         inputs: &[Impression<String>],
+///     ) -> anyhow::Result<Impression<String>> {
+///         let joined = inputs.iter().map(|i| i.raw_data.clone()).collect::<Vec<_>>().join(" ");
+///         Ok(Impression::new(joined.clone(), None::<String>, joined))
+///     }
+/// }
+/// let wit = Prehension::new(Echo);
+/// ```
+pub struct Prehension<I, O, S> {
+    summarizer: S,
+    buffer: Mutex<Vec<Impression<I>>>,
+    _marker: PhantomData<O>,
+}
+
+impl<I, O, S> Prehension<I, O, S>
+where
+    S: Summarizer<I, O> + Send + Sync,
+{
+    /// Create a new `Prehension` using the given [`Summarizer`].
+    pub fn new(summarizer: S) -> Self {
+        Self {
+            summarizer,
+            buffer: Mutex::new(Vec::new()),
+            _marker: PhantomData,
+        }
+    }
+}
+
+#[async_trait]
+impl<I, O, S> Wit<Impression<I>, O> for Prehension<I, O, S>
+where
+    S: Summarizer<I, O> + Send + Sync,
+    I: Send + Sync + Clone + 'static,
+    O: Send + Sync + 'static,
+{
+    async fn observe(&self, input: Impression<I>) {
+        debug!("prehension observed input");
+        self.buffer.lock().unwrap().push(input);
+    }
+
+    async fn tick(&self) -> Option<Impression<O>> {
+        let inputs = {
+            let mut buf = self.buffer.lock().unwrap();
+            if buf.is_empty() {
+                return None;
+            }
+            let data = buf.clone();
+            buf.clear();
+            data
+        };
+        debug!("prehension digesting {} items", inputs.len());
+        self.summarizer.digest(&inputs).await.ok()
+    }
+}

--- a/psyche/src/vision_wit.rs
+++ b/psyche/src/vision_wit.rs
@@ -24,7 +24,7 @@ impl VisionWit {
 }
 
 #[async_trait]
-impl Wit<ImageData> for VisionWit {
+impl Wit<ImageData, ImageData> for VisionWit {
     async fn observe(&self, input: ImageData) {
         self.buffer.lock().unwrap().push(input);
     }

--- a/psyche/tests/experience.rs
+++ b/psyche/tests/experience.rs
@@ -60,7 +60,7 @@ struct CountingWit {
 }
 
 #[async_trait]
-impl Wit<()> for CountingWit {
+impl Wit<(), ()> for CountingWit {
     async fn observe(&self, _: ()) {}
     async fn tick(&self) -> Option<Impression<()>> {
         let mut t = self.ticks.lock().unwrap();

--- a/psyche/tests/prehension.rs
+++ b/psyche/tests/prehension.rs
@@ -1,0 +1,51 @@
+use async_trait::async_trait;
+use psyche::wit::Summarizer;
+use psyche::{Impression, Prehension, Wit};
+
+#[derive(Default)]
+struct MoodSummarizer;
+
+#[async_trait]
+impl Summarizer<String, String> for MoodSummarizer {
+    async fn digest(&self, inputs: &[Impression<String>]) -> anyhow::Result<Impression<String>> {
+        let joined = inputs
+            .iter()
+            .map(|i| i.raw_data.as_str())
+            .collect::<Vec<_>>()
+            .join(" ");
+        let summary = if joined.contains("smiling")
+            && joined.contains("frowning")
+            && joined.contains("Travis")
+        {
+            "Travis suddenly becomes sad".to_string()
+        } else {
+            joined.clone()
+        };
+        Ok(Impression::new(summary.clone(), Some(joined), summary))
+    }
+}
+
+#[tokio::test]
+async fn prehension_summarizes_buffer() {
+    let wit = Prehension::new(MoodSummarizer::default());
+    wit.observe(Impression::new(
+        "",
+        None::<String>,
+        "I see a man smiling".to_string(),
+    ))
+    .await;
+    wit.observe(Impression::new(
+        "",
+        None::<String>,
+        "I recognize Travis's face".to_string(),
+    ))
+    .await;
+    wit.observe(Impression::new(
+        "",
+        None::<String>,
+        "I see a man frowning".to_string(),
+    ))
+    .await;
+    let result = wit.tick().await.unwrap();
+    assert_eq!(result.headline, "Travis suddenly becomes sad");
+}


### PR DESCRIPTION
## Summary
- introduce `Prehension` for buffered summarization
- make `Wit` generic over input and output
- update `VisionWit` and registration helpers
- document the new trait and usage
- add tests for `Prehension`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68524fdc610c83209094c48c8a7093a7