### PR TITLE
Clarify summarization prompts

### DIFF
--- a/psyche/src/prompt.rs
+++ b/psyche/src/prompt.rs
@@ -26,7 +26,7 @@ pub struct WillPrompt;
 
 impl PromptBuilder for WillPrompt {
     fn build(&self, input: &str) -> String {
-        format!("In one short sentence, what should Pete do or say next?\n{input}")
+        format!("In one or two short sentences, what should Pete do or say next?\n{input}")
     }
 }
 
@@ -46,6 +46,6 @@ pub struct CombobulatorPrompt;
 
 impl PromptBuilder for CombobulatorPrompt {
     fn build(&self, input: &str) -> String {
-        format!("Summarize Pete's current awareness in one sentence:\n{input}")
+        format!("Summarize Pete's current awareness in one or two sentences:\n{input}")
     }
 }

--- a/psyche/src/traits/wit.rs
+++ b/psyche/src/traits/wit.rs
@@ -149,7 +149,7 @@ impl Summarizer<Sensation, Instant> for InstantWit {
             combined.push_str(&desc);
         }
         let prompt = format!(
-            "Summarize the following sensations in one sentence:\n{}",
+            "Summarize the following sensations in one or two sentences:\n{}",
             combined
         );
         let resp = self
@@ -224,7 +224,7 @@ impl Summarizer<Instant, Moment> for MomentWit {
         let combined = combined.trim().to_string();
 
         let prompt = format!(
-            "Summarize the following observations into one short paragraph:\n{}",
+            "Summarize the following observations in one or two sentences:\n{}",
             combined
         );
 
@@ -290,7 +290,7 @@ impl Summarizer<Moment, Situation> for SituationWit {
             combined.push_str(&imp.raw_data.summary);
         }
         let prompt = format!(
-            "Summarize the following moments in one sentence:\n{}",
+            "Summarize the following moments in one or two sentences:\n{}",
             combined
         );
         let resp = self
@@ -356,7 +356,7 @@ impl Summarizer<Situation, Episode> for EpisodeWit {
             combined.push_str(&imp.raw_data.summary);
         }
         let prompt = format!(
-            "Summarize these situations into a short episode:\n{}",
+            "Summarize these situations in one or two sentences:\n{}",
             combined
         );
         let resp = self


### PR DESCRIPTION
## Summary
- specify 1–2 sentence limit in `WillPrompt`
- match `CombobulatorPrompt` wording
- adjust Wit prompts for same constraint

## Testing
- `cargo test` *(fails: tests hang)*
- `npm install`
- `npm test` *(fails: audio tests error)*

------
https://chatgpt.com/codex/tasks/task_e_68539801325c83208a9ce1baba6307c7