### PR TITLE
Add tracing for Ollama requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,7 @@ The previous Deno-based client has been removed. Update the files in
 * When skipping speech for empty responses, increment the turn counter so the conversation loop can exit.
 * Log Coqui TTS request URLs with `info!(%url, "requesting TTS")` to ease debugging misconfigured endpoints.
 * Log each Wit tick with its name and keep loops alive even when idle.
+* Log Ollama prompts and streamed chunks with `debug!` for troubleshooting.
 * When introducing new CLI arguments or environment variables, update
   `.env.example` and README examples accordingly.
 

--- a/lingproc/Cargo.toml
+++ b/lingproc/Cargo.toml
@@ -11,6 +11,7 @@ tokio-stream = { version = "0.1", features = ["sync"] }
 pragmatic-segmenter = "0.1"
 unicode-segmentation = "1"
 futures = "0.3"
+tracing = "0.1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/pete/tests/ws_geolocate.rs
+++ b/pete/tests/ws_geolocate.rs
@@ -15,7 +15,6 @@ async fn websocket_forwards_geolocation() {
     let voice = psyche.voice();
     let ear = Arc::new(ChannelEar::new(
         psyche.input_sender(),
-        conversation.clone(),
         Arc::new(AtomicBool::new(false)),
         voice,
     ));


### PR DESCRIPTION
## Summary
- log prompts and streamed responses in `OllamaProvider`
- include tracing dependency for `lingproc`
- update ws geolocation test for new `ChannelEar` API
- document debug-level Ollama logging in AGENTS

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685729d5ed5083208dddf7e8c9f8d9bc