### PR TITLE
Enable Wit debug by default

### DIFF
--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -104,6 +104,7 @@ async fn main() -> anyhow::Result<()> {
         &cli.neo4j_user,
         &cli.neo4j_pass,
     )?;
+    psyche.enable_all_debug().await;
     let speaking = Arc::new(AtomicBool::new(false));
     let connections = Arc::new(AtomicUsize::new(0));
     #[cfg(feature = "tts")]

--- a/pete/tests/enable_debug.rs
+++ b/pete/tests/enable_debug.rs
@@ -1,0 +1,10 @@
+use pete::dummy_psyche;
+use psyche::{debug_enabled, disable_debug};
+
+#[tokio::test]
+async fn enable_all_debug_turns_on_every_label() {
+    let psyche = dummy_psyche();
+    psyche.enable_all_debug().await;
+    assert!(debug_enabled("Vision").await);
+    disable_debug("Vision").await;
+}

--- a/psyche/src/psyche.rs
+++ b/psyche/src/psyche.rs
@@ -265,6 +265,13 @@ impl Psyche {
         }
     }
 
+    /// Enable debugging for all registered Wits.
+    pub async fn enable_all_debug(&self) {
+        for label in self.wits.iter().map(|w| w.debug_label()) {
+            crate::debug::enable_debug(label).await;
+        }
+    }
+
     /// Get a handle to the voice component.
     pub fn voice(&self) -> Arc<crate::voice::Voice> {
         self.voice.clone()


### PR DESCRIPTION
## Summary
- make `Psyche` able to enable debug for every registered Wit
- turn on all debug output on server startup
- verify `enable_all_debug` works

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68572155da7c8320bba9f280d88d2f9f