### PR TITLE
Fix tts test compile

### DIFF
--- a/pete/tests/coqui.rs
+++ b/pete/tests/coqui.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "tts")]
 use futures::StreamExt;
 use httpmock::{Method::GET, MockServer};
-use pete::CoquiTts;
+use pete::{CoquiTts, Tts};
 
 #[tokio::test]
 async fn coqui_url_has_required_params() {


### PR DESCRIPTION
## Summary
- fix compile error in tts tests by importing the `Tts` trait

## Testing
- `cargo test`
- `cargo test --features tts`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68545b17c95c8320ad3658f0d6578365