### PR TITLE
Fix audio overlap and layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ Navigate to `http://localhost:3000/` to load the web face which connects to
 The previous Deno-based client has been removed. Update the files in
 `frontend/dist` directly to change the interface.
 * Queue audio playback on the client so clips never overlap.
+* Define CSS variables in `styles.css` to control colors and fonts.
 * Serve over HTTPS by passing `--tls-cert` and `--tls-key` to the `pete` binary.
 
 ## Communication

--- a/frontend/dist/app.js
+++ b/frontend/dist/app.js
@@ -22,12 +22,16 @@
     }
     playing = true;
     const audio = new Audio(`data:audio/wav;base64,${next}`);
-    audio.onended = () => {
+    const done = () => {
+      audio.removeEventListener("ended", done);
+      audio.removeEventListener("error", done);
       playNext();
     };
+    audio.addEventListener("ended", done);
+    audio.addEventListener("error", done);
     audio.play().catch((err) => {
       console.error("audio", err);
-      playNext();
+      done();
     });
   }
   ws.onmessage = (ev) => {
@@ -41,6 +45,7 @@
         case "Say":
         case "say":
           words.textContent += "\n" + m.data.words;
+          words.scrollTop = words.scrollHeight;
           if (m.data.audio) {
             enqueueAudio(m.data.audio);
           }

--- a/frontend/dist/styles.css
+++ b/frontend/dist/styles.css
@@ -1,3 +1,4 @@
+:root{--bs-primary:#0d6efd;--bs-secondary:#6c757d;--bs-border-radius:.375rem;--bs-font-size-lg:1.25rem;}
 .mien,
 .Mien {
     text-align: center;
@@ -27,8 +28,12 @@
     font-size: var(--bs-font-size-lg);
     color: var(--bs-secondary);
     margin-top: 1rem;
-    width: 100%;
-    height: 10rem;
+    display: block;
+    max-width: 80vw;
+    max-height: 8rem;
+    overflow-y: auto;
+    overflow-wrap: anywhere;
+    white-space: pre-wrap;
 }
 
 /* Override Bootstrap's button styling */
@@ -105,7 +110,8 @@
 }
 
 body {
-    background-color: orange;
+    background-color: black;
+    color: white;
 }
 
 .thought-bubble {
@@ -154,7 +160,7 @@ body {
 }
 
 .spoken-words {
-    white-space: pre;
+    white-space: pre-wrap;
     position: relative;
     background-color: #fff;
     padding: 0.5em;


### PR DESCRIPTION
## Summary
- tune CSS to ensure words fit in a container
- add a dark body style and bootstrap-style vars
- improve audio playback error handling
- keep speech container scrolled to the end
- document style vars in AGENTS

## Testing
- `cargo fmt`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6854ea473e64832083a41d36d78ebc70