### PR TITLE
Wire voice into ChannelEar

### DIFF
--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -84,14 +84,15 @@ async fn main() -> anyhow::Result<()> {
     psyche.set_emotion("😐");
     psyche.set_connection_counter(connections.clone());
     let conversation = psyche.conversation();
+    let voice = psyche.voice();
     let ear = Arc::new(ChannelEar::new(
         psyche.input_sender(),
         conversation.clone(),
         speaking.clone(),
+        voice.clone(),
     ));
     let eye = Arc::new(EyeSensor::new(psyche.input_sender()));
     psyche.add_sense(eye.description());
-    let voice = psyche.voice();
     tokio::spawn(listen_user_input(user_rx, ear.clone(), voice.clone()));
 
     if let Some(secs) = cli.auto_voice {

--- a/pete/tests/conversation.rs
+++ b/pete/tests/conversation.rs
@@ -15,6 +15,7 @@ async fn returns_log_json() {
         psyche.input_sender(),
         conversation.clone(),
         Arc::new(AtomicBool::new(false)),
+        psyche.voice(),
     ));
     let (bus, _user_rx) = EventBus::new();
     let bus = Arc::new(bus);

--- a/pete/tests/input_listener.rs
+++ b/pete/tests/input_listener.rs
@@ -6,15 +6,16 @@ use tokio::sync::mpsc;
 async fn records_user_input() {
     let mut psyche = dummy_psyche();
     let conv = psyche.conversation();
+    let voice = psyche.voice();
     let speaking = std::sync::Arc::new(AtomicBool::new(false));
     let ear = std::sync::Arc::new(ChannelEar::new(
         psyche.input_sender(),
         conv.clone(),
         speaking,
+        voice.clone(),
     ));
     let (tx, rx) = mpsc::unbounded_channel();
 
-    let voice = psyche.voice();
     tokio::spawn(listen_user_input(rx, ear, voice));
 
     tx.send("hello".to_string()).unwrap();

--- a/pete/tests/ws_audio.rs
+++ b/pete/tests/ws_audio.rs
@@ -12,10 +12,12 @@ use std::sync::{
 async fn websocket_forwards_audio() {
     let mut psyche = dummy_psyche();
     let conversation = psyche.conversation();
+    let voice = psyche.voice();
     let ear = Arc::new(ChannelEar::new(
         psyche.input_sender(),
         conversation.clone(),
         Arc::new(AtomicBool::new(false)),
+        voice,
     ));
     let eye = Arc::new(EyeSensor::new(psyche.input_sender()));
     psyche.add_sense(eye.description());


### PR DESCRIPTION
## Summary
- keep the speaking flag and voice in sync by injecting `Voice` into `ChannelEar`
- update server and tests to supply the `Voice`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6855ef4b83248320b7518a3381bb7a49