### PR TITLE
Handle frontend errors visibly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ This repository is a Rust workspace.
 * Keep `index.html` and `pete/build.rs` in sync.
 * Front-end tests live under `frontend/` and run with `npm test`.
 * Run `npm install` first if dependencies are missing.
+* Surface front-end errors in the console and show them on the page via `chatApp().error`.
 
 ## Communication
 

--- a/frontend/__tests__/audio.test.js
+++ b/frontend/__tests__/audio.test.js
@@ -26,7 +26,7 @@ function loadAppWithSocket() {
   const socket = { send: jest.fn() };
   window.WebSocket = jest.fn(() => socket);
   const app = window.chatApp();
-  app.$refs = { log: document.createElement('div'), player: {}, video: {} };
+  app.$refs = { log: document.createElement('div'), player: { play: jest.fn(() => Promise.resolve()), onended: null }, video: {} };
   app.$nextTick = (cb) => cb();
   app.connect();
   return { app, socket };
@@ -43,9 +43,8 @@ test('playNext loads audio and sends ack', () => {
   expect(app.playing).toBe(false);
 });
 
-test('displayed ack sent when text arrives', () => {
+test('speech message appends to log', () => {
   const { app, socket } = loadAppWithSocket();
-  socket.onmessage({ data: JSON.stringify({ kind: 'pete-says', text: 'hi' }) });
+  socket.onmessage({ data: JSON.stringify({ kind: 'pete-speech', text: 'hi', audio: '' }) });
   expect(app.log[0].text).toBe('hi');
-  expect(socket.send).toHaveBeenCalledWith(JSON.stringify({ type: 'displayed', text: 'hi' }));
 });

--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
     <aside class="w-48 p-4 bg-gray-100 space-y-2">
       <div id="status" x-text="status" class="text-xs font-semibold text-gray-500"></div>
       <div id="debug-status" x-text="debugStatus" class="text-xs text-gray-400"></div>
+      <div id="error" x-show="error" x-text="error" class="text-xs text-red-600"></div>
       <div id="face" x-text="emotion" class="text-4xl"></div>
       <audio controls x-ref="player" class="w-full"></audio>
       <!-- autoplay on the video element can race with manual play() calls -->
@@ -68,6 +69,7 @@
         thoughts: [],
         input: '',
         emotion: '😐',
+        error: '',
         audioQueue: [],
         playing: false,
         stream: null,
@@ -86,10 +88,16 @@
             this.stream.oninactive = () => this.initCamera();
             const v = this.$refs.video;
             v.srcObject = s;
-            v.play().catch(() => {});
+            v.play().catch(err => {
+              console.error('video play failed:', err);
+              this.error = 'Video play failed: ' + err.message;
+            });
             v.onerror = () => this.initCamera();
             this.startCaptureLoop();
-          }).catch(() => {});
+          }).catch(err => {
+            console.error('getUserMedia failed:', err);
+            this.error = 'Camera error: ' + err.message;
+          });
         },
         connect() {
           if (this.ws && (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING)) {
@@ -100,7 +108,11 @@
           this.ws = new WebSocket('ws://localhost:3000/ws');
           this.ws.onopen = () => this.status = 'WS: open';
           this.ws.onclose = () => { this.status = 'WS: closed'; setTimeout(() => this.connect(), 1000); };
-          this.ws.onerror = () => this.status = 'WS: error';
+          this.ws.onerror = (e) => {
+            console.error('WebSocket error:', e);
+            this.status = 'WS: error';
+            this.error = 'WebSocket error';
+          };
           this.ws.onmessage = (ev) => {
             try {
               const data = JSON.parse(ev.data);
@@ -110,7 +122,9 @@
                 this.audioQueue.push({ audio: data.audio, text: data.text });
                 this.playNext();
               }
-            } catch (_) {
+            } catch (err) {
+              console.error('WS message error:', err);
+              this.error = 'WS parse error: ' + err.message;
               this.append('system', ev.data);
             }
           };
@@ -124,14 +138,21 @@
           this.debugWs = new WebSocket('ws://localhost:3000/debug');
           this.debugWs.onopen = () => this.debugStatus = 'Debug: open';
           this.debugWs.onclose = () => { this.debugStatus = 'Debug: closed'; setTimeout(() => this.connectDebug(), 1000); };
-          this.debugWs.onerror = () => this.debugStatus = 'Debug: error';
+          this.debugWs.onerror = (e) => {
+            console.error('Debug WebSocket error:', e);
+            this.debugStatus = 'Debug: error';
+            this.error = 'Debug WebSocket error';
+          };
           this.debugWs.onmessage = (ev) => {
             try {
               const d = JSON.parse(ev.data);
               if (d.type === 'wit') {
                 this.thoughts.push(`${d.name}: ${d.prompt} => ${d.output}`);
               }
-            } catch {}
+            } catch (err) {
+              console.error('Debug message error:', err);
+              this.error = 'Debug parse error: ' + err.message;
+            }
           };
         },
         playNext() {


### PR DESCRIPTION
## Summary
- surface frontend errors on the page via `error` field
- log websocket and camera errors to console
- update frontend tests for unified speech event
- note error handling in `AGENTS.md`

## Testing
- `cargo test --quiet`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685434f6aa5483209931c2ae38323566