### PR TITLE
Add topic-based pub/sub bus

### DIFF
--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod psyche;
 pub mod sensation;
+pub mod topics;
 mod voice;
 
 pub mod traits {
@@ -69,6 +70,7 @@ pub use prehension::Prehension;
 pub use prompt::{CombobulatorPrompt, PromptBuilder, VoicePrompt, WillPrompt};
 pub use psyche::DEFAULT_SYSTEM_PROMPT;
 pub use sensor::Sensor;
+pub use topics::{Topic, TopicBus, TopicMessage};
 pub use trim_mouth::TrimMouth;
 pub use types::{GeoLoc, ImageData};
 

--- a/psyche/src/topics.rs
+++ b/psyche/src/topics.rs
@@ -1,0 +1,65 @@
+use futures::Stream;
+use futures::StreamExt;
+use std::any::Any;
+use std::sync::Arc;
+use tokio::sync::broadcast;
+use tokio_stream::wrappers::BroadcastStream;
+
+/// Cognitive topics exchanged between Wits.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Topic {
+    Instant,
+    Moment,
+    Situation,
+    Identity,
+    Instructions,
+}
+
+/// Envelope for topic messages carrying any payload.
+#[derive(Debug, Clone)]
+pub struct TopicMessage {
+    /// Topic this message belongs to.
+    pub topic: Topic,
+    /// Opaque payload associated with the topic.
+    pub payload: Arc<dyn Any + Send + Sync>,
+}
+
+/// Simple async pub/sub bus tagged by [`Topic`].
+#[derive(Clone)]
+pub struct TopicBus {
+    tx: broadcast::Sender<TopicMessage>,
+}
+
+impl TopicBus {
+    /// Create a new bus with the given channel capacity.
+    pub fn new(capacity: usize) -> Self {
+        let (tx, _r) = broadcast::channel(capacity);
+        Self { tx }
+    }
+
+    /// Publish `payload` on `topic` to all subscribers.
+    pub fn publish(&self, topic: Topic, payload: impl Any + Send + Sync + 'static) {
+        let _ = self.tx.send(TopicMessage {
+            topic,
+            payload: Arc::new(payload),
+        });
+    }
+
+    /// Subscribe to messages tagged with `topic`.
+    pub fn subscribe(&self, topic: Topic) -> impl Stream<Item = Arc<dyn Any + Send + Sync>> {
+        BroadcastStream::new(self.tx.subscribe()).filter_map(move |res| {
+            let topic = topic;
+            async move {
+                match res {
+                    Ok(msg) if msg.topic == topic => Some(msg.payload),
+                    _ => None,
+                }
+            }
+        })
+    }
+
+    /// Subscribe to all raw messages.
+    pub fn subscribe_raw(&self) -> broadcast::Receiver<TopicMessage> {
+        self.tx.subscribe()
+    }
+}

--- a/psyche/tests/topic_bus.rs
+++ b/psyche/tests/topic_bus.rs
@@ -1,0 +1,74 @@
+use async_trait::async_trait;
+use futures::{StreamExt, pin_mut};
+use psyche::ling::{Chatter, Doer, Instruction, Message, Vectorizer};
+use psyche::{Ear, Mouth, Psyche, Topic};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+#[derive(Clone, Default)]
+struct Dummy {
+    speaking: Arc<AtomicBool>,
+}
+
+#[async_trait]
+impl Mouth for Dummy {
+    async fn speak(&self, _t: &str) {
+        self.speaking.store(true, Ordering::SeqCst);
+    }
+    async fn interrupt(&self) {
+        self.speaking.store(false, Ordering::SeqCst);
+    }
+    fn speaking(&self) -> bool {
+        self.speaking.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl Ear for Dummy {
+    async fn hear_self_say(&self, _t: &str) {
+        self.speaking.store(false, Ordering::SeqCst);
+    }
+    async fn hear_user_say(&self, _t: &str) {}
+}
+
+#[async_trait]
+impl Doer for Dummy {
+    async fn follow(&self, _: Instruction) -> anyhow::Result<String> {
+        Ok("ok".into())
+    }
+}
+
+#[async_trait]
+impl Chatter for Dummy {
+    async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+        Ok(Box::pin(tokio_stream::once(Ok("hi".to_string()))))
+    }
+}
+
+#[async_trait]
+impl Vectorizer for Dummy {
+    async fn vectorize(&self, _: &str) -> anyhow::Result<Vec<f32>> {
+        Ok(vec![0.0])
+    }
+}
+
+#[tokio::test]
+async fn feel_forwards_to_topic_bus() {
+    let mouth = Arc::new(Dummy::default());
+    let ear = mouth.clone();
+    let psyche = Psyche::new(
+        Box::new(Dummy::default()),
+        Box::new(Dummy::default()),
+        Box::new(Dummy::default()),
+        Arc::new(psyche::NoopMemory),
+        mouth,
+        ear,
+    );
+    let bus = psyche.topic_bus();
+    let mut sub = bus.subscribe(Topic::Instant);
+    pin_mut!(sub);
+    psyche.feel("hello".to_string());
+    let payload = sub.next().await.unwrap();
+    let text = payload.downcast::<String>().unwrap();
+    assert_eq!(&*text, "hello");
+}


### PR DESCRIPTION
## Summary
- implement `TopicBus` using `tokio::broadcast`
- expose topic bus on `Psyche` and add new `feel` method
- provide `Topic` enum and message envelope
- test message delivery via topic bus

## Testing
- `cargo fetch`
- `cargo fmt`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685745b81d9883209a899a6558db8f70