### PR TITLE
Add FondDuCoeur Wit

### DIFF
--- a/pete/src/psyche_factory.rs
+++ b/pete/src/psyche_factory.rs
@@ -61,8 +61,8 @@ pub fn ollama_psyche(host: &str, model: &str) -> anyhow::Result<Psyche> {
     use crate::LoggingMotor;
     use psyche::ling::OllamaProvider;
     use psyche::wits::{
-        BasicMemory, Combobulator, CombobulatorWit, HeartWit, MemoryWit, Neo4jClient, QdrantClient,
-        Will, WillWit,
+        BasicMemory, Combobulator, CombobulatorWit, FondDuCoeur, FondDuCoeurWit, HeartWit,
+        MemoryWit, Neo4jClient, QdrantClient, Will, WillWit,
     };
 
     let narrator = OllamaProvider::new(host, model)?;
@@ -108,6 +108,10 @@ pub fn ollama_psyche(host: &str, model: &str) -> anyhow::Result<Psyche> {
         Box::new(OllamaProvider::new(host, model)?),
         Arc::new(LoggingMotor),
     )));
+    psyche.register_typed_wit(Arc::new(FondDuCoeurWit::new(FondDuCoeur::with_debug(
+        Box::new(OllamaProvider::new(host, model)?),
+        wit_tx.clone(),
+    ))));
     psyche.set_turn_limit(usize::MAX);
     info!(%host, %model, "created ollama psyche");
     Ok(psyche)

--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -20,6 +20,8 @@ pub mod wit;
 pub mod wits {
     pub mod combobulator;
     pub mod combobulator_wit;
+    pub mod fond_du_coeur;
+    pub mod fond_du_coeur_wit;
     pub mod heart_wit;
     pub mod memory;
     pub mod memory_wit;
@@ -29,6 +31,8 @@ pub mod wits {
 
     pub use combobulator::Combobulator;
     pub use combobulator_wit::CombobulatorWit;
+    pub use fond_du_coeur::FondDuCoeur;
+    pub use fond_du_coeur_wit::FondDuCoeurWit;
     pub use heart_wit::HeartWit;
     pub use memory::{BasicMemory, GraphStore, Memory, Neo4jClient, NoopMemory, QdrantClient};
     pub use memory_wit::MemoryWit;
@@ -69,6 +73,6 @@ pub use sensation::{Event, Sensation, WitReport};
 pub use traits::{Ear, ErasedWit, Mouth, SensationObserver, Summarizer, Wit, WitAdapter};
 pub use voice::{Voice, extract_emojis};
 pub use wits::{
-    BasicMemory, CombobulatorWit, GraphStore, HeartWit, Memory, MemoryWit, Neo4jClient, NoopMemory,
-    QdrantClient, VisionWit, Will, WillWit,
+    BasicMemory, CombobulatorWit, FondDuCoeur, FondDuCoeurWit, GraphStore, HeartWit, Memory,
+    MemoryWit, Neo4jClient, NoopMemory, QdrantClient, VisionWit, Will, WillWit,
 };

--- a/psyche/src/wits/fond_du_coeur.rs
+++ b/psyche/src/wits/fond_du_coeur.rs
@@ -1,0 +1,77 @@
+use crate::{
+    Impression, Summarizer,
+    ling::{Doer, Instruction},
+    wit::Moment,
+};
+use async_trait::async_trait;
+use chrono::Utc;
+use std::sync::{Arc, Mutex};
+use tokio::sync::broadcast;
+use uuid::Uuid;
+
+/// Summarizes recent `Moment`s into a rolling life story.
+#[derive(Clone)]
+pub struct FondDuCoeur {
+    doer: Arc<dyn Doer>,
+    story: Arc<Mutex<String>>,
+    tx: Option<broadcast::Sender<crate::WitReport>>,
+}
+
+impl FondDuCoeur {
+    /// Create a new `FondDuCoeur` using the provided [`Doer`].
+    pub fn new(doer: Box<dyn Doer>) -> Self {
+        Self {
+            doer: doer.into(),
+            story: Arc::new(Mutex::new(String::new())),
+            tx: None,
+        }
+    }
+
+    /// Create a `FondDuCoeur` that emits [`WitReport`]s using `tx`.
+    pub fn with_debug(doer: Box<dyn Doer>, tx: broadcast::Sender<crate::WitReport>) -> Self {
+        Self {
+            doer: doer.into(),
+            story: Arc::new(Mutex::new(String::new())),
+            tx: Some(tx),
+        }
+    }
+
+    /// Return the most recently generated story.
+    pub fn story(&self) -> String {
+        self.story.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl Summarizer<Moment, String> for FondDuCoeur {
+    async fn digest(&self, inputs: &[Impression<Moment>]) -> anyhow::Result<Impression<String>> {
+        let mut combined = self.story();
+        for imp in inputs {
+            if !combined.is_empty() {
+                combined.push(' ');
+            }
+            combined.push_str(&imp.raw_data.summary);
+        }
+        let instruction = Instruction {
+            command: format!("Summarize Pete's life story in one paragraph:\n{combined}"),
+            images: Vec::new(),
+        };
+        let resp = self.doer.follow(instruction.clone()).await?;
+        let summary = resp.trim().to_string();
+        *self.story.lock().unwrap() = summary.clone();
+        if let Some(tx) = &self.tx {
+            let _ = tx.send(crate::WitReport {
+                name: "Story".into(),
+                prompt: instruction.command.clone(),
+                output: summary.clone(),
+            });
+        }
+        Ok(Impression {
+            id: Uuid::new_v4(),
+            timestamp: Utc::now(),
+            headline: summary.clone(),
+            details: None,
+            raw_data: summary,
+        })
+    }
+}

--- a/psyche/src/wits/fond_du_coeur_wit.rs
+++ b/psyche/src/wits/fond_du_coeur_wit.rs
@@ -1,0 +1,46 @@
+use crate::{
+    Impression, Summarizer,
+    wit::{Moment, Wit},
+    wits::FondDuCoeur,
+};
+use async_trait::async_trait;
+use std::sync::Mutex;
+
+/// Wit that produces a single-paragraph life story from recent moments.
+pub struct FondDuCoeurWit {
+    summarizer: FondDuCoeur,
+    buffer: Mutex<Vec<Impression<Moment>>>,
+}
+
+impl FondDuCoeurWit {
+    /// Create a new `FondDuCoeurWit` using the given summarizer.
+    pub fn new(summarizer: FondDuCoeur) -> Self {
+        Self {
+            summarizer,
+            buffer: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+#[async_trait]
+impl Wit<Impression<Moment>, String> for FondDuCoeurWit {
+    async fn observe(&self, input: Impression<Moment>) {
+        self.buffer.lock().unwrap().push(input);
+    }
+
+    async fn tick(&self) -> Vec<Impression<String>> {
+        let inputs = {
+            let mut buf = self.buffer.lock().unwrap();
+            if buf.is_empty() {
+                return Vec::new();
+            }
+            let data = buf.clone();
+            buf.clear();
+            data
+        };
+        match self.summarizer.digest(&inputs).await {
+            Ok(i) => vec![i],
+            Err(_) => Vec::new(),
+        }
+    }
+}

--- a/psyche/tests/fond_du_coeur.rs
+++ b/psyche/tests/fond_du_coeur.rs
@@ -1,0 +1,47 @@
+use async_trait::async_trait;
+use psyche::Impression;
+use psyche::ling::{Doer, Instruction};
+use psyche::wit::{Moment, Wit};
+use psyche::wits::{FondDuCoeur, FondDuCoeurWit};
+use tokio::sync::broadcast;
+
+#[derive(Clone)]
+struct Dummy;
+
+#[async_trait]
+impl Doer for Dummy {
+    async fn follow(&self, i: Instruction) -> anyhow::Result<String> {
+        Ok(format!("story:{}", i.command))
+    }
+}
+
+#[tokio::test]
+async fn summarizes_moments_into_story() {
+    let (tx, mut rx) = broadcast::channel(8);
+    let summarizer = FondDuCoeur::with_debug(Box::new(Dummy), tx);
+    let wit = FondDuCoeurWit::new(summarizer.clone());
+    wit.observe(Impression::new(
+        "m1",
+        None::<String>,
+        Moment {
+            summary: "Pete woke".into(),
+        },
+    ))
+    .await;
+    let out = wit.tick().await;
+    assert_eq!(out.len(), 1);
+    let report = rx.recv().await.unwrap();
+    assert_eq!(report.name, "Story");
+    assert!(report.output.contains("story:"));
+    // second tick should include previous story
+    wit.observe(Impression::new(
+        "m2",
+        None::<String>,
+        Moment {
+            summary: "Pete slept".into(),
+        },
+    ))
+    .await;
+    let _ = wit.tick().await;
+    assert!(summarizer.story().contains("story:"));
+}


### PR DESCRIPTION
## Summary
- implement `FondDuCoeur` summarizer for Moments
- create `FondDuCoeurWit` to emit rolling life story
- export and register new wit
- test story generation

## Testing
- `cargo fmt`
- `cargo fetch`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6856ce618b248320a029ae3c556f3a8b