### PR TITLE
Fix conversation log duplication

### DIFF
--- a/lingproc/src/segment.rs
+++ b/lingproc/src/segment.rs
@@ -18,10 +18,10 @@ where
     S: Stream<Item = Result<String, E>> + Unpin,
 {
     use futures::stream::unfold;
-    let mut buf = String::new();
+    let buf = String::new();
     let seg = Segmenter::new().expect("segmenter init");
-    let mut leftover = String::new();
-    let mut pending: VecDeque<String> = VecDeque::new();
+    let leftover = String::new();
+    let pending: VecDeque<String> = VecDeque::new();
 
     unfold(
         (input, buf, seg, leftover, pending),
@@ -68,8 +68,8 @@ where
     S: Stream<Item = Result<String, E>> + Unpin,
 {
     use futures::stream::unfold;
-    let mut buf = String::new();
-    let mut pending: VecDeque<String> = VecDeque::new();
+    let buf = String::new();
+    let pending: VecDeque<String> = VecDeque::new();
 
     unfold(
         (input, buf, pending),

--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -370,8 +370,6 @@ impl Psyche {
                     Some(Sensation::HeardUserVoice(msg)) => {
                         debug!("heard user voice: {}", msg);
                         self.ear.hear_user_say(&msg).await;
-                        let mut conv = self.conversation.lock().await;
-                        conv.add_user(msg);
                         self.pending_user_message = true;
                         continue;
                     }
@@ -445,8 +443,6 @@ impl Psyche {
                                 self.is_speaking = false;
                             }
                             self.ear.hear_user_say(&msg).await;
-                            let mut conv = self.conversation.lock().await;
-                            conv.add_user(msg);
                             self.pending_user_message = true;
                             break;
                         }


### PR DESCRIPTION
## Summary
- prevent user messages from being added to the conversation twice
- clean up unused mut declarations in `lingproc::segment`

## Testing
- `cargo clippy`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6852c2bb2e1c8320872bb9814ffa699b