### PR TITLE
Show webcam thumbnail in thought bubble

### DIFF
--- a/frontend/dist/app.js
+++ b/frontend/dist/app.js
@@ -5,6 +5,8 @@
   const mien = document.getElementById("mien");
   const words = document.getElementById("words");
   const thought = document.getElementById("thought");
+  const thoughtText = document.getElementById("thought-text");
+  const thoughtImage = document.getElementById("thought-image");
   const player = document.getElementById("audio-player");
   const audioQueue = [];
   let playing = false;
@@ -62,7 +64,7 @@
           break;
         case "Think":
         case "think":
-          thought.textContent = m.data;
+          thoughtText.textContent = m.data;
           if (m.data && m.data.trim() !== "") {
             thought.style.display = "flex";
           } else {
@@ -118,6 +120,8 @@
         canvas.height = video.videoHeight;
         canvas.getContext("2d").drawImage(video, 0, 0);
         const data = canvas.toDataURL("image/jpeg");
+        thoughtImage.src = data;
+        thoughtImage.style.display = "block";
         ws.send(JSON.stringify({ type: "See", data: data }));
       }, 1000);
     } catch (e) {

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -10,7 +10,10 @@
   <video id="webcam" autoplay muted playsinline style="display:none"></video>
   <div id="face" class="face" style="position:relative;width:100vw;height:100vh;overflow:hidden;">
     <div id="mien" class="mien" style="z-index:1;position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);">😐</div>
-    <div id="thought" class="thought-bubble" style="display:none;position:absolute;top:10%;left:50%;transform:translateX(-50%);"></div>
+    <div id="thought" class="thought-bubble" style="display:none;position:absolute;top:10%;left:50%;transform:translateX(-50%);">
+      <img id="thought-image" alt="Webcam thumbnail" style="display:none;" />
+      <span id="thought-text"></span>
+    </div>
     <div id="words" class="spoken-words" style="position:absolute;bottom:10%;left:50%;transform:translateX(-50%);"></div>
     <audio id="audio-player" style="display:none;position:absolute;bottom:0;left:0;width:100%;"></audio>
   </div>

--- a/frontend/dist/styles.css
+++ b/frontend/dist/styles.css
@@ -133,6 +133,12 @@ body {
     text-align: center;
 }
 
+#thought-image {
+    max-width: 80px;
+    max-height: 60px;
+    margin-right: 0.5rem;
+}
+
 .thought-bubble:before,
 .thought-bubble:after {
     content: "";


### PR DESCRIPTION
## Summary
- add `<img id="thought-image">` next to the thought text
- stream webcam frames into that thumbnail for quick visual confirmation
- style the thumbnail via new `#thought-image` rule

## Testing
- `cargo fetch`
- `cargo fmt --all`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6855f95927a08320ac9200b6275f0c48