### PR TITLE
Introduce psyche_core crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["psyche", "pete", "lingproc", "shared"]
+members = ["psyche", "pete", "lingproc", "shared", "core"]
 resolver = "2"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Daringsby Workspace
 
-This repository contains a Rust workspace with three crates:
+This repository contains a Rust workspace with multiple crates:
 
-- **psyche** – a library crate providing the `Psyche` type
+- **psyche_core** – minimal cognitive kernel built around `Stimulus` and `Impression`
+- **psyche** – higher-level abstractions built atop `psyche_core`
 - **lingproc** – helper LLM abstractions re-exported by `psyche`
 - **pete** – a binary crate depending on `psyche`
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "psyche_core"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+async-trait = "0.1"
+tracing = "0.1"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt"] }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,0 +1,11 @@
+//! Minimal cognitive kernel.
+
+pub mod memory;
+pub mod psyche;
+pub mod types;
+pub mod wit;
+
+pub use memory::{Memory, NoopMemory};
+pub use psyche::Psyche;
+pub use types::{Experience, Impression, Stimulus};
+pub use wit::Wit;

--- a/core/src/memory.rs
+++ b/core/src/memory.rs
@@ -1,0 +1,14 @@
+use crate::types::Impression;
+
+/// Simple sink for storing impressions.
+pub trait Memory: Send + Sync {
+    /// Archive the given impression.
+    fn remember(&mut self, imp: &Impression);
+}
+
+/// Placeholder implementation that discards impressions.
+pub struct NoopMemory;
+
+impl Memory for NoopMemory {
+    fn remember(&mut self, _imp: &Impression) {}
+}

--- a/core/src/psyche.rs
+++ b/core/src/psyche.rs
@@ -1,0 +1,37 @@
+use crate::{memory::Memory, types::Stimulus, wit::Wit};
+use serde_json;
+use tracing::info;
+
+/// Core processing loop combining multiple wits.
+pub struct Psyche {
+    /// Registered cognitive modules.
+    pub wits: Vec<Box<dyn Wit>>,
+    /// Recent stimuli available for reflection.
+    pub stimuli: Vec<Stimulus>,
+    /// Optional memory sink.
+    pub memory: Option<Box<dyn Memory>>,
+}
+
+impl Psyche {
+    /// Process one tick by invoking each wit.
+    pub async fn tick(&mut self) {
+        let mut new_impressions = vec![];
+
+        for wit in self.wits.iter_mut() {
+            if let Some(imp) = wit.tick(self.stimuli.clone()).await {
+                info!(wit = wit.name(), summary = %imp.summary, emoji = ?imp.emoji, "wit fired");
+                if let Some(mem) = self.memory.as_mut() {
+                    mem.remember(&imp);
+                }
+                new_impressions.push(imp);
+            }
+        }
+
+        for imp in &new_impressions {
+            self.stimuli.push(Stimulus {
+                what: serde_json::to_value(imp).expect("serialize"),
+                timestamp: imp.timestamp,
+            });
+        }
+    }
+}

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -1,0 +1,35 @@
+use serde::{Deserialize, Serialize};
+
+/// Basic unit of input for the psyche.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Stimulus<T = serde_json::Value> {
+    /// Arbitrary payload describing the stimulus.
+    pub what: T,
+    /// Millisecond timestamp when the stimulus occurred.
+    pub timestamp: i64,
+}
+
+/// Wit's output summarising a set of stimuli.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Impression {
+    /// Raw stimuli that led to the impression.
+    pub stimuli: Vec<Stimulus>,
+    /// Human friendly summary.
+    pub summary: String,
+    /// Optional emoji representing the impression.
+    pub emoji: Option<String>,
+    /// Millisecond timestamp of the impression.
+    pub timestamp: i64,
+}
+
+/// Result of embedding an impression.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Experience {
+    /// The impression itself.
+    #[serde(flatten)]
+    pub impression: Impression,
+    /// Vector representation of the impression.
+    pub embedding: Vec<f32>,
+    /// Unique identifier used by memory stores.
+    pub id: String,
+}

--- a/core/src/wit.rs
+++ b/core/src/wit.rs
@@ -1,0 +1,11 @@
+use crate::types::{Impression, Stimulus};
+use async_trait::async_trait;
+
+/// A cognitive process observing stimuli and optionally emitting an impression.
+#[async_trait]
+pub trait Wit: Send + Sync {
+    /// Called on each tick with the current stimuli buffer.
+    async fn tick(&mut self, inputs: Vec<Stimulus>) -> Option<Impression>;
+    /// Human readable name for debugging.
+    fn name(&self) -> &'static str;
+}

--- a/core/tests/psyche.rs
+++ b/core/tests/psyche.rs
@@ -1,0 +1,44 @@
+use async_trait::async_trait;
+use psyche_core::{Impression, NoopMemory, Psyche, Stimulus, Wit};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+struct EchoWit {
+    count: AtomicUsize,
+}
+
+#[async_trait]
+impl Wit for EchoWit {
+    async fn tick(&mut self, inputs: Vec<Stimulus>) -> Option<Impression> {
+        if self.count.fetch_add(1, Ordering::SeqCst) == 0 {
+            Some(Impression {
+                stimuli: inputs,
+                summary: "echo".into(),
+                emoji: Some("🙂".into()),
+                timestamp: 0,
+            })
+        } else {
+            None
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        "echo"
+    }
+}
+
+#[tokio::test]
+async fn psyche_recurses() {
+    let mut psyche = Psyche {
+        wits: vec![Box::new(EchoWit {
+            count: AtomicUsize::new(0),
+        })],
+        stimuli: vec![Stimulus {
+            what: serde_json::json!({"msg": "hi"}),
+            timestamp: 0,
+        }],
+        memory: Some(Box::new(NoopMemory)),
+    };
+
+    psyche.tick().await;
+    assert_eq!(psyche.stimuli.len(), 2);
+}


### PR DESCRIPTION
## Summary
- add new `psyche_core` crate with Stimulus, Impression, Experience
- implement Wit trait and new Psyche loop
- include simple Memory trait and NoopMemory
- document new crate in README
- add initial test for recursive impressions

## Testing
- `cargo fetch`
- `cargo fmt`
- `cargo test --workspace --tests core`


------
https://chatgpt.com/codex/tasks/task_e_6856e1bfe1188320b8f98f9cfac57d27