### PR TITLE
Add wit debug display

### DIFF
--- a/frontend/__tests__/debug.test.js
+++ b/frontend/__tests__/debug.test.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+function loadApp() {
+  const html = fs.readFileSync(path.join(__dirname, '../..', 'index.html'), 'utf8');
+  const dom = new JSDOM(html, { runScripts: 'dangerously' });
+  const { window } = dom;
+  global.document = window.document;
+  global.window = window;
+  window.navigator.mediaDevices = { getUserMedia: () => Promise.resolve({}) };
+  const socket = {};
+  window.WebSocket = jest.fn(() => socket);
+  const app = window.chatApp();
+  app.$refs = { log: document.createElement('div'), player: {}, video: {} };
+  app.ws = { send: jest.fn() };
+  app.connectDebug();
+  return { app, socket };
+}
+
+test('debug messages append thoughts', () => {
+  const { app, socket } = loadApp();
+  const msg = JSON.stringify({ type: 'wit', name: 'Will', prompt: 'go', output: 'ok' });
+  socket.onmessage({ data: msg });
+  expect(app.thoughts[0]).toBe('Will: go => ok');
+});

--- a/index.html
+++ b/index.html
@@ -36,16 +36,16 @@
       <div id="face" x-text="emotion" class="text-4xl"></div>
       <audio controls x-ref="player" class="w-full"></audio>
       <video x-ref="video" autoplay playsinline class="w-full max-h-40"></video>
+      <ul id="thoughts" class="p-2 bg-gray-50 rounded flex flex-col space-y-1 text-xs text-gray-500 list-none max-h-24 overflow-y-auto">
+        <template x-for="(t, i) in thoughts" :key="'t'+i">
+          <li x-text="t"></li>
+        </template>
+      </ul>
     </aside>
     <main class="flex flex-col flex-1 p-6 space-y-4">
       <ul id="log" x-ref="log" class="chat-log p-2 bg-gray-50 rounded flex flex-col space-y-1 flex-grow list-none">
         <template x-for="(msg, i) in log" :key="i">
           <li :class="msg.role" x-text="msg.text"></li>
-        </template>
-      </ul>
-      <ul id="thoughts" class="p-2 bg-gray-50 rounded flex flex-col space-y-1 text-sm text-gray-500 list-none max-h-32 overflow-y-auto">
-        <template x-for="(t, i) in thoughts" :key="'t'+i">
-          <li x-text="t"></li>
         </template>
       </ul>
       <form class="flex gap-2 mt-auto" @submit.prevent="send">


### PR DESCRIPTION
## Summary
- display /debug messages in the sidebar
- ensure debug websocket messages update thoughts via tests

## Testing
- `npm test`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6853116170d483209078ce2d9ae9933d