### PR TITLE
Register core Wits in ollama psyche

### DIFF
--- a/pete/src/psyche_factory.rs
+++ b/pete/src/psyche_factory.rs
@@ -58,7 +58,12 @@ pub fn dummy_psyche() -> Psyche {
 /// This uses [`OllamaProvider`](psyche::ling::OllamaProvider) for all language
 /// capabilities and the no-op ear and mouth implementations.
 pub fn ollama_psyche(host: &str, model: &str) -> anyhow::Result<Psyche> {
+    use crate::LoggingMotor;
     use psyche::ling::OllamaProvider;
+    use psyche::wits::{
+        BasicMemory, Combobulator, CombobulatorWit, HeartWit, MemoryWit, Neo4jClient, QdrantClient,
+        Will, WillWit,
+    };
 
     let narrator = OllamaProvider::new(host, model)?;
     let voice = OllamaProvider::new(host, model)?;
@@ -67,18 +72,37 @@ pub fn ollama_psyche(host: &str, model: &str) -> anyhow::Result<Psyche> {
     let mouth = Arc::new(NoopMouth::default());
     let ear = Arc::new(NoopEar);
 
+    let memory = Arc::new(BasicMemory {
+        vectorizer: Arc::new(OllamaProvider::new(host, model)?),
+        qdrant: QdrantClient::default(),
+        neo4j: Arc::new(Neo4jClient::default()),
+    });
+
     let mut psyche = Psyche::new(
         Box::new(narrator),
-        Box::new(voice),
+        Box::new(voice.clone()),
         Box::new(vectorizer),
-        Arc::new(psyche::NoopMemory),
+        memory.clone(),
         mouth,
         ear,
     );
     let wit_tx = psyche.wit_sender();
     psyche.register_observing_wit(Arc::new(psyche::VisionWit::with_debug(
-        Arc::new(psyche::ling::OllamaProvider::new(host, model)?),
-        wit_tx,
+        Arc::new(OllamaProvider::new(host, model)?),
+        wit_tx.clone(),
+    )));
+    psyche.register_typed_wit(Arc::new(CombobulatorWit::new(Combobulator::with_debug(
+        Box::new(OllamaProvider::new(host, model)?),
+        wit_tx.clone(),
+    ))));
+    psyche.register_typed_wit(Arc::new(WillWit::new(
+        Will::with_debug(Box::new(OllamaProvider::new(host, model)?), wit_tx.clone()),
+        psyche.voice(),
+    )));
+    psyche.register_typed_wit(Arc::new(MemoryWit::new(memory.clone())));
+    psyche.register_typed_wit(Arc::new(HeartWit::new(
+        Box::new(OllamaProvider::new(host, model)?),
+        Arc::new(LoggingMotor),
     )));
     psyche.set_turn_limit(usize::MAX);
     info!(%host, %model, "created ollama psyche");

--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -19,14 +19,22 @@ pub mod traits {
 pub mod wit;
 pub mod wits {
     pub mod combobulator;
+    pub mod combobulator_wit;
+    pub mod heart_wit;
     pub mod memory;
+    pub mod memory_wit;
     pub mod vision_wit;
     pub mod will;
+    pub mod will_wit;
 
     pub use combobulator::Combobulator;
+    pub use combobulator_wit::CombobulatorWit;
+    pub use heart_wit::HeartWit;
     pub use memory::{BasicMemory, GraphStore, Memory, Neo4jClient, NoopMemory, QdrantClient};
+    pub use memory_wit::MemoryWit;
     pub use vision_wit::VisionWit;
     pub use will::Will;
+    pub use will_wit::WillWit;
 }
 
 mod and_mouth;
@@ -57,5 +65,6 @@ pub use sensation::{Event, Sensation, WitReport};
 pub use traits::{Ear, ErasedWit, Mouth, SensationObserver, Summarizer, Wit, WitAdapter};
 pub use voice::{Voice, extract_emojis};
 pub use wits::{
-    BasicMemory, GraphStore, Memory, Neo4jClient, NoopMemory, QdrantClient, VisionWit, Will,
+    BasicMemory, CombobulatorWit, GraphStore, HeartWit, Memory, MemoryWit, Neo4jClient, NoopMemory,
+    QdrantClient, VisionWit, Will, WillWit,
 };

--- a/psyche/src/wits/combobulator_wit.rs
+++ b/psyche/src/wits/combobulator_wit.rs
@@ -1,0 +1,44 @@
+use crate::{
+    Impression,
+    wit::{Episode, Wit},
+    wits::Combobulator,
+    Summarizer,
+};
+use async_trait::async_trait;
+use std::sync::Mutex;
+
+/// Wit summarizing recent episodes into a short awareness statement.
+pub struct CombobulatorWit {
+    combobulator: Combobulator,
+    buffer: Mutex<Vec<Impression<Episode>>>,
+}
+
+impl CombobulatorWit {
+    /// Create a new `CombobulatorWit` using the given summarizer.
+    pub fn new(combobulator: Combobulator) -> Self {
+        Self {
+            combobulator,
+            buffer: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+#[async_trait]
+impl Wit<Impression<Episode>, String> for CombobulatorWit {
+    async fn observe(&self, input: Impression<Episode>) {
+        self.buffer.lock().unwrap().push(input);
+    }
+
+    async fn tick(&self) -> Option<Impression<String>> {
+        let inputs = {
+            let mut buf = self.buffer.lock().unwrap();
+            if buf.is_empty() {
+                return None;
+            }
+            let data = buf.clone();
+            buf.clear();
+            data
+        };
+        self.combobulator.digest(&inputs).await.ok()
+    }
+}

--- a/psyche/src/wits/heart_wit.rs
+++ b/psyche/src/wits/heart_wit.rs
@@ -1,0 +1,57 @@
+use crate::{
+    Impression, Motor,
+    ling::{Doer, Instruction},
+    wit::Wit,
+};
+use async_trait::async_trait;
+use std::sync::{Arc, Mutex};
+
+/// Wit analyzing feelings and updating Pete's emotional state.
+pub struct HeartWit {
+    doer: Arc<dyn Doer>,
+    motor: Arc<dyn Motor>,
+    buffer: Mutex<Vec<Impression<String>>>,
+}
+
+impl HeartWit {
+    /// Create a new `HeartWit` using the given LLM `doer` and host `motor`.
+    pub fn new(doer: Box<dyn Doer>, motor: Arc<dyn Motor>) -> Self {
+        Self {
+            doer: doer.into(),
+            motor,
+            buffer: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+#[async_trait]
+impl Wit<Impression<String>, String> for HeartWit {
+    async fn observe(&self, input: Impression<String>) {
+        self.buffer.lock().unwrap().push(input);
+    }
+
+    async fn tick(&self) -> Option<Impression<String>> {
+        let inputs = {
+            let mut buf = self.buffer.lock().unwrap();
+            if buf.is_empty() {
+                return None;
+            }
+            let data = buf.clone();
+            buf.clear();
+            data
+        };
+        let summary = inputs
+            .iter()
+            .map(|i| i.raw_data.clone())
+            .collect::<Vec<_>>()
+            .join(" ");
+        let instruction = Instruction {
+            command: format!("What emoji reflects Pete's mood? {summary}"),
+            images: Vec::new(),
+        };
+        let resp = self.doer.follow(instruction).await.ok()?;
+        let mood = resp.trim().to_string();
+        self.motor.set_emotion(&mood).await;
+        Some(Impression::new(mood.clone(), Some(summary), mood))
+    }
+}

--- a/psyche/src/wits/memory_wit.rs
+++ b/psyche/src/wits/memory_wit.rs
@@ -1,0 +1,45 @@
+use crate::wit::Wit;
+use crate::{Impression, wits::Memory};
+use async_trait::async_trait;
+use serde_json::Value;
+use std::sync::{Arc, Mutex};
+use tracing::debug;
+
+/// Wit that persists impressions into the configured [`Memory`].
+pub struct MemoryWit {
+    memory: Arc<dyn Memory>,
+    buffer: Mutex<Vec<Impression<Value>>>,
+}
+
+impl MemoryWit {
+    /// Create a new `MemoryWit` using the given storage backend.
+    pub fn new(memory: Arc<dyn Memory>) -> Self {
+        Self {
+            memory,
+            buffer: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+#[async_trait]
+impl Wit<Impression<Value>, ()> for MemoryWit {
+    async fn observe(&self, input: Impression<Value>) {
+        self.buffer.lock().unwrap().push(input);
+    }
+
+    async fn tick(&self) -> Option<Impression<()>> {
+        let items = {
+            let mut buf = self.buffer.lock().unwrap();
+            if buf.is_empty() {
+                return None;
+            }
+            let data = buf.drain(..).collect::<Vec<_>>();
+            data
+        };
+        for imp in items {
+            debug!("memory storing impression: {}", imp.headline);
+            let _ = self.memory.store(&imp).await;
+        }
+        None
+    }
+}

--- a/psyche/src/wits/will_wit.rs
+++ b/psyche/src/wits/will_wit.rs
@@ -1,0 +1,47 @@
+use crate::{Impression, voice::Voice, wit::Wit, wits::Will, Summarizer};
+use async_trait::async_trait;
+use std::sync::{Arc, Mutex};
+
+/// Wit driving Pete's actions via the [`Will`] summarizer.
+///
+/// Accumulates awareness statements and periodically decides what to do or
+/// say next. After generating a decision it commands the [`Voice`] to speak.
+pub struct WillWit {
+    will: Will,
+    buffer: Mutex<Vec<Impression<String>>>,
+    voice: Arc<Voice>,
+}
+
+impl WillWit {
+    /// Create a new `WillWit` using `will` to decide actions and allowing
+    /// `voice` to speak.
+    pub fn new(will: Will, voice: Arc<Voice>) -> Self {
+        Self {
+            will,
+            buffer: Mutex::new(Vec::new()),
+            voice,
+        }
+    }
+}
+
+#[async_trait]
+impl Wit<Impression<String>, String> for WillWit {
+    async fn observe(&self, input: Impression<String>) {
+        self.buffer.lock().unwrap().push(input);
+    }
+
+    async fn tick(&self) -> Option<Impression<String>> {
+        let inputs = {
+            let mut buf = self.buffer.lock().unwrap();
+            if buf.is_empty() {
+                return None;
+            }
+            let data = buf.clone();
+            buf.clear();
+            data
+        };
+        let decision = self.will.digest(&inputs).await.ok()?;
+        self.will.command_voice_to_speak(&self.voice, None);
+        Some(decision)
+    }
+}

--- a/psyche/tests/heart_wit.rs
+++ b/psyche/tests/heart_wit.rs
@@ -1,0 +1,39 @@
+use async_trait::async_trait;
+use psyche::ling::{Doer, Instruction};
+use psyche::wits::HeartWit;
+use psyche::{Impression, Motor, Wit};
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone)]
+struct DummyLLM;
+
+#[async_trait]
+impl Doer for DummyLLM {
+    async fn follow(&self, _i: Instruction) -> anyhow::Result<String> {
+        Ok("😊".to_string())
+    }
+}
+
+#[derive(Default)]
+struct RecordingMotor(Arc<Mutex<Vec<String>>>);
+
+#[async_trait]
+impl Motor for RecordingMotor {
+    async fn say(&self, _text: &str) {}
+    async fn set_emotion(&self, emoji: &str) {
+        self.0.lock().unwrap().push(emoji.to_string());
+    }
+    async fn take_photo(&self) {}
+    async fn focus_on(&self, _name: &str) {}
+}
+
+#[tokio::test]
+async fn updates_emotion_on_tick() {
+    let motor = Arc::new(RecordingMotor::default());
+    let wit = HeartWit::new(Box::new(DummyLLM), motor.clone());
+    wit.observe(Impression::new("", None::<String>, "test".to_string()))
+        .await;
+    let _ = wit.tick().await.unwrap();
+    let emos = motor.0.lock().unwrap().clone();
+    assert_eq!(emos, vec!["😊".to_string()]);
+}


### PR DESCRIPTION
## Summary
- implement WillWit, MemoryWit, HeartWit and CombobulatorWit
- expose new Wits from psyche
- register the Wits and real memory in `ollama_psyche`
- test HeartWit emotion update

## Testing
- `cargo test --test heart_wit`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6855a7a3ebc083209847c2ef692ae409