### PR TITLE
Add per-wit debug view

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ The interface communicates over WebSocket at `ws://localhost:3000/ws` (or `wss:/
 Another WebSocket at `/debug` streams debugging information from the Wits.
 The `/debug/psyche` HTTP endpoint returns JSON with the sensation buffer length
 and last tick time for each registered Wit.
+Navigate to `/debug/wit/{label}` to view the latest prompt and response for a
+specific Wit in real time.
 Speech arrives as `say` messages:
 ```json
 { "type": "say", "data": { "words": "hi", "audio": "UklGRg==" } }

--- a/frontend/dist/wit_debug.html
+++ b/frontend/dist/wit_debug.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Wit Debug</title>
+  <link rel="stylesheet" href="/styles.css" />
+</head>
+<body>
+  <h1 id="title"></h1>
+  <pre id="prompt" class="well"></pre>
+  <pre id="stream" class="well"></pre>
+  <script>
+    (function(){
+      const label = location.pathname.split('/').pop();
+      document.getElementById('title').textContent = `Debug for ${label}`;
+      const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+      const ws = new WebSocket(`${proto}//${location.host}/debug`);
+      const promptEl = document.getElementById('prompt');
+      const streamEl = document.getElementById('stream');
+      ws.onmessage = (ev) => {
+        try {
+          const m = JSON.parse(ev.data);
+          if ((m.type === 'Think' || m.type === 'think') && m.data.name.toLowerCase() === label) {
+            promptEl.textContent = m.data.prompt;
+            streamEl.textContent = m.data.output;
+          }
+        } catch (e) {
+          console.error(e);
+        }
+      };
+    })();
+  </script>
+</body>
+</html>

--- a/pete/src/lib.rs
+++ b/pete/src/lib.rs
@@ -26,5 +26,5 @@ pub use simulator::Simulator;
 pub use tts_mouth::{CoquiTts, Tts, TtsMouth, TtsStream};
 pub use web::{
     AppState, WsRequest, app, conversation_log, index, listen_user_input, log_ws_handler,
-    psyche_debug, toggle_wit_debug, ws_handler,
+    psyche_debug, toggle_wit_debug, wit_debug_page, ws_handler,
 };

--- a/pete/src/web.rs
+++ b/pete/src/web.rs
@@ -230,6 +230,10 @@ pub async fn toggle_wit_debug(
     StatusCode::OK
 }
 
+pub async fn wit_debug_page(Path(_label): Path<String>) -> Html<&'static str> {
+    Html(include_str!("../../frontend/dist/wit_debug.html"))
+}
+
 fn parse_data_url(url: &str) -> Option<(String, String)> {
     let (prefix, data) = url.split_once(',')?;
     let mime = prefix
@@ -256,7 +260,10 @@ pub fn app(state: AppState) -> Router {
         .route("/ws", get(ws_handler))
         .route("/log", get(log_ws_handler))
         .route("/debug", get(wit_ws_handler))
-        .route("/debug/wit/{label}", post(toggle_wit_debug))
+        .route(
+            "/debug/wit/{label}",
+            get(wit_debug_page).post(toggle_wit_debug),
+        )
         .route("/debug/psyche", get(psyche_debug))
         .route("/conversation", get(conversation_log))
         .fallback_service(

--- a/pete/tests/wit_page.rs
+++ b/pete/tests/wit_page.rs
@@ -1,0 +1,9 @@
+use axum::extract::Path;
+use pete::wit_debug_page;
+
+#[tokio::test]
+async fn serves_wit_debug_html() {
+    let resp = wit_debug_page(Path("will".to_string())).await;
+    let body = resp.0;
+    assert!(body.contains("Debug for"));
+}

--- a/pete/tests/ws_geolocate.rs
+++ b/pete/tests/ws_geolocate.rs
@@ -12,12 +12,10 @@ use tokio::sync::mpsc;
 async fn websocket_forwards_geolocation() {
     let mut psyche = dummy_psyche();
     let conversation = psyche.conversation();
-    let voice = psyche.voice();
     let ear = Arc::new(ChannelEar::new(
         psyche.input_sender(),
-        conversation.clone(),
         Arc::new(AtomicBool::new(false)),
-        voice,
+        psyche.voice(),
     ));
     // capture sensations sent by geo sensor
     let (tx, mut rx) = mpsc::unbounded_channel();


### PR DESCRIPTION
## Summary
- serve a new HTML page at `/debug/wit/{label}` showing per-Wit debug output
- export the page handler from the library
- document the endpoint in the README
- fix websocket geolocate test
- test that the debug page renders HTML

## Testing
- `cargo test --workspace --exclude codex --exclude frontend -q`

------
https://chatgpt.com/codex/tasks/task_e_685734049db08320bd2c82a8132933e9