### PR TITLE
Improve TTS streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ periodic impressions of type `O`. The `Prehension` helper buffers incoming
 impressions and summarizes them using a `Summarizer`.
 
 `Psyche` starts with a prompt asking the LLM to respond in one or two sentences at most. You can override it with `set_system_prompt`.
+Pete's mouth streams audio one sentence at a time so long replies don't block.
 
 Example with the `OllamaProvider`:
 

--- a/pete/src/tts_mouth.rs
+++ b/pete/src/tts_mouth.rs
@@ -111,21 +111,20 @@ impl Mouth for TtsMouth {
             }
             match self.tts.stream_wav(sent).await {
                 Ok(mut stream) => {
-                    let mut buf = Vec::new();
                     while let Some(chunk) = stream.next().await {
                         match chunk {
-                            Ok(bytes) => buf.extend_from_slice(&bytes),
+                            Ok(bytes) if !bytes.is_empty() => {
+                                let b64 = general_purpose::STANDARD.encode(bytes);
+                                if self.events.send(Event::SpeechAudio(b64)).is_err() {
+                                    error!("failed sending audio chunk");
+                                    break;
+                                }
+                            }
+                            Ok(_) => {}
                             Err(e) => {
                                 error!(?e, "tts streaming failed");
-                                buf.clear();
                                 break;
                             }
-                        }
-                    }
-                    if !buf.is_empty() {
-                        let b64 = general_purpose::STANDARD.encode(buf);
-                        if self.events.send(Event::SpeechAudio(b64)).is_err() {
-                            error!("failed sending audio chunk");
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- stream Coqui TTS output chunk-by-chunk instead of buffering
- document that Pete streams sentences individually to TTS

## Testing
- `cargo fetch`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_685314e4c1648320aa4b9db9560eb3a5