### PR TITLE
Add wit debug tabs

### DIFF
--- a/frontend/dist/app.js
+++ b/frontend/dist/app.js
@@ -5,10 +5,11 @@
   const mien = document.getElementById("mien");
   const words = document.getElementById("words");
   const thought = document.getElementById("thought");
-  const thoughtText = document.getElementById("thought-text");
+  const thoughtTabs = document.getElementById("thought-tabs");
   const thoughtImage = document.getElementById("thought-image");
   const player = document.getElementById("audio-player");
   const audioQueue = [];
+  const witOutputs = {};
   let playing = false;
 
   function enqueueAudio(item) {
@@ -63,14 +64,22 @@
           enqueueAudio({ audio: m.data.audio || null, text: m.data.words });
           break;
         case "Think":
-        case "think":
-          thoughtText.textContent = m.data;
-          if (m.data && m.data.trim() !== "") {
-            thought.style.display = "flex";
+        case "think": {
+          if (typeof m.data === "object" && m.data !== null) {
+            witOutputs[m.data.name] = m.data.output;
           } else {
-            thought.style.display = "none";
+            witOutputs["unknown"] = m.data;
           }
+          thoughtTabs.innerHTML = "";
+          Object.entries(witOutputs).forEach(([name, output]) => {
+            const div = document.createElement("div");
+            div.className = "wit-report";
+            div.textContent = `${name}: ${output}`;
+            thoughtTabs.appendChild(div);
+          });
+          thought.style.display = Object.keys(witOutputs).length ? "flex" : "none";
           break;
+        }
         case "Heard":
         case "heard":
           // ignore for now

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -12,7 +12,7 @@
     <div id="mien" class="mien" style="z-index:1;position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);">😐</div>
     <div id="thought" class="thought-bubble" style="display:none;position:absolute;top:10%;left:50%;transform:translateX(-50%);">
       <img id="thought-image" alt="Webcam thumbnail" style="display:none;" />
-      <span id="thought-text"></span>
+      <div id="thought-tabs"></div>
     </div>
     <div id="words" class="spoken-words" style="position:absolute;bottom:10%;left:50%;transform:translateX(-50%);"></div>
     <audio id="audio-player" style="display:none;position:absolute;bottom:0;left:0;width:100%;"></audio>

--- a/frontend/dist/styles.css
+++ b/frontend/dist/styles.css
@@ -169,6 +169,19 @@ body {
 
 }
 
+/* Debug tabs for wit reports */
+#thought-tabs {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.wit-report {
+    font-size: 0.75rem;
+    color: black;
+    text-align: left;
+}
+
 .spoken-words {
     white-space: pre-wrap;
     position: relative;

--- a/pete/src/web.rs
+++ b/pete/src/web.rs
@@ -18,7 +18,7 @@ use tower_http::services::ServeDir;
 use tracing::{debug, error, info};
 
 use crate::EventBus;
-use psyche::{Ear, Event, ImageData, Sensor, ling::Role};
+use psyche::{Ear, Event, ImageData, Sensor, WitReport, ling::Role};
 
 /// State shared across HTTP handlers and WebSocket tasks.
 #[derive(Clone)]
@@ -60,7 +60,7 @@ enum WsResponse {
     #[serde(rename = "emote")]
     Emote(String),
     #[serde(rename = "think")]
-    Think(String),
+    Think(WitReport),
     #[serde(rename = "heard")]
     Heard(String),
 }
@@ -179,7 +179,7 @@ async fn handle_wit_socket(mut socket: WebSocket, state: AppState) {
     info!("wit websocket connected");
     let mut rx = state.bus.subscribe_wits();
     while let Ok(report) = rx.recv().await {
-        let msg = serde_json::to_string(&WsResponse::Think(report.output.clone())).unwrap();
+        let msg = serde_json::to_string(&WsResponse::Think(report.clone())).unwrap();
         if socket.send(WsMessage::Text(msg.into())).await.is_err() {
             break;
         }


### PR DESCRIPTION
## Summary
- expose `WitReport` over WebSocket so clients know which Wit produced output
- show separate debug lines per wit in the thought bubble

## Testing
- `cargo fetch`
- `cargo fmt`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6855fb8ebe5c8320914e1d0d0a9de2fa