### PR TITLE
Refactor face sensor to publish sensations

### DIFF
--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -139,7 +139,7 @@ async fn main() -> anyhow::Result<()> {
     let face_sensor = Arc::new(FaceSensor::new(
         Arc::new(psyche::DummyDetector::default()),
         psyche::QdrantClient::default(),
-        psyche.input_sender(),
+        psyche.topic_bus(),
     ));
     psyche.add_sense(eye.description());
     psyche.add_sense(face_sensor.description());

--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -22,7 +22,6 @@ pub mod wits {
     pub mod combobulator;
     pub mod combobulator_wit;
     pub mod face_memory_wit;
-    pub mod face_sensor;
     pub mod fond_du_coeur;
     pub mod fond_du_coeur_wit;
     pub mod heart_wit;
@@ -35,7 +34,6 @@ pub mod wits {
     pub use combobulator::Combobulator;
     pub use combobulator_wit::CombobulatorWit;
     pub use face_memory_wit::FaceMemoryWit;
-    pub use face_sensor::{DummyDetector, FaceDetector, FaceInfo, FaceSensor};
     pub use fond_du_coeur::FondDuCoeur;
     pub use fond_du_coeur_wit::FondDuCoeurWit;
     pub use heart_wit::HeartWit;
@@ -58,6 +56,10 @@ mod plain_mouth;
 mod prehension;
 mod prompt;
 mod sensor;
+pub mod sensors {
+    pub mod face;
+    pub use face::{DummyDetector, FaceDetector, FaceInfo, FaceSensor};
+}
 mod trim_mouth;
 mod types;
 
@@ -77,10 +79,10 @@ pub use types::{GeoLoc, ImageData};
 pub use ling::{Feeling, Ling};
 pub use psyche::{Conversation, Psyche};
 pub use sensation::{Event, Sensation, WitReport};
+pub use sensors::{DummyDetector, FaceDetector, FaceInfo, FaceSensor};
 pub use traits::{Ear, ErasedWit, Mouth, SensationObserver, Summarizer, Wit, WitAdapter};
 pub use voice::{Voice, extract_emojis};
 pub use wits::{
-    BasicMemory, CombobulatorWit, DummyDetector, FaceDetector, FaceInfo, FaceMemoryWit, FaceSensor,
-    FondDuCoeur, FondDuCoeurWit, GraphStore, HeartWit, Memory, MemoryWit, Neo4jClient, NoopMemory,
-    QdrantClient, VisionWit, Will, WillWit,
+    BasicMemory, CombobulatorWit, FaceMemoryWit, FondDuCoeur, FondDuCoeurWit, GraphStore, HeartWit,
+    Memory, MemoryWit, Neo4jClient, NoopMemory, QdrantClient, VisionWit, Will, WillWit,
 };

--- a/psyche/src/psyche.rs
+++ b/psyche/src/psyche.rs
@@ -231,7 +231,7 @@ impl Psyche {
     /// Publish a raw sensory impression on the [`TopicBus`].
     pub fn feel(&self, payload: impl Any + Send + Sync + 'static) {
         self.topic_bus
-            .publish(crate::topics::Topic::Instant, payload);
+            .publish(crate::topics::Topic::Sensation, payload);
     }
 
     /// Obtain the sender used to broadcast conversation [`Event`]s.

--- a/psyche/src/sensors/mod.rs
+++ b/psyche/src/sensors/mod.rs
@@ -1,0 +1,3 @@
+pub mod face;
+
+pub use face::{FaceDetector, DummyDetector, FaceInfo, FaceSensor};

--- a/psyche/src/topics.rs
+++ b/psyche/src/topics.rs
@@ -8,11 +8,13 @@ use tokio_stream::wrappers::BroadcastStream;
 /// Cognitive topics exchanged between Wits.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Topic {
+    Sensation,
     Instant,
     Moment,
     Situation,
     Identity,
-    Instructions,
+    Instruction,
+    FaceInfo,
 }
 
 /// Envelope for topic messages carrying any payload.

--- a/psyche/src/wits/face_memory_wit.rs
+++ b/psyche/src/wits/face_memory_wit.rs
@@ -1,6 +1,6 @@
+use crate::sensors::face::FaceInfo;
 use crate::traits::observer::SensationObserver;
 use crate::traits::wit::Wit;
-use crate::wits::face_sensor::FaceInfo;
 use crate::{Impression, Sensation, Stimulus};
 use async_trait::async_trait;
 use std::sync::{

--- a/psyche/tests/face_memory_wit.rs
+++ b/psyche/tests/face_memory_wit.rs
@@ -1,6 +1,6 @@
 use psyche::Wit;
+use psyche::sensors::face::FaceInfo;
 use psyche::wits::face_memory_wit::FaceMemoryWit;
-use psyche::wits::face_sensor::FaceInfo;
 use std::sync::Arc;
 
 fn dummy_info(val: f32) -> FaceInfo {

--- a/psyche/tests/face_sensor.rs
+++ b/psyche/tests/face_sensor.rs
@@ -1,33 +1,81 @@
+use async_trait::async_trait;
+use futures::{StreamExt, pin_mut};
+use psyche::ling::{Chatter, Doer, Instruction, Message, Vectorizer};
 use psyche::{
-    ImageData, Sensation, Sensor,
-    wits::{
-        face_sensor::{DummyDetector, FaceInfo, FaceSensor},
-        memory::QdrantClient,
-    },
+    Ear, ImageData, Mouth, Psyche, Sensation, Sensor, Topic,
+    sensors::face::{DummyDetector, FaceInfo, FaceSensor},
+    wits::memory::QdrantClient,
 };
-use tokio::sync::mpsc;
+use std::sync::Arc;
 
 #[tokio::test]
 async fn emits_face_info() {
-    let (tx, mut rx) = mpsc::unbounded_channel();
-    let sensor = FaceSensor::new(
-        std::sync::Arc::new(DummyDetector::default()),
-        QdrantClient::default(),
-        tx,
+    #[derive(Clone, Default)]
+    struct Dummy;
+    #[async_trait]
+    impl Mouth for Dummy {
+        async fn speak(&self, _: &str) {}
+        async fn interrupt(&self) {}
+        fn speaking(&self) -> bool {
+            false
+        }
+    }
+    #[async_trait]
+    impl Ear for Dummy {
+        async fn hear_self_say(&self, _: &str) {}
+        async fn hear_user_say(&self, _: &str) {}
+    }
+    #[async_trait]
+    impl Doer for Dummy {
+        async fn follow(&self, _: Instruction) -> anyhow::Result<String> {
+            Ok("ok".into())
+        }
+    }
+    #[async_trait]
+    impl Chatter for Dummy {
+        async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+            Ok(Box::pin(tokio_stream::once(Ok("hi".to_string()))))
+        }
+    }
+    #[async_trait]
+    impl Vectorizer for Dummy {
+        async fn vectorize(&self, _: &str) -> anyhow::Result<Vec<f32>> {
+            Ok(vec![0.0])
+        }
+    }
+    let mouth = Arc::new(Dummy::default());
+    let ear = mouth.clone();
+    let psyche = Psyche::new(
+        Box::new(Dummy),
+        Box::new(Dummy),
+        Box::new(Dummy),
+        Arc::new(psyche::NoopMemory),
+        mouth,
+        ear,
     );
+    let bus = psyche.topic_bus();
+    let sensor = FaceSensor::new(
+        Arc::new(DummyDetector::default()),
+        QdrantClient::default(),
+        bus.clone(),
+    );
+    let mut sub = bus.subscribe(Topic::Sensation);
+    pin_mut!(sub);
     sensor
         .sense(ImageData {
             mime: "image/png".into(),
             base64: "AA==".into(),
         })
         .await;
-    let sensed = rx.recv().await.expect("no sensation");
-    if let Sensation::Of(any) = sensed {
-        let info = any
-            .downcast_ref::<psyche::wits::face_sensor::FaceInfo>()
-            .unwrap();
-        assert_eq!(info.crop.mime, "image/png");
-        assert_eq!(info.embedding, vec![0.0]);
+    let sensed = sub.next().await.unwrap();
+    if let Some(s) = sensed.downcast_ref::<Sensation>() {
+        if let Sensation::Of(any) = s {
+            let info = any.downcast_ref::<FaceInfo>().unwrap();
+            assert_eq!(info.crop.mime, "image/png");
+            assert_eq!(info.embedding, vec![0.0]);
+        } else {
+            panic!("wrong sensation")
+        }
     } else {
         panic!("wrong sensation")
     }

--- a/psyche/tests/topic_bus.rs
+++ b/psyche/tests/topic_bus.rs
@@ -65,7 +65,7 @@ async fn feel_forwards_to_topic_bus() {
         ear,
     );
     let bus = psyche.topic_bus();
-    let mut sub = bus.subscribe(Topic::Instant);
+    let mut sub = bus.subscribe(Topic::Sensation);
     pin_mut!(sub);
     psyche.feel("hello".to_string());
     let payload = sub.next().await.unwrap();


### PR DESCRIPTION
## Summary
- add `Sensation` and other variants to `Topic`
- forward `Psyche::feel` to `Topic::Sensation`
- move FaceSensor under new `sensors` module
- publish face info via the topic bus
- adjust main and tests for new sensor location

## Testing
- `cargo check -p psyche`
- `cargo check -p pete`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68574a3b03308320a575b77743ab753f