### PR TITLE
Adjust mouth echo flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,6 +102,8 @@
                 this.emotion = data.text;
               } else if (data.text) {
                 this.pendingText += data.text;
+                this.append('system', data.text);
+                this.ws.send(JSON.stringify({ type: 'displayed', text: data.text }));
               }
               if (data.audio) {
                 const text = this.pendingText;

--- a/psyche/src/psyche.rs
+++ b/psyche/src/psyche.rs
@@ -276,6 +276,10 @@ impl Psyche {
                     tokio::time::sleep(Duration::from_millis(100)).await;
                 }
             }
+            while let Ok(Sensation::HeardOwnVoice(msg)) = self.input_rx.try_recv() {
+                let mut conv = self.conversation.lock().await;
+                conv.add_assistant(msg);
+            }
             if self.speak_when_spoken_to && !self.pending_user_message {
                 match self.input_rx.recv().await {
                     Some(Sensation::HeardUserVoice(msg)) => {
@@ -346,11 +350,6 @@ impl Psyche {
                                     self.is_speaking = true;
                                     self.countenance.express(&self.emotion);
                                     self.mouth.speak(&sentence).await;
-                                    self.ear.hear_self_say(&sentence).await;
-                                    {
-                                        let mut conv = self.conversation.lock().await;
-                                        conv.add_assistant(sentence.clone());
-                                    }
                                     self.is_speaking = false;
                                 }
                             }
@@ -374,11 +373,6 @@ impl Psyche {
                     self.is_speaking = true;
                     self.countenance.express(&self.emotion);
                     self.mouth.speak(trimmed).await;
-                    self.ear.hear_self_say(trimmed).await;
-                    {
-                        let mut conv = self.conversation.lock().await;
-                        conv.add_assistant(trimmed.to_string());
-                    }
                     self.is_speaking = false;
                 }
 

--- a/psyche/tests/converse.rs
+++ b/psyche/tests/converse.rs
@@ -228,7 +228,10 @@ async fn adds_message_after_voice_heard() {
     while let Ok(evt) = events.recv().await {
         match evt {
             Event::StreamChunk(_) => saw_chunk = true,
-            Event::IntentionToSay(_) => break,
+            Event::IntentionToSay(t) => {
+                input.send(Sensation::HeardOwnVoice(t)).unwrap();
+                break;
+            }
             Event::SpeechAudio(_) => {}
             Event::EmotionChanged(_) => {}
         }
@@ -538,6 +541,8 @@ async fn voice_response_is_echoed() {
     while let Ok(evt) = events.recv().await {
         if let Event::IntentionToSay(msg) = evt {
             assert_eq!(msg, "hi 🙂");
+            ear.hear_self_say(&msg).await;
+            input.send(Sensation::HeardOwnVoice(msg)).unwrap();
             break;
         }
     }


### PR DESCRIPTION
## Summary
- add displayed ACKs to the frontend when text chunks arrive
- record HeardOwnVoice messages before starting a new turn
- update tests to send HeardOwnVoice ACKs

## Testing
- `cargo test > /tmp/test.log && tail -n 20 /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_e_685364be4e608320946a4745b199ca8a