### PR TITLE
Add psyche debug tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ cargo run -p pete --features tts -- \
   --tts-url http://localhost:5002/api/tts \
   --tts-speaker-id p376
 
+Use `--auto-voice N` to have Pete speak automatically every N seconds during development.
+
 To serve the interface over HTTPS provide a certificate and key:
 
 ```sh
@@ -135,6 +137,8 @@ cargo run -p pete -- \
 After starting the server, navigate to `http://localhost:3000/` (or `https://localhost:3000/` when TLS is enabled) to open the built-in web face.
 The interface communicates over WebSocket at `ws://localhost:3000/ws` (or `wss://localhost:3000/ws` when using HTTPS).
 Another WebSocket at `/debug` streams debugging information from the Wits.
+The `/debug/psyche` HTTP endpoint returns JSON with the sensation buffer length
+and last tick time for each registered Wit.
 Speech arrives as `say` messages:
 ```json
 { "type": "say", "data": { "words": "hi", "audio": "UklGRg==" } }
@@ -160,3 +164,9 @@ Which returns JSON like:
 ### Logging
 
 Set `RUST_LOG=info` when running the server to enable helpful tracing output.
+
+### Simulation Utility
+
+Run `cargo run -p pete --bin simulate -- text "hello"` to send a text message to
+the running server. Use the `image` subcommand with a file path to simulate an
+image sensation.

--- a/pete/Cargo.toml
+++ b/pete/Cargo.toml
@@ -25,6 +25,8 @@ futures = "0.3"
 urlencoding = "2"
 tower-http = { version = "0.6", features = ["fs"] }
 axum-server = { version = "0.7", features = ["tls-rustls"] }
+tokio-tungstenite = "0.27"
+mime_guess = "2"
 
 [features]
 default = []
@@ -38,7 +40,6 @@ dioxus-ssr = "0.4.3"
 [dev-dependencies]
 assert_cmd = "2"
 futures = "0.3"
-tokio-tungstenite = "0.27"
 httpmock = "0.6"
 cucumber = "0.21"
 

--- a/pete/src/bin/simulate.rs
+++ b/pete/src/bin/simulate.rs
@@ -1,0 +1,44 @@
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD;
+use clap::{Parser, Subcommand};
+use futures::SinkExt;
+use mime_guess::MimeGuess;
+use tokio_tungstenite::{connect_async, tungstenite::Message};
+use tracing::info;
+
+#[derive(Parser)]
+struct Cli {
+    /// WebSocket endpoint
+    #[arg(long, default_value = "ws://127.0.0.1:3000/ws")]
+    ws: String,
+    #[command(subcommand)]
+    cmd: Cmd,
+}
+
+#[derive(Subcommand)]
+enum Cmd {
+    /// Send a text message
+    Text { msg: String },
+    /// Send an image file
+    Image { path: String },
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+    let cli = Cli::parse();
+    let (mut ws, _) = connect_async(&cli.ws).await?;
+    info!("connected to {ws}", ws = cli.ws);
+    let payload = match cli.cmd {
+        Cmd::Text { msg } => serde_json::json!({"type":"text","data":msg}),
+        Cmd::Image { path } => {
+            let bytes = tokio::fs::read(&path).await?;
+            let mime = MimeGuess::from_path(&path).first_or_octet_stream();
+            let b64 = base64::engine::general_purpose::STANDARD.encode(bytes);
+            let data = format!("data:{};base64,{}", mime.essence_str(), b64);
+            serde_json::json!({"type":"see","data":data})
+        }
+    };
+    ws.send(Message::Text(payload.to_string().into())).await?;
+    Ok(())
+}

--- a/pete/src/lib.rs
+++ b/pete/src/lib.rs
@@ -8,6 +8,7 @@ mod motor;
 mod mouth;
 mod psyche_factory;
 mod sensor;
+mod simulator;
 #[cfg(feature = "tts")]
 mod tts_mouth;
 mod web;
@@ -18,9 +19,10 @@ pub use motor::LoggingMotor;
 pub use mouth::{ChannelMouth, NoopMouth};
 pub use psyche_factory::{dummy_psyche, ollama_psyche};
 pub use sensor::eye::EyeSensor;
+pub use simulator::Simulator;
 #[cfg(feature = "tts")]
 pub use tts_mouth::{CoquiTts, Tts, TtsMouth, TtsStream};
 pub use web::{
     AppState, WsRequest, app, conversation_log, index, listen_user_input, log_ws_handler,
-    ws_handler,
+    psyche_debug, ws_handler,
 };

--- a/pete/src/simulator.rs
+++ b/pete/src/simulator.rs
@@ -1,0 +1,34 @@
+use std::sync::Arc;
+
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use psyche::{Ear, ImageData, Sensor};
+
+/// Utility for feeding fake sensations to a [`Psyche`].
+#[derive(Clone)]
+pub struct Simulator {
+    ear: Arc<dyn Ear>,
+    eye: Arc<dyn Sensor<ImageData>>,
+}
+
+impl Simulator {
+    /// Create a new `Simulator` using the provided ear and eye.
+    pub fn new(ear: Arc<dyn Ear>, eye: Arc<dyn Sensor<ImageData>>) -> Self {
+        Self { ear, eye }
+    }
+
+    /// Send a text message as if spoken by the user.
+    pub async fn text(&self, msg: &str) {
+        self.ear.hear_user_say(msg).await;
+    }
+
+    /// Send raw image bytes with MIME type to the psyche.
+    pub async fn image(&self, mime: &str, bytes: &[u8]) {
+        let data = BASE64.encode(bytes);
+        let img = ImageData {
+            mime: mime.to_string(),
+            base64: data,
+        };
+        self.eye.sense(img).await;
+    }
+}

--- a/pete/tests/conversation.rs
+++ b/pete/tests/conversation.rs
@@ -23,6 +23,7 @@ async fn returns_log_json() {
     let (user_tx, _user_rx) = mpsc::unbounded_channel();
     let eye = Arc::new(EyeSensor::new(psyche.input_sender()));
     psyche.add_sense(eye.description());
+    let debug = psyche.debug_handle();
     let state = AppState {
         user_input: user_tx,
         events: Arc::new(event_tx.subscribe()),
@@ -32,6 +33,7 @@ async fn returns_log_json() {
         eye,
         conversation,
         connections: Arc::new(AtomicUsize::new(1)),
+        psyche_debug: debug,
     };
     let resp = conversation_log(State(state)).await.into_response();
     let body = body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();

--- a/pete/tests/ws_audio.rs
+++ b/pete/tests/ws_audio.rs
@@ -24,6 +24,7 @@ async fn websocket_forwards_audio() {
     let (wit_tx, _) = broadcast::channel(8);
     let (log_tx, _) = broadcast::channel(8);
     let (user_tx, _user_rx) = mpsc::unbounded_channel();
+    let debug = psyche.debug_handle();
     let state = AppState {
         user_input: user_tx,
         events: Arc::new(event_tx.subscribe()),
@@ -33,6 +34,7 @@ async fn websocket_forwards_audio() {
         eye,
         conversation,
         connections: Arc::new(AtomicUsize::new(0)),
+        psyche_debug: debug,
     };
     let app = Router::new()
         .route("/ws", get(ws_handler))

--- a/psyche/src/debug.rs
+++ b/psyche/src/debug.rs
@@ -1,0 +1,38 @@
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use std::{collections::HashMap, collections::VecDeque, sync::Arc};
+use tokio::sync::Mutex;
+
+use crate::Sensation;
+
+/// Snapshot of internal Psyche state for debugging.
+#[derive(Serialize)]
+pub struct DebugInfo {
+    /// Number of queued sensations.
+    pub buffer_len: usize,
+    /// Names of registered wits.
+    pub active_wits: Vec<String>,
+    /// Last tick time for each wit.
+    pub last_ticks: HashMap<String, DateTime<Utc>>,
+}
+
+/// Handle providing read-only access to debug information.
+#[derive(Clone)]
+pub struct DebugHandle {
+    pub(crate) buffer: Arc<Mutex<VecDeque<Sensation>>>,
+    pub(crate) ticks: Arc<Mutex<HashMap<String, DateTime<Utc>>>>,
+    pub(crate) wits: Vec<String>,
+}
+
+impl DebugHandle {
+    /// Gather the current [`DebugInfo`] snapshot.
+    pub async fn snapshot(&self) -> DebugInfo {
+        let buffer_len = self.buffer.lock().await.len();
+        let last_ticks = self.ticks.lock().await.clone();
+        DebugInfo {
+            buffer_len,
+            active_wits: self.wits.clone(),
+            last_ticks,
+        }
+    }
+}

--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -39,6 +39,7 @@ pub mod wits {
 
 mod and_mouth;
 
+mod debug;
 mod impression;
 pub mod ling;
 mod motor;
@@ -50,6 +51,7 @@ mod trim_mouth;
 mod types;
 
 pub use and_mouth::AndMouth;
+pub use debug::{DebugHandle, DebugInfo};
 pub use impression::Impression;
 pub use motor::{Motor, NoopMotor};
 pub use plain_mouth::PlainMouth;


### PR DESCRIPTION
## Summary
- expose `DebugHandle` for psyche internals
- surface `/debug/psyche` endpoint
- add `--auto-voice` CLI option
- include a simulation helper and CLI
- document new features

## Testing
- `cargo fmt`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6855b418c4e4832085c4fbc21d65f044