### PR TITLE
Fix webcam capture loop

### DIFF
--- a/frontend/__tests__/audio.test.js
+++ b/frontend/__tests__/audio.test.js
@@ -11,6 +11,7 @@ function loadApp() {
   window.navigator.mediaDevices = { getUserMedia: () => Promise.resolve({}) };
   const app = window.chatApp();
   app.$refs = { player: { src: '', play: jest.fn(() => Promise.resolve()), onended: null }, log: document.createElement('div'), video: {} };
+  app.$nextTick = (cb) => cb();
   app.ws = { send: jest.fn() };
   return app;
 }
@@ -26,6 +27,7 @@ function loadAppWithSocket() {
   window.WebSocket = jest.fn(() => socket);
   const app = window.chatApp();
   app.$refs = { log: document.createElement('div'), player: {}, video: {} };
+  app.$nextTick = (cb) => cb();
   app.connect();
   return { app, socket };
 }

--- a/frontend/__tests__/debug.test.js
+++ b/frontend/__tests__/debug.test.js
@@ -13,6 +13,7 @@ function loadApp() {
   window.WebSocket = jest.fn(() => socket);
   const app = window.chatApp();
   app.$refs = { log: document.createElement('div'), player: {}, video: {} };
+  app.$nextTick = (cb) => cb();
   app.ws = { send: jest.fn() };
   app.connectDebug();
   return { app, socket };

--- a/index.html
+++ b/index.html
@@ -75,6 +75,13 @@
         captureInterval: null,
         init() { this.connect(); this.connectDebug(); this.initCamera(); },
         initCamera() {
+          if (this.stream) {
+            this.stream.getTracks().forEach(t => t.stop());
+          }
+          if (this.captureInterval) {
+            clearInterval(this.captureInterval);
+            this.captureInterval = null;
+          }
           navigator.mediaDevices.getUserMedia({ video: true }).then(s => {
             this.stream = s;
             this.stream.oninactive = () => this.initCamera();


### PR DESCRIPTION
## Summary
- reset capture loop and stop previous tracks when camera restarts
- stub `$nextTick` in frontend tests for jsdom

## Testing
- `cargo test` *(fails: `running 2 tests` hangs)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853a6b76d0083208528676b3e4b25e1