### PR TITLE
Connect UI to debug websocket

### DIFF
--- a/frontend/dist/app.js
+++ b/frontend/dist/app.js
@@ -1,6 +1,7 @@
 (function () {
   const wsProtocol = location.protocol === "https:" ? "wss:" : "ws:";
   const ws = new WebSocket(`${wsProtocol}//${location.hostname}:3000/ws`);
+  const debugWs = new WebSocket(`${wsProtocol}//${location.hostname}:3000/debug`);
   const mien = document.getElementById("mien");
   const words = document.getElementById("words");
   const thought = document.getElementById("thought");
@@ -35,7 +36,7 @@
       done();
     });
   }
-  ws.onmessage = (ev) => {
+  function handleMessage(ev) {
     try {
       const m = JSON.parse(ev.data);
       switch (m.type) {
@@ -68,7 +69,10 @@
     } catch (e) {
       console.error(e);
     }
-  };
+  }
+
+  ws.onmessage = handleMessage;
+  debugWs.onmessage = handleMessage;
 
   document.getElementById("text-form").addEventListener("submit", (e) => {
     e.preventDefault();

--- a/pete/tests/wits_loop.rs
+++ b/pete/tests/wits_loop.rs
@@ -17,9 +17,7 @@ async fn vision_wit_receives_images() {
 
     let mut got = false;
     for _ in 0..5 {
-        if let Ok(Ok(r)) =
-            tokio::time::timeout(Duration::from_millis(50), reports.recv()).await
-        {
+        if let Ok(Ok(r)) = tokio::time::timeout(Duration::from_millis(50), reports.recv()).await {
             if r.name == "VisionWit" {
                 got = true;
                 break;


### PR DESCRIPTION
## Summary
- open a secondary WebSocket to `/debug`
- handle messages from both chat and debug sockets
- rustfmt cleaned a test file

## Testing
- `cargo fetch`
- `cargo fmt`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6854fc8023548320ba4ef41609d382b7