### PR TITLE
Support batch memory store and vector tick

### DIFF
--- a/psyche/tests/wit_vec_tick.rs
+++ b/psyche/tests/wit_vec_tick.rs
@@ -37,12 +37,8 @@ async fn run_once(
     let mut tasks = Vec::new();
     for wit in &wits {
         let wit = wit.clone();
-        let memory = memory.clone();
         tasks.push(tokio::spawn(async move {
             let imps = wit.tick_erased().await;
-            for imp in &imps {
-                let _ = memory.store_serializable(imp).await;
-            }
             imps
         }));
     }
@@ -53,6 +49,7 @@ async fn run_once(
         }
     }
     if !all.is_empty() {
+        let _ = memory.store_all(&all).await;
         ling.lock().await.add_impressions(&all).await;
     }
 }


### PR DESCRIPTION
## Summary
- add `store_all` and helper for type-erased batch storage
- batch impressions from wits before persisting to memory
- update `wit_vec_tick` test to exercise batch flow

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6855e961888883209d436987be5c798c