### PR TITLE
Fix canvas readback hint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,8 @@ The previous Deno-based client has been removed. Update the files in
 * Define CSS variables in `styles.css` to control colors and fonts.
 * Keep the thought bubble hidden until there is text to display.
 * Serve over HTTPS by passing `--tls-cert` and `--tls-key` to the `pete` binary.
+* Canvas elements that repeatedly call `getImageData` must obtain their context
+  with `{ willReadFrequently: true }`.
 
 ## Communication
 

--- a/frontend/dist/app.js
+++ b/frontend/dist/app.js
@@ -125,6 +125,7 @@
       video.srcObject = stream;
       await video.play();
       const canvas = document.createElement("canvas");
+      const ctx = canvas.getContext("2d", { willReadFrequently: true });
       setInterval(() => {
         if (video.videoWidth === 0) {
           video.play().catch(() => {});
@@ -132,7 +133,6 @@
         }
         canvas.width = video.videoWidth;
         canvas.height = video.videoHeight;
-        const ctx = canvas.getContext("2d");
         ctx.drawImage(video, 0, 0);
         const pixel = ctx.getImageData(
           Math.floor(canvas.width / 2),


### PR DESCRIPTION
## Summary
- optimize webcam canvas access by creating the context with `willReadFrequently: true`
- document canvas setup guidance in `AGENTS.md`

## Testing
- `cargo fetch`
- `cargo fmt`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68571fa33dcc83208cc13f933bea1ac0