### PR TITLE
Implement body description support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ This repository is a Rust workspace.
 * Prefer traits for abstraction (`Mouth`, `Ear`, `Countenance`, `Wit`).
 * Use `Summarizer` when batching impressions into higher-level summaries.
 * Document new traits with examples and unit tests.
+* Sensors expose `description()` for prompt inclusion.
 * Prefer `AndMouth` when composing multiple `Mouth` implementations.
 * Use `TrimMouth` to skip speaking empty/whitespace-only text.
 * Use `EmojiMouth` to route emoji to the countenance instead of speaking them.

--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -7,7 +7,7 @@ use pete::{
 #[cfg(feature = "tts")]
 use pete::{CoquiTts, TtsMouth};
 use psyche::PlainMouth;
-use psyche::{AndMouth, EmojiMouth, Mouth, TrimMouth};
+use psyche::{AndMouth, EmojiMouth, Mouth, Sensor, TrimMouth};
 use std::{
     net::SocketAddr,
     sync::{
@@ -87,6 +87,7 @@ async fn main() -> anyhow::Result<()> {
         speaking.clone(),
     ));
     let eye = Arc::new(EyeSensor::new(psyche.input_sender()));
+    psyche.add_sense(eye.description());
     let (user_tx, user_rx) = mpsc::unbounded_channel();
 
     tokio::spawn(listen_user_input(user_rx, ear.clone()));

--- a/pete/src/sensor/eye.rs
+++ b/pete/src/sensor/eye.rs
@@ -22,4 +22,8 @@ impl Sensor<ImageData> for EyeSensor {
         debug!("eye sensed image");
         let _ = self.forward.send(Sensation::Of(Box::new(image)));
     }
+
+    fn description(&self) -> String {
+        "Webcam: Streams images from your environment.".to_string()
+    }
 }

--- a/pete/tests/conversation.rs
+++ b/pete/tests/conversation.rs
@@ -1,5 +1,6 @@
 use axum::{body, extract::State, response::IntoResponse};
 use pete::{AppState, ChannelEar, EyeSensor, conversation_log, dummy_psyche};
+use psyche::Sensor;
 use std::sync::{
     Arc,
     atomic::{AtomicBool, AtomicUsize},
@@ -8,7 +9,7 @@ use tokio::sync::{broadcast, mpsc};
 
 #[tokio::test]
 async fn returns_log_json() {
-    let psyche = dummy_psyche();
+    let mut psyche = dummy_psyche();
     let conversation = psyche.conversation();
     conversation.lock().await.add_user("hi".into());
     let ear = Arc::new(ChannelEar::new(
@@ -21,6 +22,7 @@ async fn returns_log_json() {
     let (log_tx, _) = broadcast::channel(8);
     let (user_tx, _user_rx) = mpsc::unbounded_channel();
     let eye = Arc::new(EyeSensor::new(psyche.input_sender()));
+    psyche.add_sense(eye.description());
     let state = AppState {
         user_input: user_tx,
         events: Arc::new(event_tx.subscribe()),

--- a/pete/tests/ws_audio.rs
+++ b/pete/tests/ws_audio.rs
@@ -2,6 +2,7 @@ use axum::{Router, routing::get, serve};
 use futures::StreamExt;
 use pete::{AppState, ChannelEar, EyeSensor, dummy_psyche, ws_handler};
 use psyche::Event;
+use psyche::Sensor;
 use std::sync::{
     Arc,
     atomic::{AtomicBool, AtomicUsize},
@@ -10,7 +11,7 @@ use tokio::sync::{broadcast, mpsc};
 
 #[tokio::test]
 async fn websocket_forwards_audio() {
-    let psyche = dummy_psyche();
+    let mut psyche = dummy_psyche();
     let conversation = psyche.conversation();
     let ear = Arc::new(ChannelEar::new(
         psyche.input_sender(),
@@ -18,6 +19,7 @@ async fn websocket_forwards_audio() {
         Arc::new(AtomicBool::new(false)),
     ));
     let eye = Arc::new(EyeSensor::new(psyche.input_sender()));
+    psyche.add_sense(eye.description());
     let (event_tx, _) = broadcast::channel(8);
     let (wit_tx, _) = broadcast::channel(8);
     let (log_tx, _) = broadcast::channel(8);

--- a/psyche/src/sensor.rs
+++ b/psyche/src/sensor.rs
@@ -5,4 +5,6 @@ use async_trait::async_trait;
 pub trait Sensor<T>: Send + Sync {
     /// Forward a sensed input of type `T`.
     async fn sense(&self, input: T);
+    /// Human-readable description of this sense.
+    fn description(&self) -> String;
 }

--- a/psyche/tests/prompt.rs
+++ b/psyche/tests/prompt.rs
@@ -64,3 +64,20 @@ fn default_prompt_present() {
     );
     assert_eq!(psyche.system_prompt(), DEFAULT_SYSTEM_PROMPT);
 }
+
+#[test]
+fn senses_are_described() {
+    let mouth = std::sync::Arc::new(Dummy::default());
+    let ear = mouth.clone();
+    let mut psyche = Psyche::new(
+        Box::new(Dummy::default()),
+        Box::new(Dummy::default()),
+        Box::new(Dummy::default()),
+        std::sync::Arc::new(psyche::NoopMemory),
+        mouth,
+        ear,
+    );
+    psyche.add_sense("Heartbeat: Announces the time every 7 minutes.".into());
+    let prompt = psyche.described_system_prompt();
+    assert!(prompt.contains("Heartbeat"));
+}


### PR DESCRIPTION
## Summary
- introduce `description()` method to `Sensor`
- update `EyeSensor` with a basic description
- add sense registration and prompt building in `Psyche`
- expose sense description in server and tests
- document new trait behavior in `AGENTS.md`

## Testing
- `cargo test` *(fails: roundtrip_speech hangs)*

------
https://chatgpt.com/codex/tasks/task_e_685399e17f7083208bfcec91deea10ae