### PR TITLE
Allow WillWit to permit voice

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,8 @@ The previous Deno-based client has been removed. Update the files in
 * Only `Will` may invoke `Voice::take_turn`.
 * `Voice::take_turn` extracts emoji and emits `Event::EmotionChanged`.
 * `Voice` will not speak until `Will::command_voice_to_speak` grants permission.
+* `Voice::permit` is idempotent and returns early when already ready.
+* `WillWit::tick` may call `voice.permit(Some(prompt))` to trigger speech when rules allow.
 
 ## Additional Suggestions
 

--- a/psyche/src/voice.rs
+++ b/psyche/src/voice.rs
@@ -47,8 +47,18 @@ impl Voice {
     }
 
     pub fn permit(&self, prompt: Option<String>) {
+        let mut ready = self.ready.lock().unwrap();
+        if *ready {
+            return;
+        }
+        *ready = true;
+        drop(ready);
         *self.extra_prompt.lock().unwrap() = prompt;
-        *self.ready.lock().unwrap() = true;
+    }
+
+    /// Returns `true` if the voice is currently permitted to speak.
+    pub fn ready(&self) -> bool {
+        *self.ready.lock().unwrap()
     }
 
     pub async fn update_prompt_context(&self, ctx: &str) {

--- a/psyche/src/wits/will_wit.rs
+++ b/psyche/src/wits/will_wit.rs
@@ -1,6 +1,9 @@
-use crate::{Impression, voice::Voice, wit::Wit, wits::Will, Summarizer};
+use crate::{Impression, Summarizer, voice::Voice, wit::Wit, wits::Will};
 use async_trait::async_trait;
-use std::sync::{Arc, Mutex};
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicUsize, Ordering},
+};
 
 /// Wit driving Pete's actions via the [`Will`] summarizer.
 ///
@@ -10,6 +13,7 @@ pub struct WillWit {
     will: Will,
     buffer: Mutex<Vec<Impression<String>>>,
     voice: Arc<Voice>,
+    ticks: AtomicUsize,
 }
 
 impl WillWit {
@@ -20,6 +24,7 @@ impl WillWit {
             will,
             buffer: Mutex::new(Vec::new()),
             voice,
+            ticks: AtomicUsize::new(0),
         }
     }
 }
@@ -41,6 +46,19 @@ impl Wit<Impression<String>, String> for WillWit {
             data
         };
         let decision = self.will.digest(&inputs).await.ok()?;
+
+        let count = self.ticks.fetch_add(1, Ordering::SeqCst) + 1;
+        let mut prompt = None;
+        if count % 3 == 0 {
+            prompt = Some("share a brief update".to_string());
+        }
+        if inputs.iter().any(|i| i.raw_data.contains('?')) {
+            prompt = Some("answer the user's question".to_string());
+        }
+        if let Some(p) = prompt {
+            self.voice.permit(Some(p));
+        }
+
         self.will.command_voice_to_speak(&self.voice, None);
         Some(decision)
     }

--- a/psyche/tests/voice.rs
+++ b/psyche/tests/voice.rs
@@ -45,6 +45,39 @@ fn extract_emojis_splits() {
     assert_eq!(e, vec!["😊"]);
 }
 
+#[derive(Clone, Default)]
+struct SpyLLM(Arc<tokio::sync::Mutex<Vec<String>>>);
+
+#[async_trait]
+impl Chatter for SpyLLM {
+    async fn chat(&self, s: &str, _h: &[Message]) -> anyhow::Result<ChatStream> {
+        self.0.lock().await.push(s.to_string());
+        Ok(Box::pin(once(Ok("ok".into()))))
+    }
+    async fn update_prompt_context(&self, _c: &str) {}
+}
+
+#[async_trait]
+impl Doer for SpyLLM {
+    async fn follow(&self, _i: Instruction) -> anyhow::Result<String> {
+        Ok("ok".into())
+    }
+}
+
+#[tokio::test]
+async fn permit_is_idempotent() {
+    let llm = Arc::new(SpyLLM::default());
+    let mouth = Arc::new(RecMouth::default());
+    let (tx, _rx) = broadcast::channel(8);
+    let voice = Voice::new(llm.clone(), mouth, tx);
+    voice.take_turn("sys", &[]).await.unwrap();
+    voice.permit(Some("one".into()));
+    voice.permit(Some("two".into()));
+    voice.take_turn("base", &[]).await.unwrap();
+    let prompts = llm.0.lock().await.clone();
+    assert_eq!(prompts.last().unwrap(), "base\none");
+}
+
 // TODO: Fix broken tests
 // #[tokio::test]
 // async fn take_turn_routes_emojis() {

--- a/psyche/tests/will_wit.rs
+++ b/psyche/tests/will_wit.rs
@@ -1,0 +1,68 @@
+use async_trait::async_trait;
+use psyche::ling::{ChatStream, Chatter, Doer, Instruction, Message};
+use psyche::{
+    Impression, Voice, Wit,
+    wits::{Will, WillWit},
+};
+use std::sync::Arc;
+use tokio::sync::broadcast;
+use tokio_stream::once;
+
+#[derive(Clone, Default)]
+struct SpyLLM(Arc<tokio::sync::Mutex<Vec<String>>>);
+
+#[derive(Clone, Default)]
+struct RecMouth(Arc<tokio::sync::Mutex<Vec<String>>>);
+
+#[async_trait]
+impl psyche::Mouth for RecMouth {
+    async fn speak(&self, t: &str) {
+        self.0.lock().await.push(t.to_string());
+    }
+    async fn interrupt(&self) {}
+    fn speaking(&self) -> bool {
+        false
+    }
+}
+
+#[async_trait]
+impl Chatter for SpyLLM {
+    async fn chat(&self, s: &str, _h: &[Message]) -> anyhow::Result<ChatStream> {
+        self.0.lock().await.push(s.to_string());
+        Ok(Box::pin(once(Ok("ok".into()))))
+    }
+    async fn update_prompt_context(&self, _c: &str) {}
+}
+
+#[async_trait]
+impl Doer for SpyLLM {
+    async fn follow(&self, _i: Instruction) -> anyhow::Result<String> {
+        Ok("ok".into())
+    }
+}
+
+#[tokio::test]
+async fn permits_every_third_tick() {
+    let llm = Arc::new(SpyLLM::default());
+    let mouth = Arc::new(RecMouth::default());
+    let (tx, _rx) = broadcast::channel(8);
+    let voice = Arc::new(Voice::new(llm.clone(), mouth, tx));
+    voice.take_turn("init", &[]).await.unwrap();
+    let will = Will::new(Box::new(SpyLLM::default()));
+    let wit = WillWit::new(will, voice.clone());
+
+    for _ in 0..2 {
+        wit.observe(Impression::new("", None::<String>, "hi".into()))
+            .await;
+        let _ = wit.tick().await.unwrap();
+        voice.take_turn("sys", &[]).await.unwrap();
+    }
+
+    wit.observe(Impression::new("", None::<String>, "hey".into()))
+        .await;
+    let _ = wit.tick().await.unwrap();
+    voice.take_turn("sys", &[]).await.unwrap();
+
+    let prompts = llm.0.lock().await.clone();
+    assert!(prompts.last().unwrap().contains("share a brief update"));
+}


### PR DESCRIPTION
## Summary
- document voice permitting rules
- prevent permitting a ready voice
- check voice readiness
- permit speaking from `WillWit`
- test voice permit idempotence
- test WillWit permitting logic

## Testing
- `cargo test --workspace --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6855ad8eb4e0832087570bdeadc7f3ad