### PR TITLE
Refactor wits to emit Vec<Impression>

### DIFF
--- a/psyche/src/prehension.rs
+++ b/psyche/src/prehension.rs
@@ -64,17 +64,20 @@ where
         self.buffer.lock().unwrap().push(input);
     }
 
-    async fn tick(&self) -> Option<Impression<O>> {
+    async fn tick(&self) -> Vec<Impression<O>> {
         let inputs = {
             let mut buf = self.buffer.lock().unwrap();
             if buf.is_empty() {
-                return None;
+                return Vec::new();
             }
             let data = buf.clone();
             buf.clear();
             data
         };
         debug!("prehension digesting {} items", inputs.len());
-        self.summarizer.digest(&inputs).await.ok()
+        match self.summarizer.digest(&inputs).await {
+            Ok(imp) => vec![imp],
+            Err(_) => Vec::new(),
+        }
     }
 }

--- a/psyche/src/wits/combobulator_wit.rs
+++ b/psyche/src/wits/combobulator_wit.rs
@@ -1,8 +1,7 @@
 use crate::{
-    Impression,
+    Impression, Summarizer,
     wit::{Episode, Wit},
     wits::Combobulator,
-    Summarizer,
 };
 use async_trait::async_trait;
 use std::sync::Mutex;
@@ -29,16 +28,19 @@ impl Wit<Impression<Episode>, String> for CombobulatorWit {
         self.buffer.lock().unwrap().push(input);
     }
 
-    async fn tick(&self) -> Option<Impression<String>> {
+    async fn tick(&self) -> Vec<Impression<String>> {
         let inputs = {
             let mut buf = self.buffer.lock().unwrap();
             if buf.is_empty() {
-                return None;
+                return Vec::new();
             }
             let data = buf.clone();
             buf.clear();
             data
         };
-        self.combobulator.digest(&inputs).await.ok()
+        match self.combobulator.digest(&inputs).await {
+            Ok(i) => vec![i],
+            Err(_) => Vec::new(),
+        }
     }
 }

--- a/psyche/src/wits/memory_wit.rs
+++ b/psyche/src/wits/memory_wit.rs
@@ -27,11 +27,11 @@ impl Wit<Impression<Value>, ()> for MemoryWit {
         self.buffer.lock().unwrap().push(input);
     }
 
-    async fn tick(&self) -> Option<Impression<()>> {
+    async fn tick(&self) -> Vec<Impression<()>> {
         let items = {
             let mut buf = self.buffer.lock().unwrap();
             if buf.is_empty() {
-                return None;
+                return Vec::new();
             }
             let data = buf.drain(..).collect::<Vec<_>>();
             data
@@ -40,6 +40,6 @@ impl Wit<Impression<Value>, ()> for MemoryWit {
             debug!("memory storing impression: {}", imp.headline);
             let _ = self.memory.store(&imp).await;
         }
-        None
+        Vec::new()
     }
 }

--- a/psyche/tests/heart_wit.rs
+++ b/psyche/tests/heart_wit.rs
@@ -33,7 +33,8 @@ async fn updates_emotion_on_tick() {
     let wit = HeartWit::new(Box::new(DummyLLM), motor.clone());
     wit.observe(Impression::new("", None::<String>, "test".to_string()))
         .await;
-    let _ = wit.tick().await.unwrap();
+    let out = wit.tick().await;
+    assert_eq!(out.len(), 1);
     let emos = motor.0.lock().unwrap().clone();
     assert_eq!(emos, vec!["😊".to_string()]);
 }

--- a/psyche/tests/prehension.rs
+++ b/psyche/tests/prehension.rs
@@ -46,6 +46,7 @@ async fn prehension_summarizes_buffer() {
         "I see a man frowning".to_string(),
     ))
     .await;
-    let result = wit.tick().await.unwrap();
-    assert_eq!(result.headline, "Travis suddenly becomes sad");
+    let result = wit.tick().await;
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].headline, "Travis suddenly becomes sad");
 }

--- a/psyche/tests/vision_wit.rs
+++ b/psyche/tests/vision_wit.rs
@@ -21,7 +21,9 @@ async fn captions_image() {
         base64: "zzz".into(),
     })
     .await;
-    let imp = wit.tick().await.unwrap();
+    let out = wit.tick().await;
+    assert_eq!(out.len(), 1);
+    let imp = &out[0];
     assert!(imp.headline.starts_with("I "));
     assert_eq!(imp.raw_data.mime, "image/png");
 }

--- a/psyche/tests/will_wit.rs
+++ b/psyche/tests/will_wit.rs
@@ -54,13 +54,13 @@ async fn permits_every_third_tick() {
     for _ in 0..2 {
         wit.observe(Impression::new("", None::<String>, "hi".into()))
             .await;
-        let _ = wit.tick().await.unwrap();
+        assert!(!wit.tick().await.is_empty());
         voice.take_turn("sys", &[]).await.unwrap();
     }
 
     wit.observe(Impression::new("", None::<String>, "hey".into()))
         .await;
-    let _ = wit.tick().await.unwrap();
+    assert!(!wit.tick().await.is_empty());
     voice.take_turn("sys", &[]).await.unwrap();
 
     let prompts = llm.0.lock().await.clone();

--- a/psyche/tests/wit_vec_tick.rs
+++ b/psyche/tests/wit_vec_tick.rs
@@ -1,0 +1,90 @@
+use async_trait::async_trait;
+use psyche::{Conversation, ErasedWit, Impression, Ling, Memory, Wit, WitAdapter};
+use serde_json::Value;
+use std::sync::{Arc, Mutex};
+use tokio::sync::Mutex as AsyncMutex;
+
+#[derive(Default)]
+struct RecMemory(AsyncMutex<Vec<String>>);
+
+#[async_trait]
+impl Memory for RecMemory {
+    async fn store(&self, impression: &Impression<Value>) -> anyhow::Result<()> {
+        self.0.lock().await.push(impression.headline.clone());
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct DummyWit {
+    outputs: Mutex<Vec<Vec<Impression<()>>>>,
+}
+
+#[async_trait]
+impl Wit<(), ()> for DummyWit {
+    async fn observe(&self, _: ()) {}
+
+    async fn tick(&self) -> Vec<Impression<()>> {
+        self.outputs.lock().unwrap().pop().unwrap_or_default()
+    }
+}
+
+async fn run_once(
+    memory: Arc<dyn Memory>,
+    wits: Vec<Arc<dyn ErasedWit + Send + Sync>>,
+    ling: Arc<AsyncMutex<Ling>>,
+) {
+    let mut tasks = Vec::new();
+    for wit in &wits {
+        let wit = wit.clone();
+        let memory = memory.clone();
+        tasks.push(tokio::spawn(async move {
+            let imps = wit.tick_erased().await;
+            for imp in &imps {
+                let _ = memory.store_serializable(imp).await;
+            }
+            imps
+        }));
+    }
+    let mut all = Vec::new();
+    for t in tasks {
+        if let Ok(imps) = t.await {
+            all.extend(imps);
+        }
+    }
+    if !all.is_empty() {
+        ling.lock().await.add_impressions(&all).await;
+    }
+}
+
+#[tokio::test]
+async fn multiple_impressions_flow_to_memory_and_context() {
+    let mem = Arc::new(RecMemory::default());
+    let conversation = Arc::new(AsyncMutex::new(Conversation::default()));
+    let ling = Arc::new(AsyncMutex::new(Ling::new("sys", conversation)));
+
+    let wit = Arc::new(DummyWit {
+        outputs: Mutex::new(vec![
+            vec![Impression::new("c", None::<String>, ())],
+            vec![
+                Impression::new("b", None::<String>, ()),
+                Impression::new("b2", None::<String>, ()),
+            ],
+            vec![Impression::new("a", None::<String>, ())],
+            Vec::new(),
+        ]),
+    });
+    let wits: Vec<Arc<dyn ErasedWit + Send + Sync>> = vec![Arc::new(WitAdapter::new(wit))];
+
+    for _ in 0..4 {
+        run_once(mem.clone(), wits.clone(), ling.clone()).await;
+    }
+
+    let stored = mem.0.lock().await.clone();
+    assert_eq!(stored, vec!["a", "b", "b2", "c"]);
+    let prompt = ling.lock().await.build_prompt().await;
+    assert!(prompt.contains("a"));
+    assert!(prompt.contains("b"));
+    assert!(prompt.contains("b2"));
+    assert!(prompt.contains("c"));
+}


### PR DESCRIPTION
## Summary
- update `Wit` trait to return `Vec<Impression>`
- adapt type-erased wrapper and `experience` loop to handle many impressions
- refactor wits to emit zero or more impressions
- adjust tests and add coverage for multiple impressions

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6855e05b96a483208523c36a19b4713c