### PR TITLE
Add Combobulator wit

### DIFF
--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -17,11 +17,13 @@ pub mod traits {
 
 pub mod wit;
 pub mod wits {
+    pub mod combobulator;
     pub mod heart;
     pub mod memory;
     pub mod vision_wit;
     pub mod will;
 
+    pub use combobulator::Combobulator;
     pub use heart::Heart;
     pub use memory::{BasicMemory, GraphStore, Memory, Neo4jClient, NoopMemory, QdrantClient};
     pub use vision_wit::VisionWit;
@@ -46,7 +48,7 @@ pub use impression::Impression;
 pub use motor::{Motor, NoopMotor};
 pub use plain_mouth::PlainMouth;
 pub use prehension::Prehension;
-pub use prompt::{HeartPrompt, PromptBuilder, VoicePrompt, WillPrompt};
+pub use prompt::{CombobulatorPrompt, HeartPrompt, PromptBuilder, VoicePrompt, WillPrompt};
 pub use psyche::DEFAULT_SYSTEM_PROMPT;
 pub use sensor::Sensor;
 pub use trim_mouth::TrimMouth;

--- a/psyche/src/prompt.rs
+++ b/psyche/src/prompt.rs
@@ -39,3 +39,13 @@ impl PromptBuilder for HeartPrompt {
         format!("Respond with a single emoji describing the overall emotion of:\n{input}")
     }
 }
+
+/// Prompt builder for the `Combobulator` subagent.
+#[derive(Clone, Default)]
+pub struct CombobulatorPrompt;
+
+impl PromptBuilder for CombobulatorPrompt {
+    fn build(&self, input: &str) -> String {
+        format!("Summarize Pete's current awareness in one sentence:\n{input}")
+    }
+}

--- a/psyche/src/wits/combobulator.rs
+++ b/psyche/src/wits/combobulator.rs
@@ -1,0 +1,101 @@
+use crate::prompt::PromptBuilder;
+use crate::{
+    Impression, Summarizer,
+    ling::{Doer, Instruction},
+    wit::Episode,
+};
+use async_trait::async_trait;
+use chrono::Utc;
+use std::sync::Arc;
+use tokio::sync::broadcast;
+use uuid::Uuid;
+
+/// Summarizes recent [`Episode`]s into a short awareness statement.
+///
+/// The resulting sentence feeds into [`Will`] to inform the next action.
+///
+/// # Example
+/// ```no_run
+/// # use psyche::{wits::Combobulator, ling::{Doer, Instruction}, Impression, Summarizer, wit::Episode};
+/// # use async_trait::async_trait;
+/// # struct Dummy;
+/// # #[async_trait]
+/// # impl Doer for Dummy {
+/// #   async fn follow(&self, _i: Instruction) -> anyhow::Result<String> {
+/// #       Ok("All clear.".to_string())
+/// #   }
+/// # }
+/// # #[tokio::main]
+/// # async fn main() -> anyhow::Result<()> {
+/// let combo = Combobulator::new(Box::new(Dummy));
+/// let imp = combo
+///     .digest(&[Impression::new("", None::<String>, Episode { summary: "Pete looked around".into() })])
+///     .await?;
+/// assert_eq!(imp.raw_data, "All clear.");
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Clone)]
+pub struct Combobulator {
+    doer: Arc<dyn Doer>,
+    prompt: crate::prompt::CombobulatorPrompt,
+    tx: Option<broadcast::Sender<crate::WitReport>>,
+}
+
+impl Combobulator {
+    /// Create a new `Combobulator` using the provided [`Doer`].
+    pub fn new(doer: Box<dyn Doer>) -> Self {
+        Self {
+            doer: doer.into(),
+            prompt: crate::prompt::CombobulatorPrompt::default(),
+            tx: None,
+        }
+    }
+
+    /// Create a `Combobulator` that emits [`WitReport`]s using `tx`.
+    pub fn with_debug(doer: Box<dyn Doer>, tx: broadcast::Sender<crate::WitReport>) -> Self {
+        Self {
+            doer: doer.into(),
+            prompt: crate::prompt::CombobulatorPrompt::default(),
+            tx: Some(tx),
+        }
+    }
+
+    /// Replace the prompt builder.
+    pub fn set_prompt(&mut self, prompt: crate::prompt::CombobulatorPrompt) {
+        self.prompt = prompt;
+    }
+}
+
+#[async_trait]
+impl Summarizer<Episode, String> for Combobulator {
+    async fn digest(&self, inputs: &[Impression<Episode>]) -> anyhow::Result<Impression<String>> {
+        let mut combined = String::new();
+        for imp in inputs {
+            if !combined.is_empty() {
+                combined.push(' ');
+            }
+            combined.push_str(&imp.raw_data.summary);
+        }
+        let instruction = Instruction {
+            command: self.prompt.build(&combined),
+            images: Vec::new(),
+        };
+        let resp = self.doer.follow(instruction.clone()).await?;
+        let summary = resp.trim().to_string();
+        if let Some(tx) = &self.tx {
+            let _ = tx.send(crate::WitReport {
+                name: "Combobulator".into(),
+                prompt: instruction.command.clone(),
+                output: summary.clone(),
+            });
+        }
+        Ok(Impression {
+            id: Uuid::new_v4(),
+            timestamp: Utc::now(),
+            headline: summary.clone(),
+            details: Some(combined),
+            raw_data: summary,
+        })
+    }
+}

--- a/psyche/tests/combobulator.rs
+++ b/psyche/tests/combobulator.rs
@@ -1,0 +1,34 @@
+use async_trait::async_trait;
+use chrono::Utc;
+use psyche::ling::{Doer, Instruction};
+use psyche::{Impression, Summarizer, wit::Episode, wits::Combobulator};
+use uuid::Uuid;
+
+#[derive(Clone)]
+struct Dummy;
+
+#[async_trait]
+impl Doer for Dummy {
+    async fn follow(&self, _: Instruction) -> anyhow::Result<String> {
+        Ok("All clear.".to_string())
+    }
+}
+
+#[tokio::test]
+async fn returns_awareness_impression() {
+    let combo = Combobulator::new(Box::new(Dummy));
+    let imp = combo
+        .digest(&[Impression {
+            id: Uuid::new_v4(),
+            timestamp: Utc::now(),
+            headline: "".into(),
+            details: None,
+            raw_data: Episode {
+                summary: "Pete looked around.".into(),
+            },
+        }])
+        .await
+        .unwrap();
+    assert_eq!(imp.raw_data, "All clear.");
+    assert_eq!(imp.headline, "All clear.");
+}


### PR DESCRIPTION
## Summary
- add `Combobulator` wit for summarizing episodes
- export new prompt and wit in `lib.rs`
- provide `CombobulatorPrompt` for prompt generation
- test Combobulator summarization

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68530748c930832084073b05e9a402b1