### PR TITLE
Add EventBus wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,13 @@ let psyche = Psyche::new(
 );
 // replace the dummy mouth with your own implementation
 let speaking = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-let display = std::sync::Arc::new(pete::ChannelMouth::new(psyche.event_sender(), speaking.clone()));
+let (bus, _rx) = pete::EventBus::new();
+let bus = std::sync::Arc::new(bus);
+let display = std::sync::Arc::new(pete::ChannelMouth::new(bus.clone(), speaking.clone()));
 #[cfg(feature = "tts")]
 let tts = std::sync::Arc::new(psyche::PlainMouth::new(
     std::sync::Arc::new(pete::TtsMouth::new(
-        psyche.event_sender(),
+        bus.event_sender(),
         speaking.clone(),
         std::sync::Arc::new(pete::CoquiTts::new(
             "http://localhost:5002/api/tts",

--- a/pete/src/event_bus.rs
+++ b/pete/src/event_bus.rs
@@ -1,0 +1,77 @@
+use psyche::{Event, WitReport};
+use tokio::sync::{broadcast, mpsc};
+
+/// Central communication hub for Pete events and logs.
+#[derive(Clone)]
+pub struct EventBus {
+    events: broadcast::Sender<Event>,
+    logs: broadcast::Sender<String>,
+    wits: broadcast::Sender<WitReport>,
+    input: mpsc::UnboundedSender<String>,
+}
+
+impl EventBus {
+    /// Create a new `EventBus` wrapping existing channels.
+    ///
+    /// Returns the bus and a receiver for user input.
+    pub fn new() -> (Self, mpsc::UnboundedReceiver<String>) {
+        let (events, _) = broadcast::channel(16);
+        let (logs, _) = broadcast::channel(100);
+        let (wits, _) = broadcast::channel(16);
+        let (input, rx) = mpsc::unbounded_channel();
+        (
+            Self {
+                events,
+                logs,
+                wits,
+                input,
+            },
+            rx,
+        )
+    }
+
+    /// Send an [`Event`] to all subscribers.
+    pub fn publish_event(&self, event: Event) {
+        let _ = self.events.send(event);
+    }
+
+    /// Subscribe to [`Event`]s published on the bus.
+    pub fn subscribe_events(&self) -> broadcast::Receiver<Event> {
+        self.events.subscribe()
+    }
+
+    /// Obtain the event sender for direct use.
+    pub fn event_sender(&self) -> broadcast::Sender<Event> {
+        self.events.clone()
+    }
+
+    /// Send a log line to listeners.
+    pub fn log(&self, msg: impl Into<String>) {
+        let _ = self.logs.send(msg.into());
+    }
+
+    /// Subscribe to log messages.
+    pub fn subscribe_logs(&self) -> broadcast::Receiver<String> {
+        self.logs.subscribe()
+    }
+
+    /// Publish a [`WitReport`].
+    pub fn publish_wit(&self, report: WitReport) {
+        let _ = self.wits.send(report);
+    }
+
+    /// Subscribe to [`WitReport`]s.
+    pub fn subscribe_wits(&self) -> broadcast::Receiver<WitReport> {
+        self.wits.subscribe()
+    }
+
+    /// Obtain a sender for incoming user text.
+    pub fn user_input_sender(&self) -> mpsc::UnboundedSender<String> {
+        self.input.clone()
+    }
+
+    /// Access the log sender for initialization.
+    pub fn log_sender(&self) -> broadcast::Sender<String> {
+        self.logs.clone()
+    }
+}

--- a/pete/src/lib.rs
+++ b/pete/src/lib.rs
@@ -3,6 +3,7 @@
 //! This crate exposes helpers for running the Pete chatbot server and interacting with a [`psyche::Psyche`] instance. It wires HTTP and WebSocket endpoints to the psyche and provides mouth/ear implementations.
 
 mod ear;
+mod event_bus;
 mod logging;
 mod motor;
 mod mouth;
@@ -14,6 +15,7 @@ mod tts_mouth;
 mod web;
 
 pub use ear::{ChannelEar, NoopEar};
+pub use event_bus::EventBus;
 pub use logging::init_logging;
 pub use motor::LoggingMotor;
 pub use mouth::{ChannelMouth, NoopMouth};

--- a/pete/tests/mouth.rs
+++ b/pete/tests/mouth.rs
@@ -1,12 +1,13 @@
-use pete::ChannelMouth;
+use pete::{ChannelMouth, EventBus};
 use psyche::{Event, Mouth};
 use std::sync::{Arc, atomic::AtomicBool};
-use tokio::sync::broadcast;
 
 #[tokio::test]
 async fn sends_sentence_by_sentence() {
-    let (tx, mut rx) = broadcast::channel(8);
-    let mouth = ChannelMouth::new(tx.clone(), Arc::new(AtomicBool::new(false)));
+    let (bus, _) = EventBus::new();
+    let bus = Arc::new(bus);
+    let mut rx = bus.subscribe_events();
+    let mouth = ChannelMouth::new(bus.clone(), Arc::new(AtomicBool::new(false)));
     mouth.speak("Hello world. How are you?").await;
     assert_eq!(
         rx.recv().await.unwrap(),


### PR DESCRIPTION
## Summary
- add a new `EventBus` helper wrapping event, log, wit, and input channels
- adapt `ChannelMouth` and web server to use the `EventBus`
- wire up the bus in `main` and update examples
- update unit tests for the new interface

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6855b8243d8483209c4df667ff9e8d48