### PR TITLE
Hide thought bubble until text is set

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ The previous Deno-based client has been removed. Update the files in
 * Queue audio playback on the client so clips never overlap.
 * Reuse a single `<audio>` element for speech playback so controls remain visible.
 * Define CSS variables in `styles.css` to control colors and fonts.
+* Keep the thought bubble hidden until there is text to display.
 * Serve over HTTPS by passing `--tls-cert` and `--tls-key` to the `pete` binary.
 
 ## Communication

--- a/frontend/dist/app.js
+++ b/frontend/dist/app.js
@@ -54,6 +54,11 @@
         case "Think":
         case "think":
           thought.textContent = m.data;
+          if (m.data && m.data.trim() !== "") {
+            thought.style.display = "flex";
+          } else {
+            thought.style.display = "none";
+          }
           break;
         case "Heard":
         case "heard":

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -10,7 +10,7 @@
   <video id="webcam" autoplay muted playsinline style="display:none"></video>
   <div id="face" class="face" style="position:relative;width:100vw;height:100vh;overflow:hidden;">
     <div id="mien" class="mien" style="z-index:1;position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);">😐</div>
-    <div id="thought" class="thought-bubble" style="position:absolute;top:10%;left:50%;transform:translateX(-50%);"></div>
+    <div id="thought" class="thought-bubble" style="display:none;position:absolute;top:10%;left:50%;transform:translateX(-50%);"></div>
     <div id="words" class="spoken-words" style="position:absolute;bottom:10%;left:50%;transform:translateX(-50%);"></div>
     <audio id="audio-player" controls style="position:absolute;bottom:0;left:0;width:100%;"></audio>
   </div>


### PR DESCRIPTION
## Summary
- keep the thought bubble hidden until text is provided
- show/hide bubble in JS based on incoming `Think` events
- document thought bubble behavior in AGENTS instructions

## Testing
- `cargo fetch`
- `cargo fmt`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6854f23db3488320999e4ae6d331b463