### PR TITLE
Implement summarizing MemoryWit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,9 @@ The previous Deno-based client has been removed. Update the files in
 * Memory graph (Neo4j) and embedding DB (Qdrant) must stay in sync.
 * Long-lived impressions are stored as `Impression<T>` with headline, detail, and raw data.
 * Use `Prehension` when buffering impressions for summarization. `Wit` is generic over input and output types.
+* When adding new Wits that emit `WitReport`s, prefer constructors like
+  `with_debug` and register them with `psyche.wit_sender()` so debug output is
+  available during tests.
 
 ## Contributor Notes
 

--- a/pete/src/psyche_factory.rs
+++ b/pete/src/psyche_factory.rs
@@ -100,7 +100,10 @@ pub fn ollama_psyche(host: &str, model: &str) -> anyhow::Result<Psyche> {
         wit_tx.clone(),
     ));
     psyche.register_typed_wit(Arc::new(WillWit::new(will, psyche.voice())));
-    psyche.register_typed_wit(Arc::new(MemoryWit::new(memory.clone())));
+    psyche.register_typed_wit(Arc::new(MemoryWit::with_debug(
+        memory.clone(),
+        wit_tx.clone(),
+    )));
     psyche.register_typed_wit(Arc::new(HeartWit::new(
         Box::new(OllamaProvider::new(host, model)?),
         Arc::new(LoggingMotor),

--- a/psyche/src/wits/memory_wit.rs
+++ b/psyche/src/wits/memory_wit.rs
@@ -1,45 +1,104 @@
-use crate::wit::Wit;
+use crate::wit::{Moment, Wit};
 use crate::{Impression, wits::Memory};
 use async_trait::async_trait;
-use serde_json::Value;
-use std::sync::{Arc, Mutex};
-use tracing::debug;
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicUsize, Ordering},
+};
+use tokio::sync::broadcast;
+use tracing::{debug, error};
 
-/// Wit that persists impressions into the configured [`Memory`].
+/// Wit that aggregates text impressions into brief [`Moment`] summaries.
+///
+/// Collected impressions are periodically concatenated and stored in the
+/// provided [`Memory`] implementation. A [`WitReport`] is emitted whenever a
+/// summary is created.
 pub struct MemoryWit {
     memory: Arc<dyn Memory>,
-    buffer: Mutex<Vec<Impression<Value>>>,
+    buffer: Mutex<Vec<Impression<String>>>,
+    collected: Mutex<Vec<Impression<String>>>,
+    ticks: AtomicUsize,
+    threshold: usize,
+    tx: Option<broadcast::Sender<crate::WitReport>>,
 }
 
 impl MemoryWit {
-    /// Create a new `MemoryWit` using the given storage backend.
+    /// Create a new `MemoryWit` using `memory` as the storage backend.
     pub fn new(memory: Arc<dyn Memory>) -> Self {
         Self {
             memory,
             buffer: Mutex::new(Vec::new()),
+            collected: Mutex::new(Vec::new()),
+            ticks: AtomicUsize::new(0),
+            threshold: 5,
+            tx: None,
+        }
+    }
+
+    /// Create a `MemoryWit` that emits [`WitReport`]s using `tx`.
+    pub fn with_debug(memory: Arc<dyn Memory>, tx: broadcast::Sender<crate::WitReport>) -> Self {
+        Self {
+            tx: Some(tx),
+            ..Self::new(memory)
         }
     }
 }
 
 #[async_trait]
-impl Wit<Impression<Value>, ()> for MemoryWit {
-    async fn observe(&self, input: Impression<Value>) {
+impl Wit<Impression<String>, Moment> for MemoryWit {
+    async fn observe(&self, input: Impression<String>) {
         self.buffer.lock().unwrap().push(input);
     }
 
-    async fn tick(&self) -> Vec<Impression<()>> {
-        let items = {
+    async fn tick(&self) -> Vec<Impression<Moment>> {
+        let new_items = {
             let mut buf = self.buffer.lock().unwrap();
             if buf.is_empty() {
-                return Vec::new();
+                Vec::new()
+            } else {
+                buf.drain(..).collect::<Vec<_>>()
             }
-            let data = buf.drain(..).collect::<Vec<_>>();
+        };
+        {
+            let mut collected = self.collected.lock().unwrap();
+            collected.extend(new_items);
+        }
+        let count = self.ticks.fetch_add(1, Ordering::SeqCst) + 1;
+        let should_summarize = {
+            let c = self.collected.lock().unwrap();
+            !c.is_empty() && (c.len() >= self.threshold || count >= self.threshold)
+        };
+        if !should_summarize {
+            return Vec::new();
+        }
+        self.ticks.store(0, Ordering::SeqCst);
+        let items = {
+            let mut coll = self.collected.lock().unwrap();
+            let data = coll.clone();
+            coll.clear();
             data
         };
-        for imp in items {
-            debug!("memory storing impression: {}", imp.headline);
-            let _ = self.memory.store(&imp).await;
+        // create summary
+        let summary = items
+            .iter()
+            .map(|i| i.headline.clone())
+            .collect::<Vec<_>>()
+            .join(" ");
+        let moment = Moment {
+            summary: summary.clone(),
+        };
+        let impression = Impression::new(summary.clone(), None::<String>, moment.clone());
+        if let Err(e) = self.memory.store_serializable(&impression).await {
+            error!(?e, "failed to store memory summary");
         }
-        Vec::new()
+        if let Some(tx) = &self.tx {
+            let _ = tx.send(crate::WitReport {
+                name: "Memory".into(),
+                prompt: "naive concat".into(),
+                output: summary.clone(),
+            });
+        }
+        debug!("memory summarized {} impressions", items.len());
+        vec![impression]
     }
 }

--- a/psyche/tests/memory_wit.rs
+++ b/psyche/tests/memory_wit.rs
@@ -1,0 +1,42 @@
+use async_trait::async_trait;
+use psyche::{
+    Impression, Wit, WitReport,
+    wits::{Memory, MemoryWit},
+};
+use serde_json::Value;
+use std::sync::{Arc, Mutex};
+use tokio::sync::broadcast;
+
+#[derive(Default)]
+struct DummyMemory(Arc<Mutex<Vec<String>>>);
+
+#[async_trait]
+impl Memory for DummyMemory {
+    async fn store(&self, impression: &Impression<Value>) -> anyhow::Result<()> {
+        self.0.lock().unwrap().push(impression.headline.clone());
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn summarizes_and_emits_report() {
+    let (tx, mut rx) = broadcast::channel(8);
+    let mem = Arc::new(DummyMemory::default());
+    let wit = MemoryWit::with_debug(mem.clone(), tx);
+
+    for i in 0..5 {
+        wit.observe(Impression::new(
+            format!("h{i}"),
+            None::<String>,
+            format!("d{i}"),
+        ))
+        .await;
+    }
+
+    let out = wit.tick().await;
+    let report = rx.recv().await.unwrap();
+    assert_eq!(report.name, "Memory");
+    assert!(report.output.contains("h0"));
+    assert_eq!(out.len(), 1);
+    assert!(out[0].raw_data.summary.contains("h1"));
+}


### PR DESCRIPTION
## Summary
- implement MemoryWit that collects text impressions, summarizes them, and stores a Moment in memory
- wire MemoryWit into psyche_factory with debug reporting
- test MemoryWit summary reporting
- document debug registration for new Wits

## Testing
- `cargo clippy --workspace --tests`
- `cargo test -p psyche --test memory_wit`
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_68568d7e4da48320b04dc812658eb850