### PR TITLE
Add loop logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,5 +105,6 @@ The previous Deno-based client has been removed. Update the files in
 * Be mindful of the single-CPU assumption — prefer concurrency without heavy parallelism.
 * When skipping speech for empty responses, increment the turn counter so the conversation loop can exit.
 * Log Coqui TTS request URLs with `info!(%url, "requesting TTS")` to ease debugging misconfigured endpoints.
+* Log each Wit tick with its name and keep loops alive even when idle.
 
 This document reflects the current cognitive and runtime architecture of Pete Daringsby. Keep it consistent with the latest design discussions and behavior changes.

--- a/psyche/src/psyche.rs
+++ b/psyche/src/psyche.rs
@@ -461,7 +461,9 @@ impl Psyche {
                 let context = context.clone();
                 let voice = voice.clone();
                 tasks.push(tokio::spawn(async move {
+                    let name = wit.name();
                     let maybe_imp = wit.tick_erased().await;
+                    info!(%name, "Ticked wit");
                     if let Some(impression) = maybe_imp {
                         info!(?impression.headline, "Wit emitted impression");
                         if let Err(e) = memory.store_serializable(&impression).await {

--- a/psyche/src/traits/wit.rs
+++ b/psyche/src/traits/wit.rs
@@ -18,6 +18,11 @@ pub trait Wit<Input, Output>: Send + Sync {
 
     /// Periodically called to emit a summarized [`Impression`].
     async fn tick(&self) -> Option<Impression<Output>>;
+
+    /// Human readable name used for logging.
+    fn name(&self) -> &'static str {
+        std::any::type_name::<Self>()
+    }
 }
 
 /// Type-erased wrapper enabling heterogeneous [`Wit`]s to be stored together.
@@ -25,6 +30,9 @@ pub trait Wit<Input, Output>: Send + Sync {
 pub trait ErasedWit: Send + Sync {
     /// Execute a tick and return an [`Impression`] with the payload serialized.
     async fn tick_erased(&self) -> Option<Impression<Value>>;
+
+    /// Name of this [`Wit`]. Used for debugging.
+    fn name(&self) -> &'static str;
 }
 
 /// Adapter allowing any [`Wit`] to be used as an [`ErasedWit`].
@@ -56,6 +64,10 @@ where
                     raw_data: raw,
                 })
         })
+    }
+
+    fn name(&self) -> &'static str {
+        self.inner.name()
     }
 }
 

--- a/psyche/src/voice.rs
+++ b/psyche/src/voice.rs
@@ -66,13 +66,16 @@ impl Voice {
     }
 
     pub async fn take_turn(&self, system_prompt: &str, history: &[Message]) -> anyhow::Result<()> {
+        info!("voice take_turn called");
         {
             let mut ready = self.ready.lock().unwrap();
             if !*ready {
+                info!("voice not ready, returning early");
                 return Ok(());
             }
             *ready = false;
         }
+        info!("voice permitted, generating speech");
         let extra = self.extra_prompt.lock().unwrap().take();
         let prompt = if let Some(extra) = extra {
             format!("{}\n{}", system_prompt, extra)

--- a/psyche/tests/liveness.rs
+++ b/psyche/tests/liveness.rs
@@ -1,0 +1,73 @@
+use async_trait::async_trait;
+use psyche::ling::{Chatter, Doer, Instruction, Message, Vectorizer};
+use psyche::{Ear, Mouth, Psyche};
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+use tokio_stream::once;
+
+#[derive(Clone, Default)]
+struct Dummy {
+    running: Arc<AtomicBool>,
+}
+
+#[async_trait]
+impl Mouth for Dummy {
+    async fn speak(&self, _text: &str) {
+        self.running.store(true, Ordering::SeqCst);
+    }
+    async fn interrupt(&self) {}
+    fn speaking(&self) -> bool {
+        false
+    }
+}
+
+#[async_trait]
+impl Ear for Dummy {
+    async fn hear_self_say(&self, _t: &str) {}
+    async fn hear_user_say(&self, _t: &str) {}
+}
+
+#[async_trait]
+impl Chatter for Dummy {
+    async fn chat(&self, _s: &str, _h: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+        Ok(Box::pin(once(Ok("ok".into()))))
+    }
+    async fn update_prompt_context(&self, _c: &str) {}
+}
+
+#[async_trait]
+impl Doer for Dummy {
+    async fn follow(&self, _i: Instruction) -> anyhow::Result<String> {
+        Ok("ok".into())
+    }
+}
+
+#[async_trait]
+impl Vectorizer for Dummy {
+    async fn vectorize(&self, _t: &str) -> anyhow::Result<Vec<f32>> {
+        Ok(vec![0.0])
+    }
+}
+
+#[tokio::test]
+async fn psyche_loops_stay_alive_when_idle() {
+    let mouth = Arc::new(Dummy::default());
+    let ear = mouth.clone();
+    let mut psyche = Psyche::new(
+        Box::new(Dummy::default()),
+        Box::new(Dummy::default()),
+        Box::new(Dummy::default()),
+        Arc::new(psyche::NoopMemory),
+        mouth,
+        ear,
+    );
+    psyche.set_turn_limit(3);
+    psyche.set_speak_when_spoken_to(true);
+    let handle = tokio::spawn(async move { psyche.run().await });
+    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    assert!(!handle.is_finished());
+    handle.abort();
+    let _ = handle.await;
+}


### PR DESCRIPTION
## Summary
- ensure each Wit tick is logged
- trace voice `take_turn` behavior
- expose `name()` on `Wit` for easier logging
- keep loops alive when idle
- document logging guidance
- test conversation loop liveness

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6855b175ac248320b3f8121181d7f12a