### PR TITLE
Enable Wits to observe sensations

### DIFF
--- a/pete/src/psyche_factory.rs
+++ b/pete/src/psyche_factory.rs
@@ -44,7 +44,7 @@ pub fn dummy_psyche() -> Psyche {
         ear,
     );
     let wit_tx = psyche.wit_sender();
-    psyche.register_typed_wit(Arc::new(psyche::VisionWit::with_debug(
+    psyche.register_observing_wit(Arc::new(psyche::VisionWit::with_debug(
         Arc::new(Dummy),
         wit_tx,
     )));
@@ -76,7 +76,7 @@ pub fn ollama_psyche(host: &str, model: &str) -> anyhow::Result<Psyche> {
         ear,
     );
     let wit_tx = psyche.wit_sender();
-    psyche.register_typed_wit(Arc::new(psyche::VisionWit::with_debug(
+    psyche.register_observing_wit(Arc::new(psyche::VisionWit::with_debug(
         Arc::new(psyche::ling::OllamaProvider::new(host, model)?),
         wit_tx,
     )));

--- a/pete/tests/wits_loop.rs
+++ b/pete/tests/wits_loop.rs
@@ -1,0 +1,31 @@
+use pete::dummy_psyche;
+use psyche::{ImageData, Sensation};
+use tokio::time::Duration;
+
+#[tokio::test]
+async fn vision_wit_receives_images() {
+    let mut psyche = dummy_psyche();
+    let mut reports = psyche.wit_reports();
+    let tx = psyche.input_sender();
+    let handle = tokio::spawn(async move { psyche.run().await });
+
+    tx.send(Sensation::Of(Box::new(ImageData {
+        mime: "image/png".into(),
+        base64: "zzz".into(),
+    })))
+    .unwrap();
+
+    let mut got = false;
+    for _ in 0..5 {
+        if let Ok(r) = tokio::time::timeout(Duration::from_millis(50), reports.recv()).await {
+            if r.name == "VisionWit" {
+                got = true;
+                break;
+            }
+        }
+    }
+
+    handle.abort();
+    let _ = handle.await;
+    assert!(got);
+}

--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -7,10 +7,12 @@ mod voice;
 pub mod traits {
     pub mod ear;
     pub mod mouth;
+    pub mod observer;
     pub mod wit;
 
     pub use ear::Ear;
     pub use mouth::Mouth;
+    pub use observer::SensationObserver;
     pub use wit::{ErasedWit, Summarizer, Wit, WitAdapter};
 }
 
@@ -52,7 +54,7 @@ pub use types::ImageData;
 
 pub use psyche::{Conversation, Psyche};
 pub use sensation::{Event, Sensation, WitReport};
-pub use traits::{Ear, ErasedWit, Mouth, Summarizer, Wit, WitAdapter};
+pub use traits::{Ear, ErasedWit, Mouth, SensationObserver, Summarizer, Wit, WitAdapter};
 pub use voice::{Voice, extract_emojis};
 pub use wits::{
     BasicMemory, GraphStore, Memory, Neo4jClient, NoopMemory, QdrantClient, VisionWit, Will,

--- a/psyche/src/traits/observer.rs
+++ b/psyche/src/traits/observer.rs
@@ -1,0 +1,12 @@
+use crate::Sensation;
+use async_trait::async_trait;
+
+/// Observer of raw [`Sensation`] inputs.
+///
+/// Implementations may process incoming sensations from sensors or
+/// the conversation loop.
+#[async_trait]
+pub trait SensationObserver: Send + Sync {
+    /// Handle an incoming [`Sensation`].
+    async fn observe_sensation(&self, sensation: &Sensation);
+}

--- a/psyche/src/wits/vision_wit.rs
+++ b/psyche/src/wits/vision_wit.rs
@@ -1,6 +1,7 @@
 use crate::ImageData;
 use crate::Impression;
 use crate::ling::{Doer, Instruction};
+use crate::traits::observer::SensationObserver;
 use crate::traits::wit::Wit;
 use async_trait::async_trait;
 use lingproc::ImageData as LImageData;
@@ -65,5 +66,16 @@ impl Wit<ImageData, ImageData> for VisionWit {
             });
         }
         Some(Impression::new(how, None::<String>, img))
+    }
+}
+
+#[async_trait]
+impl SensationObserver for VisionWit {
+    async fn observe_sensation(&self, sensation: &crate::Sensation) {
+        if let crate::Sensation::Of(any) = sensation {
+            if let Some(img) = any.downcast_ref::<ImageData>() {
+                self.observe(img.clone()).await;
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- allow registering observers of raw Sensation events
- feed all sensations into registered wits
- implement the observer trait for `VisionWit`
- register observing wits in `psyche_factory`
- add regression test ensuring vision wit receives image data

## Testing
- `cargo test -p psyche --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6854f1b5a88c832086faaec8a2a9c00a