### PR TITLE
Centralize prompt logic via Ling

### DIFF
--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -62,6 +62,7 @@ pub use sensor::Sensor;
 pub use trim_mouth::TrimMouth;
 pub use types::ImageData;
 
+pub use ling::{Feeling, Ling};
 pub use psyche::{Conversation, Psyche};
 pub use sensation::{Event, Sensation, WitReport};
 pub use traits::{Ear, ErasedWit, Mouth, SensationObserver, Summarizer, Wit, WitAdapter};

--- a/psyche/src/ling.rs
+++ b/psyche/src/ling.rs
@@ -1,2 +1,112 @@
-//! Re-exported linguistic helpers.
+//! Linguistic helpers and prompt assembly utilities.
+
 pub use lingproc::*;
+
+use crate::{Conversation, Impression};
+use tokio::sync::Mutex;
+
+/// Emotional state influencing the prompt.
+#[derive(Clone, Debug)]
+pub struct Feeling {
+    /// Emoji reflecting Pete's mood.
+    pub emoji: String,
+}
+
+/// Central prompt builder combining conversation, mood and notes.
+pub struct Ling {
+    conversation: std::sync::Arc<Mutex<Conversation>>,
+    system_prompt: String,
+    senses: Vec<String>,
+    notes: Vec<String>,
+    mood: Option<Feeling>,
+}
+
+impl Ling {
+    /// Create a new `Ling` using `system_prompt` and shared `conversation`.
+    pub fn new(
+        system_prompt: impl Into<String>,
+        conversation: std::sync::Arc<Mutex<Conversation>>,
+    ) -> Self {
+        Self {
+            conversation,
+            system_prompt: system_prompt.into(),
+            senses: Vec::new(),
+            notes: Vec::new(),
+            mood: None,
+        }
+    }
+
+    /// Update the base system prompt.
+    pub fn set_system_prompt(&mut self, prompt: impl Into<String>) {
+        self.system_prompt = prompt.into();
+    }
+
+    /// Return the configured system prompt.
+    pub fn system_prompt(&self) -> &str {
+        &self.system_prompt
+    }
+
+    /// Record an attached sense for inclusion in the prompt.
+    pub fn add_sense(&mut self, description: String) {
+        self.senses.push(description);
+    }
+
+    /// Build the system prompt with attached sense descriptions only.
+    pub fn described_system_prompt(&self) -> String {
+        if self.senses.is_empty() {
+            return self.system_prompt.clone();
+        }
+        let mut out = format!("{}\n\nYou perceive through:", self.system_prompt);
+        for s in &self.senses {
+            out.push_str("\n- ");
+            out.push_str(s);
+        }
+        out
+    }
+
+    /// Append a note for additional context.
+    pub fn add_context_note(&mut self, note: &str) {
+        self.notes.push(note.to_string());
+    }
+
+    /// Include impression headlines as context notes.
+    pub async fn add_impressions<T>(&mut self, impressions: &[Impression<T>]) {
+        for imp in impressions {
+            self.add_context_note(&imp.headline);
+        }
+    }
+
+    /// Update Pete's emotional state.
+    pub fn set_mood(&mut self, feeling: Feeling) {
+        self.mood = Some(feeling);
+    }
+
+    /// Return the full conversation history.
+    pub async fn get_conversation(&self) -> Vec<Message> {
+        self.conversation.lock().await.all().to_vec()
+    }
+
+    /// Return the most recent `n` messages.
+    pub async fn get_conversation_tail(&self, n: usize) -> Vec<Message> {
+        self.conversation.lock().await.tail(n)
+    }
+
+    /// Build the system prompt with notes and mood.
+    pub async fn build_prompt(&self) -> String {
+        let mut out = self.described_system_prompt();
+        if let Some(m) = &self.mood {
+            out.push_str("\nMood: ");
+            out.push_str(&m.emoji);
+        }
+        for note in &self.notes {
+            out.push('\n');
+            out.push_str(note);
+        }
+        out
+    }
+
+    /// Clear temporary notes after a turn.
+    pub fn flush(&mut self) {
+        self.notes.clear();
+    }
+}


### PR DESCRIPTION
## Summary
- add `Ling` module for prompt and mood state
- delegate prompt and history retrieval to `Ling`
- push Wit impressions into `Ling` from the experience loop

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6855b9047e7c8320a2734d844be8ac69