### PR TITLE
Add cucumber E2E scaffold

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,8 @@ This repository is a Rust workspace.
 * Keep `index.html` and `pete/build.rs` in sync.
 * Front-end tests live under `frontend/` and run with `npm test`.
 * Run `npm install` first if dependencies are missing.
+* End-to-end tests are under `pete/tests` and require the `e2e` Cargo feature.
+  Run with `cargo test --features e2e`.
 * Surface front-end errors in the console and show them on the page via `chatApp().error`.
 
 ## Communication

--- a/pete/Cargo.toml
+++ b/pete/Cargo.toml
@@ -27,6 +27,7 @@ urlencoding = "2"
 [features]
 default = []
 tts = []
+e2e = []
 
 [build-dependencies]
 dioxus = { version = "0.4.3", default-features = false, features = ["html", "macro"] }
@@ -37,3 +38,9 @@ assert_cmd = "2"
 futures = "0.3"
 tokio-tungstenite = "0.27"
 httpmock = "0.6"
+cucumber = "0.21"
+
+[[test]]
+name = "e2e"
+harness = false
+required-features = ["e2e"]

--- a/pete/tests/e2e.rs
+++ b/pete/tests/e2e.rs
@@ -1,0 +1,151 @@
+use async_trait::async_trait;
+use cucumber::{World as _, given, then, when};
+use pete::{ChannelEar, ChannelMouth};
+use psyche::{
+    self, Ear, Event, Mouth,
+    ling::{ChatStream, Chatter, Doer, Instruction, Message, Vectorizer},
+};
+use std::sync::{Arc, atomic::AtomicBool};
+use tokio::sync::{Mutex, broadcast, mpsc};
+use tokio_stream::once;
+
+#[derive(Default, cucumber::World)]
+struct PipelineWorld {
+    response: Option<String>,
+    face: Option<String>,
+    events: Option<broadcast::Receiver<Event>>,
+    ear: Option<Arc<ChannelEar>>,
+    convo: Option<Arc<Mutex<psyche::Conversation>>>,
+    spoken: Vec<Event>,
+}
+
+impl std::fmt::Debug for PipelineWorld {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PipelineWorld").finish()
+    }
+}
+
+#[derive(Clone)]
+struct FixedLLM {
+    reply: String,
+}
+
+#[async_trait]
+impl Chatter for FixedLLM {
+    async fn chat(&self, _s: &str, _h: &[Message]) -> anyhow::Result<ChatStream> {
+        Ok(Box::pin(once(Ok(self.reply.clone()))))
+    }
+    async fn update_prompt_context(&self, _c: &str) {}
+}
+
+#[async_trait]
+impl Doer for FixedLLM {
+    async fn follow(&self, _i: Instruction) -> anyhow::Result<String> {
+        Ok("ok".into())
+    }
+}
+
+#[async_trait]
+impl Vectorizer for FixedLLM {
+    async fn vectorize(&self, _t: &str) -> anyhow::Result<Vec<f32>> {
+        Ok(vec![0.0])
+    }
+}
+
+impl PipelineWorld {
+    async fn start(&mut self) {
+        if self.events.is_some() {
+            return;
+        }
+        let (tx, _) = broadcast::channel(8);
+        let speaking = Arc::new(AtomicBool::new(false));
+        let mouth = Arc::new(ChannelMouth::new(tx.clone(), speaking.clone())) as Arc<dyn Mouth>;
+        let (ux, ur) = mpsc::unbounded_channel();
+        let conv = Arc::new(Mutex::new(psyche::Conversation::default()));
+        let ear = Arc::new(ChannelEar::new(ux, conv.clone(), speaking));
+        let llm = FixedLLM {
+            reply: self.response.clone().unwrap_or_else(|| "hi".into()),
+        };
+        let mut psyche = psyche::Psyche::new(
+            Box::new(llm.clone()),
+            Box::new(llm.clone()),
+            Box::new(llm),
+            Arc::new(psyche::NoopMemory),
+            mouth,
+            ear.clone(),
+        );
+        psyche.set_turn_limit(1);
+        psyche.set_speak_when_spoken_to(true);
+        let psyche = psyche.run();
+        tokio::spawn(async move {
+            psyche.await;
+        });
+        self.events = Some(tx.subscribe());
+        self.ear = Some(ear);
+        self.convo = Some(conv);
+        drop(ur);
+    }
+
+    async fn drain(&mut self) {
+        if let Some(rx) = &mut self.events {
+            while let Ok(e) = rx.try_recv() {
+                self.spoken.push(e);
+            }
+        }
+    }
+}
+
+#[given("Pete is running with an active interface")]
+async fn given_running(w: &mut PipelineWorld) {
+    w.start().await;
+}
+
+#[given(regex = "the front-end displays a default emoji (.+)")]
+async fn given_face(w: &mut PipelineWorld, face: String) {
+    w.face = Some(face);
+}
+
+#[given(regex = "the LLM is mocked to reply \"(.+)\" to .+")]
+async fn given_llm(w: &mut PipelineWorld, reply: String) {
+    w.response = Some(reply);
+}
+
+#[when(regex = "the user sends \"(.+)\"")]
+async fn when_user(w: &mut PipelineWorld, msg: String) {
+    w.start().await;
+    if let Some(ear) = &w.ear {
+        ear.hear_user_say(&msg).await;
+    }
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    w.drain().await;
+}
+
+#[then(regex = "Pete says \"(.+)\"")]
+async fn then_says(w: &mut PipelineWorld, msg: String) {
+    assert!(w.spoken.iter().any(|e| match e {
+        Event::Speech { text, .. } => text == &msg,
+        _ => false,
+    }));
+}
+
+#[then(regex = "the front-end emoji becomes (.+)")]
+async fn then_emoji(w: &mut PipelineWorld, emo: String) {
+    assert!(w.spoken.iter().any(|e| match e {
+        Event::EmotionChanged(e) => e == &emo,
+        _ => false,
+    }));
+}
+
+#[then("no speech is produced")]
+async fn then_no_speech(w: &mut PipelineWorld) {
+    assert!(!w.spoken.iter().any(|e| matches!(e, Event::Speech { .. })));
+}
+
+#[tokio::main]
+async fn main() {
+    let path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/features/pipeline.feature"
+    );
+    PipelineWorld::run(path).await;
+}

--- a/pete/tests/features/pipeline.feature
+++ b/pete/tests/features/pipeline.feature
@@ -1,0 +1,43 @@
+Feature: Pete's conversational pipeline
+
+  Scenario: Basic Greeting Echo with Emoji Feedback
+    Given Pete is running with an active interface
+    And the front-end displays a default emoji 😐
+    And the LLM is mocked to reply "Hello there! 🙂" to "Hello, Pete"
+    When the user sends "Hello, Pete"
+    Then Pete says "Hello there! 🙂"
+    And the front-end emoji becomes 🙂
+
+  Scenario: No Response Without Will
+    Given Pete is running with an active interface
+    And Will has not authorized a turn
+    When the user sends "Hello?"
+    Then no speech is produced
+
+  Scenario: Inline Emoji Routing
+    Given Pete is running with an active interface
+    And the LLM is mocked to reply "I'm excited! 😆" to any input
+    When the user sends "Say something"
+    Then Pete says "I'm excited! 😆"
+    And the TTS system receives "I'm excited!"
+    And the front-end emoji becomes 😆
+
+  Scenario: Echo Confirmation
+    Given Pete is running with an active interface
+    And the LLM is mocked to reply "Echo" to any input
+    When the user sends "test"
+    And the front-end acknowledges playback of "Echo"
+    Then the psyche conversation contains "Echo" from assistant
+
+  Scenario: Prompt Synchronization
+    Given Pete is running with an active interface
+    And a wit provides context "Weather is nice"
+    And the LLM is mocked to reply "ok" to any input
+    When the user sends "update"
+    Then the voice prompt used contains "Weather is nice"
+
+  Scenario: TTS Dispatch Confirmation
+    Given Pete is running with an active interface
+    And the LLM is mocked to reply "Hi" to any input
+    When the user sends "say hi"
+    Then the TTS system receives "Hi"


### PR DESCRIPTION
## Summary
- add Cucumber integration tests scaffold behind `e2e` feature
- document how to run the new tests

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68545f9fb72c8320b9128c06759f7daf