### PR TITLE
Progressive TTS playback

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,6 @@
         log: [],
         thoughts: [],
         input: '',
-        lastText: '',
         pendingText: '',
         emotion: '😐',
         audioQueue: [],
@@ -103,16 +102,11 @@
                 this.emotion = data.text;
               } else if (data.text) {
                 this.pendingText += data.text;
-                this.append('system', data.text);
               }
               if (data.audio) {
-                if (this.pendingText) {
-                  this.ws.send(JSON.stringify({ type: 'displayed', text: this.pendingText }));
-                  console.log('sent displayed ack:', this.pendingText);
-                  this.lastText = this.pendingText;
-                  this.pendingText = '';
-                }
-                this.audioQueue.push({ audio: data.audio, text: this.lastText });
+                const text = this.pendingText;
+                this.pendingText = '';
+                this.audioQueue.push({ audio: data.audio, text });
                 console.log('queued audio', this.audioQueue.length);
                 this.playNext();
               }
@@ -170,12 +164,14 @@
           };
           player.onerror = () => {
             this.playing = false;
+            this.append('system', text);
             this.ws.send(JSON.stringify({ type: 'played', text }));
             console.error('Audio element error');
             this.playNext();
           };
           player.onended = () => {
             this.playing = false;
+            this.append('system', text);
             this.ws.send(JSON.stringify({ type: 'played', text }));
             console.log('sent played ack:', text);
             this.playNext();

--- a/psyche/Cargo.toml
+++ b/psyche/Cargo.toml
@@ -10,6 +10,7 @@ ollama-rs = { version = "0.3", features = ["stream"] }
 tokio = { version = "1", features = ["sync"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tracing = "0.1"
+pragmatic-segmenter = "0.1"
 lingproc = { path = "../lingproc" }
 futures = "0.3"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary
- speak assistant sentences progressively while streaming voice output
- forward `IntentionToSay` events to the browser
- queue chat text until audio plays on the frontend
- update dependencies for segmentation

## Testing
- `cargo fetch`
- `cargo test --workspace --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68535d0fb0548320b326f80df3a4d3dd