### PR TITLE
Add Wit debugging websocket

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@ This repository is a Rust workspace.
 ## Communication
 
 * Expose WebSocket chat at `/ws`, forwarding all `Psyche` events.
+* Debug information from Wits streams via `/debug`.
 * SSE endpoints like `/chat` are deprecated; use WebSocket only.
 
 ## Audio / TTS

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ cargo run -p pete --features tts -- \
 ## Web Interface
 
 After starting the server, visit `http://127.0.0.1:3000/` in your browser. The page connects to `ws://localhost:3000/ws` and lets you chat with Pete in real time.
+A second WebSocket at `ws://localhost:3000/debug` streams debugging information from the Wits.
 When the page receives a `pete-says` message it echoes back `{type: "displayed", text}` so the server knows the line was shown. Connection status is shown in the sidebar.
 Emotion updates arrive via `pete-emotion` messages containing an emoji string.
 

--- a/index.html
+++ b/index.html
@@ -21,6 +21,10 @@
       padding: 0.25rem 0.5rem;
       border-radius: 0.375rem;
     }
+    #thoughts li {
+      align-self: flex-start;
+      color: #6b7280;
+    }
   </style>
   <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
 </head>
@@ -28,6 +32,7 @@
   <div x-data="chatApp()" x-init="init()" class="flex w-full max-w-4xl h-[80vh] bg-white rounded-xl shadow overflow-hidden">
     <aside class="w-48 p-4 bg-gray-100 space-y-2">
       <div id="status" x-text="status" class="text-xs font-semibold text-gray-500"></div>
+      <div id="debug-status" x-text="debugStatus" class="text-xs text-gray-400"></div>
       <div id="face" x-text="emotion" class="text-4xl"></div>
       <audio controls x-ref="player" class="w-full"></audio>
       <video x-ref="video" autoplay playsinline class="w-full max-h-40"></video>
@@ -36,6 +41,11 @@
       <ul id="log" x-ref="log" class="chat-log p-2 bg-gray-50 rounded flex flex-col space-y-1 flex-grow list-none">
         <template x-for="(msg, i) in log" :key="i">
           <li :class="msg.role" x-text="msg.text"></li>
+        </template>
+      </ul>
+      <ul id="thoughts" class="p-2 bg-gray-50 rounded flex flex-col space-y-1 text-sm text-gray-500 list-none max-h-32 overflow-y-auto">
+        <template x-for="(t, i) in thoughts" :key="'t'+i">
+          <li x-text="t"></li>
         </template>
       </ul>
       <form class="flex gap-2 mt-auto" @submit.prevent="send">
@@ -50,15 +60,18 @@
     function chatApp() {
       return {
         ws: null,
+        debugWs: null,
         status: 'WS: connecting',
+        debugStatus: 'Debug: connecting',
         log: [],
+        thoughts: [],
         input: '',
         lastText: '',
         emotion: '😐',
         audioQueue: [],
         playing: false,
         stream: null,
-        init() { this.connect(); this.initCamera(); },
+        init() { this.connect(); this.connectDebug(); this.initCamera(); },
         initCamera() {
           navigator.mediaDevices.getUserMedia({ video: true }).then(s => {
             this.stream = s;
@@ -94,6 +107,25 @@
             } catch (_) {
               this.append('system', ev.data);
             }
+          };
+        },
+        connectDebug() {
+          if (this.debugWs && (this.debugWs.readyState === WebSocket.OPEN || this.debugWs.readyState === WebSocket.CONNECTING)) {
+            return;
+          }
+          if (this.debugWs) { this.debugWs.close(); }
+          this.debugStatus = 'Debug: connecting';
+          this.debugWs = new WebSocket('ws://localhost:3000/debug');
+          this.debugWs.onopen = () => this.debugStatus = 'Debug: open';
+          this.debugWs.onclose = () => { this.debugStatus = 'Debug: closed'; setTimeout(() => this.connectDebug(), 1000); };
+          this.debugWs.onerror = () => this.debugStatus = 'Debug: error';
+          this.debugWs.onmessage = (ev) => {
+            try {
+              const d = JSON.parse(ev.data);
+              if (d.type === 'wit') {
+                this.thoughts.push(`${d.name}: ${d.prompt} => ${d.output}`);
+              }
+            } catch {}
           };
         },
         playNext() {

--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -89,6 +89,7 @@ async fn main() -> anyhow::Result<()> {
 
     tokio::spawn(listen_user_input(user_rx, ear.clone()));
 
+    let wit_rx = psyche.wit_reports();
     tokio::spawn(async move {
         psyche.run().await;
     });
@@ -97,6 +98,7 @@ async fn main() -> anyhow::Result<()> {
         user_input: user_tx,
         events: events.clone(),
         logs: Arc::new(log_tx.subscribe()),
+        wits: Arc::new(wit_rx),
         ear: ear.clone(),
         eye: eye.clone(),
         conversation,

--- a/pete/src/psyche_factory.rs
+++ b/pete/src/psyche_factory.rs
@@ -43,7 +43,11 @@ pub fn dummy_psyche() -> Psyche {
         mouth,
         ear,
     );
-    psyche.register_typed_wit(Arc::new(psyche::VisionWit::new(Arc::new(Dummy))));
+    let wit_tx = psyche.wit_sender();
+    psyche.register_typed_wit(Arc::new(psyche::VisionWit::with_debug(
+        Arc::new(Dummy),
+        wit_tx,
+    )));
     psyche.set_turn_limit(usize::MAX);
     info!("created dummy psyche");
     psyche
@@ -71,9 +75,11 @@ pub fn ollama_psyche(host: &str, model: &str) -> anyhow::Result<Psyche> {
         mouth,
         ear,
     );
-    psyche.register_typed_wit(Arc::new(psyche::VisionWit::new(Arc::new(
-        psyche::ling::OllamaProvider::new(host, model)?,
-    ))));
+    let wit_tx = psyche.wit_sender();
+    psyche.register_typed_wit(Arc::new(psyche::VisionWit::with_debug(
+        Arc::new(psyche::ling::OllamaProvider::new(host, model)?),
+        wit_tx,
+    )));
     psyche.set_turn_limit(usize::MAX);
     info!(%host, %model, "created ollama psyche");
     Ok(psyche)

--- a/pete/tests/conversation.rs
+++ b/pete/tests/conversation.rs
@@ -17,6 +17,7 @@ async fn returns_log_json() {
         Arc::new(AtomicBool::new(false)),
     ));
     let (event_tx, _) = broadcast::channel(8);
+    let (wit_tx, _) = broadcast::channel(8);
     let (log_tx, _) = broadcast::channel(8);
     let (user_tx, _user_rx) = mpsc::unbounded_channel();
     let eye = Arc::new(EyeSensor::new(psyche.input_sender()));
@@ -24,6 +25,7 @@ async fn returns_log_json() {
         user_input: user_tx,
         events: Arc::new(event_tx.subscribe()),
         logs: Arc::new(log_tx.subscribe()),
+        wits: Arc::new(wit_tx.subscribe()),
         ear,
         eye,
         conversation,

--- a/pete/tests/index.rs
+++ b/pete/tests/index.rs
@@ -5,7 +5,7 @@ async fn serves_index_html() {
     let resp = index().await;
     assert!(resp.0.contains("ws://localhost:3000/ws"));
     assert!(resp.0.contains("WS:"));
-    assert_eq!(resp.0.matches("new WebSocket").count(), 1);
+    assert_eq!(resp.0.matches("new WebSocket").count(), 2);
     assert!(
         resp.0
             .contains("this.log[this.log.length - 1].text += text")

--- a/pete/tests/ws_audio.rs
+++ b/pete/tests/ws_audio.rs
@@ -19,12 +19,14 @@ async fn websocket_forwards_audio() {
     ));
     let eye = Arc::new(EyeSensor::new(psyche.input_sender()));
     let (event_tx, _) = broadcast::channel(8);
+    let (wit_tx, _) = broadcast::channel(8);
     let (log_tx, _) = broadcast::channel(8);
     let (user_tx, _user_rx) = mpsc::unbounded_channel();
     let state = AppState {
         user_input: user_tx,
         events: Arc::new(event_tx.subscribe()),
         logs: Arc::new(log_tx.subscribe()),
+        wits: Arc::new(wit_tx.subscribe()),
         ear,
         eye,
         conversation,

--- a/psyche/tests/wit_report.rs
+++ b/psyche/tests/wit_report.rs
@@ -1,0 +1,36 @@
+use async_trait::async_trait;
+use chrono::Utc;
+use psyche::ling::{Doer, Instruction};
+use psyche::{Heart, Impression, Summarizer, Will, WitReport};
+use tokio::sync::broadcast;
+use uuid::Uuid;
+
+#[derive(Clone)]
+struct Dummy;
+
+#[async_trait]
+impl Doer for Dummy {
+    async fn follow(&self, _: Instruction) -> anyhow::Result<String> {
+        Ok("ok".to_string())
+    }
+}
+
+#[tokio::test]
+async fn will_sends_report() {
+    let (tx, mut rx) = broadcast::channel(8);
+    let will = Will::with_debug(Box::new(Dummy), tx.clone());
+    let _ = will
+        .digest(&[Impression {
+            id: Uuid::new_v4(),
+            timestamp: Utc::now(),
+            headline: "".into(),
+            details: None,
+            raw_data: "go".to_string(),
+        }])
+        .await
+        .unwrap();
+    let report = rx.recv().await.unwrap();
+    assert_eq!(report.name, "Will");
+    assert!(report.prompt.contains("go") || report.prompt.contains("Go"));
+    assert_eq!(report.output, "ok");
+}


### PR DESCRIPTION
## Summary
- broadcast wit prompts and responses via new `WitReport`
- wire debug channel through psyche and web server
- show wit thoughts in browser with muted styling
- update tests for new websocket and add wit report test

## Testing
- `cargo test --quiet`
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852531fdad48320bbaacb766951e3ea