### PR TITLE
Expose system prompt and live convo log

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ curl http://127.0.0.1:3000/conversation
 Which returns JSON like:
 
 ```json
-[{"role":"user","content":"Hi"}]
+[{"role":"system","content":"You are PETE \u2014 ..."}, {"role":"user","content":"Hi"}]
 ```
 
 ### Logging

--- a/frontend/dist/app.js
+++ b/frontend/dist/app.js
@@ -193,4 +193,19 @@
   if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
     setupAudio();
   }
+
+  async function updateConversation() {
+    try {
+      const resp = await fetch("/conversation");
+      const msgs = await resp.json();
+      document.getElementById("conversation-log").textContent = msgs
+        .map((m) => `${m.role}: ${m.content}`)
+        .join("\n");
+    } catch (e) {
+      console.error("conversation", e);
+    }
+  }
+
+  setInterval(updateConversation, 2000);
+  updateConversation();
 })();

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -22,6 +22,10 @@
     <input id="text-input" class="form-control" type="text" style="flex:1;" autofocus />
     <button type="submit" class="btn btn-primary">Send</button>
   </form>
+  <details style="position:absolute;top:1rem;left:1rem;max-height:40vh;overflow:auto;">
+    <summary>Conversation</summary>
+    <pre id="conversation-log" style="white-space:pre-wrap;"></pre>
+  </details>
   <script src="/app.js"></script>
 </body>
 </html>

--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -121,6 +121,7 @@ async fn main() -> anyhow::Result<()> {
             bus_events.publish_event(evt);
         }
     });
+    let system_prompt = psyche.system_prompt();
     tokio::spawn(async move {
         psyche.run().await;
     });
@@ -131,6 +132,7 @@ async fn main() -> anyhow::Result<()> {
         eye: eye.clone(),
         conversation,
         connections,
+        system_prompt: Arc::new(tokio::sync::Mutex::new(system_prompt)),
         psyche_debug: debug_handle,
     };
     let app = app(state);

--- a/pete/tests/conversation.rs
+++ b/pete/tests/conversation.rs
@@ -28,11 +28,14 @@ async fn returns_log_json() {
         eye,
         conversation,
         connections: Arc::new(AtomicUsize::new(1)),
+        system_prompt: Arc::new(tokio::sync::Mutex::new(psyche.system_prompt())),
         psyche_debug: debug,
     };
     let resp = conversation_log(State(state)).await.into_response();
     let body = body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
     let msgs: serde_json::Value = serde_json::from_slice(&body).unwrap();
-    assert_eq!(msgs[0]["role"], "user");
-    assert_eq!(msgs[0]["content"], "hi");
+    assert_eq!(msgs[0]["role"], "system");
+    assert!(msgs[0]["content"].as_str().unwrap().contains("PETE"));
+    assert_eq!(msgs[1]["role"], "user");
+    assert_eq!(msgs[1]["content"], "hi");
 }

--- a/pete/tests/ws_audio.rs
+++ b/pete/tests/ws_audio.rs
@@ -30,6 +30,7 @@ async fn websocket_forwards_audio() {
         eye,
         conversation,
         connections: Arc::new(AtomicUsize::new(0)),
+        system_prompt: Arc::new(tokio::sync::Mutex::new(psyche.system_prompt())),
         psyche_debug: debug,
     };
     let app = Router::new()


### PR DESCRIPTION
## Summary
- include latest `system_prompt` in `/conversation` endpoint
- show conversation log on the face via a details/summary section
- periodically refresh the log from the frontend
- document new `/conversation` format
- update tests for new API

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6856da75189c8320b8b14b7e4b2df51f