### PR TITLE
Ensure emotion events reach frontend

### DIFF
--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -114,6 +114,13 @@ async fn main() -> anyhow::Result<()> {
             bus_clone.publish_wit(r);
         }
     });
+    let mut event_rx = psyche.subscribe();
+    let bus_events = bus.clone();
+    tokio::spawn(async move {
+        while let Ok(evt) = event_rx.recv().await {
+            bus_events.publish_event(evt);
+        }
+    });
     tokio::spawn(async move {
         psyche.run().await;
     });


### PR DESCRIPTION
## Summary
- forward emotion updates from Psyche to the EventBus so the face reacts in real time

## Testing
- `cargo fetch`
- `cargo fmt`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6855f710aaa48320b74cd20692f4d818