### PR TITLE
Offer Pete reply after user message

### DIFF
--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -90,7 +90,8 @@ async fn main() -> anyhow::Result<()> {
     psyche.add_sense(eye.description());
     let (user_tx, user_rx) = mpsc::unbounded_channel();
 
-    tokio::spawn(listen_user_input(user_rx, ear.clone()));
+    let voice = psyche.voice();
+    tokio::spawn(listen_user_input(user_rx, ear.clone(), voice.clone()));
 
     let wit_rx = psyche.wit_reports();
     tokio::spawn(async move {

--- a/pete/src/web.rs
+++ b/pete/src/web.rs
@@ -217,10 +217,15 @@ fn parse_data_url(url: &str) -> Option<(String, String)> {
     Some((mime.to_string(), data.to_string()))
 }
 
-pub async fn listen_user_input(mut rx: mpsc::UnboundedReceiver<String>, ear: Arc<dyn Ear>) {
+pub async fn listen_user_input(
+    mut rx: mpsc::UnboundedReceiver<String>,
+    ear: Arc<dyn Ear>,
+    voice: Arc<psyche::Voice>,
+) {
     while let Some(msg) = rx.recv().await {
         debug!("forwarding user input: {}", msg);
         ear.hear_user_say(&msg).await;
+        voice.permit(None);
     }
 }
 

--- a/pete/tests/input_listener.rs
+++ b/pete/tests/input_listener.rs
@@ -14,7 +14,8 @@ async fn records_user_input() {
     ));
     let (tx, rx) = mpsc::unbounded_channel();
 
-    tokio::spawn(listen_user_input(rx, ear));
+    let voice = psyche.voice();
+    tokio::spawn(listen_user_input(rx, ear, voice));
 
     tx.send("hello".to_string()).unwrap();
     tokio::time::sleep(std::time::Duration::from_millis(10)).await;

--- a/pete/tests/wits_loop.rs
+++ b/pete/tests/wits_loop.rs
@@ -17,7 +17,9 @@ async fn vision_wit_receives_images() {
 
     let mut got = false;
     for _ in 0..5 {
-        if let Ok(r) = tokio::time::timeout(Duration::from_millis(50), reports.recv()).await {
+        if let Ok(Ok(r)) =
+            tokio::time::timeout(Duration::from_millis(50), reports.recv()).await
+        {
             if r.name == "VisionWit" {
                 got = true;
                 break;

--- a/psyche/src/psyche.rs
+++ b/psyche/src/psyche.rs
@@ -207,6 +207,11 @@ impl Psyche {
         self.wit_tx.subscribe()
     }
 
+    /// Get a handle to the voice component.
+    pub fn voice(&self) -> Arc<crate::voice::Voice> {
+        self.voice.clone()
+    }
+
     /// Swap out the [`Mouth`] used for speech output.
     pub fn set_mouth(&mut self, mouth: Arc<dyn Mouth>) {
         self.voice.set_mouth(mouth);


### PR DESCRIPTION
## Summary
- fix wits loop test to unwrap `WitReport`
- let the web server notify the voice after each user message
- expose a `voice` accessor on `Psyche`
- update listener setup and its test

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6854f73ba5388320ac995753b19eadd2