### PR TITLE
Update voice context and share across wits

### DIFF
--- a/lingproc/src/provider.rs
+++ b/lingproc/src/provider.rs
@@ -64,6 +64,8 @@ impl Chatter for OllamaProvider {
             });
         Ok(Box::pin(stream))
     }
+
+    async fn update_prompt_context(&self, _context: &str) {}
 }
 
 #[async_trait]

--- a/lingproc/src/types.rs
+++ b/lingproc/src/types.rs
@@ -139,6 +139,11 @@ pub trait Chatter: Send + Sync {
     ///
     /// Returns a stream of response chunks from the language model.
     async fn chat(&self, system_prompt: &str, history: &[Message]) -> Result<ChatStream>;
+
+    /// Update additional context for future prompts.
+    ///
+    /// Default implementation does nothing so callers may ignore this.
+    async fn update_prompt_context(&self, _context: &str) {}
 }
 
 /// Trait for generating semantic vector embeddings from text.


### PR DESCRIPTION
## Summary
- let `Chatter` accept prompt context updates
- implement stub `update_prompt_context` for the Ollama provider
- store `Chatter` inside `Psyche` as an `Arc` so the experience loop can share it
- propagate wit impressions into the voice prompt context

## Testing
- `cargo test`
- `npm install && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68531342c61c8320a0d7306e375f03f4