### PR TITLE
Fix vision pipeline

### DIFF
--- a/lingproc/tests/provider.rs
+++ b/lingproc/tests/provider.rs
@@ -1,6 +1,7 @@
 use httpmock::Method::POST;
 use httpmock::MockServer;
-use lingproc::{Vectorizer, provider::OllamaProvider};
+use httpmock::prelude::HttpMockRequest;
+use lingproc::{Doer, ImageData, Instruction, Vectorizer, provider::OllamaProvider};
 
 #[tokio::test]
 async fn vectorize_returns_floats() {
@@ -16,4 +17,38 @@ async fn vectorize_returns_floats() {
     let vec = provider.vectorize("hello").await.unwrap();
     mock.assert();
     assert_eq!(vec, vec![1.0, 2.0, 3.0]);
+}
+
+#[tokio::test]
+async fn follow_includes_images() {
+    let server = MockServer::start_async().await;
+    fn body_contains_abcd(req: &HttpMockRequest) -> bool {
+        req.body
+            .as_ref()
+            .map(|b| std::str::from_utf8(b).unwrap_or_default().contains("abcd"))
+            .unwrap_or(false)
+    }
+
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/chat")
+            .matches(body_contains_abcd);
+        then.status(200)
+            .header("content-type", "application/json")
+            .body("{\"model\":\"mistral\",\"created_at\":\"now\",\"message\":{\"role\":\"assistant\",\"content\":\"ok\"},\"done\":true}");
+    });
+
+    let provider = OllamaProvider::new(server.base_url(), "mistral").unwrap();
+    let res = provider
+        .follow(Instruction {
+            command: "look".into(),
+            images: vec![ImageData {
+                mime: "image/jpeg".into(),
+                base64: "abcd".into(),
+            }],
+        })
+        .await
+        .unwrap();
+    mock.assert();
+    assert_eq!(res, "ok");
 }

--- a/pete/src/web.rs
+++ b/pete/src/web.rs
@@ -138,8 +138,13 @@ async fn handle_socket(mut socket: WebSocket, state: AppState) {
                                 }
                                 WsRequest::See { data, .. } => {
                                     if let Some((mime, base64)) = parse_data_url(&data) {
-                                        debug!("image received");
-                                        state.eye.sense(ImageData { mime, base64 }).await;
+                                        if base64.trim().is_empty() {
+                                            debug!("blank image ignored");
+                                            state.eye.sense(ImageData { mime, base64: String::new() }).await;
+                                        } else {
+                                            debug!("image received");
+                                            state.eye.sense(ImageData { mime, base64 }).await;
+                                        }
                                     }
                                 }
                                 WsRequest::Hear { .. } => {

--- a/psyche/src/wits/vision_wit.rs
+++ b/psyche/src/wits/vision_wit.rs
@@ -52,16 +52,20 @@ impl Wit<ImageData, ImageData> for VisionWit {
         };
 
         debug!("vision wit captioning image");
-        let caption = match self
-            .doer
-            .follow(Instruction {
-                command: "You are seeing this image directly, as if with your own eyes. Describe it in a single sentence, in the first person.".into(),
-                images: vec![LImageData { mime: img.mime.clone(), base64: img.base64.clone() }],
-            })
-            .await
-        {
-            Ok(c) => c,
-            Err(_) => return Vec::new(),
+        let caption = if img.base64.is_empty() {
+            "I can't see anything.".to_string()
+        } else {
+            match self
+                .doer
+                .follow(Instruction {
+                    command: "Describe only what you see in this image in a single sentence, in the first person.".into(),
+                    images: vec![LImageData { mime: img.mime.clone(), base64: img.base64.clone() }],
+                })
+                .await
+            {
+                Ok(c) => c,
+                Err(_) => return Vec::new(),
+            }
         };
         let how = caption.trim().to_string();
         if let Some(tx) = &self.tx {


### PR DESCRIPTION
## Summary
- improve VisionWit prompt and handle blank images
- send images through OllamaProvider when following instructions
- ignore empty webcam frames on the server
- check for blank frames on the client and restart video playback
- test that OllamaProvider includes images in chat request

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68560048b70c8320a099f2de1644153a