### PR TITLE
Add wit debug stream to face

### DIFF
--- a/frontend/dist/app.js
+++ b/frontend/dist/app.js
@@ -11,7 +11,32 @@
   const player = document.getElementById("audio-player");
   const audioQueue = [];
   const witOutputs = {};
+  const witDetails = {};
+  const witDebugContainer = document.getElementById("wit-debug");
   let playing = false;
+
+  function getWitDetail(name) {
+    let entry = witDetails[name];
+    if (!entry) {
+      const details = document.createElement("details");
+      const summary = document.createElement("summary");
+      const link = document.createElement("a");
+      link.href = `/debug/wit/${name.toLowerCase()}`;
+      link.target = "_blank";
+      link.textContent = "link";
+      summary.textContent = name + " ";
+      summary.appendChild(link);
+      const promptPre = document.createElement("pre");
+      const outputPre = document.createElement("pre");
+      details.appendChild(summary);
+      details.appendChild(promptPre);
+      details.appendChild(outputPre);
+      witDebugContainer.appendChild(details);
+      entry = { promptPre, outputPre };
+      witDetails[name] = entry;
+    }
+    return entry;
+  }
 
   function enqueueAudio(item) {
     audioQueue.push(item);
@@ -68,6 +93,13 @@
         case "think": {
           if (typeof m.data === "object" && m.data !== null) {
             witOutputs[m.data.name] = m.data.output;
+            const { promptPre, outputPre } = getWitDetail(m.data.name);
+            if (m.data.prompt !== undefined) {
+              promptPre.textContent = m.data.prompt;
+            }
+            if (m.data.output !== undefined) {
+              outputPre.textContent = m.data.output;
+            }
           } else {
             witOutputs["unknown"] = m.data;
           }

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -26,6 +26,7 @@
     <summary>Conversation</summary>
     <pre id="conversation-log" style="white-space:pre-wrap;"></pre>
   </details>
+  <div id="wit-debug" style="position:absolute;top:1rem;right:1rem;max-height:40vh;overflow:auto;"></div>
   <script src="/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- display wit debug info via WebSocket on the main face
- expose `<div id="wit-debug">` in the page and stream updates per Wit

## Testing
- `cargo fetch`
- `cargo fmt --all`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68573776493c83209b1ca79de21f2b59