### PR TITLE
Frontend audio improvements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ Navigate to `http://localhost:3000/` to load the web face which connects to
 The previous Deno-based client has been removed. Update the files in
 `frontend/dist` directly to change the interface.
 * Queue audio playback on the client so clips never overlap.
+* Reuse a single `<audio>` element for speech playback so controls remain visible.
 * Define CSS variables in `styles.css` to control colors and fonts.
 * Serve over HTTPS by passing `--tls-cert` and `--tls-key` to the `pete` binary.
 

--- a/frontend/dist/app.js
+++ b/frontend/dist/app.js
@@ -4,6 +4,7 @@
   const mien = document.getElementById("mien");
   const words = document.getElementById("words");
   const thought = document.getElementById("thought");
+  const player = document.getElementById("audio-player");
   const audioQueue = [];
   let playing = false;
 
@@ -21,15 +22,15 @@
       return;
     }
     playing = true;
-    const audio = new Audio(`data:audio/wav;base64,${next}`);
     const done = () => {
-      audio.removeEventListener("ended", done);
-      audio.removeEventListener("error", done);
+      player.removeEventListener("ended", done);
+      player.removeEventListener("error", done);
       playNext();
     };
-    audio.addEventListener("ended", done);
-    audio.addEventListener("error", done);
-    audio.play().catch((err) => {
+    player.src = `data:audio/wav;base64,${next}`;
+    player.addEventListener("ended", done, { once: true });
+    player.addEventListener("error", done, { once: true });
+    player.play().catch((err) => {
       console.error("audio", err);
       done();
     });

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -12,6 +12,7 @@
     <div id="mien" class="mien" style="z-index:1;position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);">😐</div>
     <div id="thought" class="thought-bubble" style="position:absolute;top:10%;left:50%;transform:translateX(-50%);"></div>
     <div id="words" class="spoken-words" style="position:absolute;bottom:10%;left:50%;transform:translateX(-50%);"></div>
+    <audio id="audio-player" controls style="position:absolute;bottom:0;left:0;width:100%;"></audio>
   </div>
   <form id="text-form" style="position:absolute;bottom:1rem;left:50%;transform:translateX(-50%);width:80%;display:flex;gap:0.5rem;">
     <input id="text-input" class="form-control" type="text" style="flex:1;" autofocus />


### PR DESCRIPTION
## Summary
- add dedicated `<audio>` tag for consistent playback
- reuse one audio element through a queue
- document audio element reuse in AGENTS

## Testing
- `cargo fmt`
- `cargo fetch`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6854ed819ae4832083cc7aeee0f8424f