### PR TITLE
Allow independent LLM configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+CHATTER_HOST=http://localhost:11434
+CHATTER_MODEL=mistral
+WITS_HOST=http://localhost:11434
+WITS_MODEL=mistral
+EMBEDDINGS_HOST=http://localhost:11434
+EMBEDDINGS_MODEL=mistral

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,5 +112,7 @@ The previous Deno-based client has been removed. Update the files in
 * When skipping speech for empty responses, increment the turn counter so the conversation loop can exit.
 * Log Coqui TTS request URLs with `info!(%url, "requesting TTS")` to ease debugging misconfigured endpoints.
 * Log each Wit tick with its name and keep loops alive even when idle.
+* When introducing new CLI arguments or environment variables, update
+  `.env.example` and README examples accordingly.
 
 This document reflects the current cognitive and runtime architecture of Pete Daringsby. Keep it consistent with the latest design discussions and behavior changes.

--- a/README.md
+++ b/README.md
@@ -120,14 +120,19 @@ cargo test
 Run the web server with the built-in Ollama support:
 
 ```sh
-cargo run -p pete -- --ollama-url http://localhost:11434 --model mistral
+cargo run -p pete -- \
+  --chatter-host http://localhost:11434 --chatter-model mistral \
+  --wits-host http://localhost:11434 --wits-model mistral \
+  --embeddings-host http://localhost:11434 --embeddings-model mistral
 
 To enable audio output via Coqui TTS, build with the optional `tts` feature and
 provide the TTS server URL and optional voice parameters:
 
 ```sh
 cargo run -p pete --features tts -- \
-  --ollama-url http://localhost:11434 --model mistral \
+  --chatter-host http://localhost:11434 --chatter-model mistral \
+  --wits-host http://localhost:11434 --wits-model mistral \
+  --embeddings-host http://localhost:11434 --embeddings-model mistral \
   --tts-url http://localhost:5002/api/tts \
   --tts-speaker-id p376
 
@@ -137,7 +142,9 @@ To serve the interface over HTTPS provide a certificate and key:
 
 ```sh
 cargo run -p pete -- \
-  --ollama-url http://localhost:11434 --model mistral \
+  --chatter-host http://localhost:11434 --chatter-model mistral \
+  --wits-host http://localhost:11434 --wits-model mistral \
+  --embeddings-host http://localhost:11434 --embeddings-model mistral \
   --tls-cert cert.pem --tls-key key.pem
 ```
 ## Web Interface

--- a/pete/Cargo.toml
+++ b/pete/Cargo.toml
@@ -13,7 +13,7 @@ tokio-stream = { version = "0.1", features = ["sync"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 shared = { path = "../shared" }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt"] }
 pragmatic-segmenter = "0.1"

--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -25,12 +25,28 @@ struct Cli {
     /// Address to bind the HTTP server
     #[arg(long, default_value = "127.0.0.1:3000")]
     addr: String,
-    /// URL of the Ollama server
-    #[arg(long, default_value = "http://localhost:11434")]
-    ollama_url: String,
-    /// Model name to use with Ollama
-    #[arg(long, default_value = "mistral")]
-    model: String,
+    /// URL of the chatter Ollama server
+    #[arg(long, env = "CHATTER_HOST", default_value = "http://localhost:11434")]
+    chatter_host: String,
+    /// Model name to use for chatter
+    #[arg(long, env = "CHATTER_MODEL", default_value = "mistral")]
+    chatter_model: String,
+    /// URL of the wits Ollama server
+    #[arg(long, env = "WITS_HOST", default_value = "http://localhost:11434")]
+    wits_host: String,
+    /// Model name to use for wits
+    #[arg(long, env = "WITS_MODEL", default_value = "mistral")]
+    wits_model: String,
+    /// URL of the embeddings Ollama server
+    #[arg(
+        long,
+        env = "EMBEDDINGS_HOST",
+        default_value = "http://localhost:11434"
+    )]
+    embeddings_host: String,
+    /// Model name to use for embeddings
+    #[arg(long, env = "EMBEDDINGS_MODEL", default_value = "mistral")]
+    embeddings_model: String,
     /// URL of the Coqui TTS server
     #[arg(long, default_value = "http://localhost:5002/api/tts")]
     tts_url: String,
@@ -60,7 +76,14 @@ async fn main() -> anyhow::Result<()> {
 
     info!(%cli.addr, "starting server");
 
-    let mut psyche = ollama_psyche(&cli.ollama_url, &cli.model)?;
+    let mut psyche = ollama_psyche(
+        &cli.chatter_host,
+        &cli.chatter_model,
+        &cli.wits_host,
+        &cli.wits_model,
+        &cli.embeddings_host,
+        &cli.embeddings_model,
+    )?;
     let speaking = Arc::new(AtomicBool::new(false));
     let connections = Arc::new(AtomicUsize::new(0));
     #[cfg(feature = "tts")]

--- a/pete/tests/ollama.rs
+++ b/pete/tests/ollama.rs
@@ -2,6 +2,14 @@ use pete::ollama_psyche;
 
 #[tokio::test]
 async fn creates_psyche() {
-    let psyche = ollama_psyche("http://localhost:11434", "mistral").unwrap();
+    let psyche = ollama_psyche(
+        "http://localhost:11434",
+        "mistral",
+        "http://localhost:11434",
+        "mistral",
+        "http://localhost:11434",
+        "mistral",
+    )
+    .unwrap();
     assert_eq!(psyche.conversation().lock().await.all().len(), 0);
 }


### PR DESCRIPTION
## Summary
- let `ollama_psyche` take separate host/model pairs for chatter, wits and embeddings
- expose new CLI options to configure these pairs via env vars
- document the new flags in README and `.env.example`
- note env/example updates in AGENTS instructions

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68571b597c548320aeaba26e9e9c9e9c