### PR TITLE
Fix streaming and audio error handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,6 +68,7 @@
         thoughts: [],
         input: '',
         lastText: '',
+        pendingText: '',
         emotion: '😐',
         audioQueue: [],
         playing: false,
@@ -77,9 +78,11 @@
         initCamera() {
           navigator.mediaDevices.getUserMedia({ video: true }).then(s => {
             this.stream = s;
+            this.stream.oninactive = () => this.initCamera();
             const v = this.$refs.video;
             v.srcObject = s;
             v.play().catch(() => {});
+            v.onerror = () => this.initCamera();
             this.startCaptureLoop();
           }).catch(() => {});
         },
@@ -99,10 +102,16 @@
               if (data.kind === 'pete-emotion') {
                 this.emotion = data.text;
               } else if (data.text) {
-                this.lastText = data.text;
+                this.pendingText += data.text;
                 this.append('system', data.text);
               }
               if (data.audio) {
+                if (this.pendingText) {
+                  this.ws.send(JSON.stringify({ type: 'displayed', text: this.pendingText }));
+                  console.log('sent displayed ack:', this.pendingText);
+                  this.lastText = this.pendingText;
+                  this.pendingText = '';
+                }
                 this.audioQueue.push({ audio: data.audio, text: this.lastText });
                 console.log('queued audio', this.audioQueue.length);
                 this.playNext();
@@ -152,9 +161,18 @@
                   document.addEventListener('click', resume);
                 } else {
                   console.error('Audio playback failed:', err);
+                  this.playing = false;
+                  this.ws.send(JSON.stringify({ type: 'played', text }));
+                  this.playNext();
                 }
               });
             }
+          };
+          player.onerror = () => {
+            this.playing = false;
+            this.ws.send(JSON.stringify({ type: 'played', text }));
+            console.error('Audio element error');
+            this.playNext();
           };
           player.onended = () => {
             this.playing = false;
@@ -175,10 +193,6 @@
           }
           this.$nextTick(() => {
             if (atBottom) el.scrollTop = el.scrollHeight;
-            if (role !== 'user') {
-              this.ws.send(JSON.stringify({ type: 'displayed', text }));
-              console.log('sent displayed ack:', text);
-            }
           });
         },
         send() {

--- a/pete/Cargo.toml
+++ b/pete/Cargo.toml
@@ -22,6 +22,7 @@ dioxus-ssr = "0.4.3"
 reqwest = { version = "0.11", features = ["stream"] }
 base64 = { version = "0.21" }
 futures = "0.3"
+urlencoding = "2"
 
 [features]
 default = []


### PR DESCRIPTION
## Summary
- properly URL encode TTS text
- send each WAV per sentence instead of chunks
- queue text until audio and send single displayed ack
- recover gracefully on audio or video errors

## Testing
- `cargo test --all --no-fail-fast`
- `npx jest --silent`

------
https://chatgpt.com/codex/tasks/task_e_685323c9d5e48320855859cb70909910