### PR TITLE
Fix duplicate user messages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ This repository is a Rust workspace.
 * Build prompts using dedicated structs like `WillPrompt`.
 * `ChannelMouth` emits `Event::Speech` per parsed sentence without audio.
 * `Conversation::add_*` merges consecutive same-role messages, inserting a space and trimming.
+* Only the `Psyche` loop should append to `Conversation`; `Ear` implementations forward sensations without modifying the log.
 * Use the `Motor` trait for host actions. Implementations live in `pete`.
 
 ## Frontend

--- a/pete/src/ear.rs
+++ b/pete/src/ear.rs
@@ -4,14 +4,13 @@ use std::sync::{
     Arc,
     atomic::{AtomicBool, Ordering},
 };
-use tokio::sync::{Mutex, mpsc};
+use tokio::sync::mpsc;
 use tracing::debug;
 
 /// [`Ear`] implementation that forwards heard text through a channel.
 #[derive(Clone)]
 pub struct ChannelEar {
     forward: mpsc::UnboundedSender<Sensation>,
-    conversation: Arc<Mutex<psyche::Conversation>>, // share log from psyche
     speaking: Arc<AtomicBool>,
     voice: Arc<Voice>,
 }
@@ -20,13 +19,11 @@ impl ChannelEar {
     /// Create a new `ChannelEar` wired to the given channels.
     pub fn new(
         forward: mpsc::UnboundedSender<Sensation>,
-        conversation: Arc<Mutex<psyche::Conversation>>,
         speaking: Arc<AtomicBool>,
         voice: Arc<Voice>,
     ) -> Self {
         Self {
             forward,
-            conversation,
             speaking,
             voice,
         }
@@ -49,8 +46,6 @@ impl Ear for ChannelEar {
         let _ = self
             .forward
             .send(Sensation::HeardUserVoice(text.to_string()));
-        let mut conv = self.conversation.lock().await;
-        conv.add_user(text.to_string());
     }
 }
 

--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -130,7 +130,6 @@ async fn main() -> anyhow::Result<()> {
     let voice = psyche.voice();
     let ear = Arc::new(ChannelEar::new(
         psyche.input_sender(),
-        conversation.clone(),
         speaking.clone(),
         voice.clone(),
     ));

--- a/pete/tests/conversation.rs
+++ b/pete/tests/conversation.rs
@@ -13,7 +13,6 @@ async fn returns_log_json() {
     conversation.lock().await.add_user("hi".into());
     let ear = Arc::new(ChannelEar::new(
         psyche.input_sender(),
-        conversation.clone(),
         Arc::new(AtomicBool::new(false)),
         psyche.voice(),
     ));

--- a/pete/tests/e2e.rs
+++ b/pete/tests/e2e.rs
@@ -78,7 +78,6 @@ impl PipelineWorld {
         let voice = psyche.voice();
         let ear = Arc::new(ChannelEar::new(
             psyche.input_sender(),
-            conversation.clone(),
             speaking,
             voice.clone(),
         ));

--- a/pete/tests/input_listener.rs
+++ b/pete/tests/input_listener.rs
@@ -10,16 +10,18 @@ async fn records_user_input() {
     let speaking = std::sync::Arc::new(AtomicBool::new(false));
     let ear = std::sync::Arc::new(ChannelEar::new(
         psyche.input_sender(),
-        conv.clone(),
         speaking,
         voice.clone(),
     ));
     let (tx, rx) = mpsc::unbounded_channel();
 
     tokio::spawn(listen_user_input(rx, ear, voice));
+    let handle = tokio::spawn(async move { psyche.run().await });
 
     tx.send("hello".to_string()).unwrap();
-    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    handle.abort();
+    let _ = handle.await;
 
     let log_len = { conv.lock().await.all().len() };
     assert_eq!(log_len, 1);

--- a/pete/tests/ws_audio.rs
+++ b/pete/tests/ws_audio.rs
@@ -15,7 +15,6 @@ async fn websocket_forwards_audio() {
     let voice = psyche.voice();
     let ear = Arc::new(ChannelEar::new(
         psyche.input_sender(),
-        conversation.clone(),
         Arc::new(AtomicBool::new(false)),
         voice,
     ));


### PR DESCRIPTION
## Summary
- ensure only Psyche appends to `Conversation`
- update tests and `ChannelEar` accordingly
- document Ear behavior in `AGENTS.md`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685721b8e6748320b968abe67c687be7