### PR TITLE
Implement reactive WillWit

### DIFF
--- a/pete/src/psyche_factory.rs
+++ b/pete/src/psyche_factory.rs
@@ -74,7 +74,7 @@ pub fn ollama_psyche(
     use psyche::ling::OllamaProvider;
     use psyche::wits::{
         BasicMemory, Combobulator, CombobulatorWit, FondDuCoeur, FondDuCoeurWit, HeartWit,
-        MemoryWit, Neo4jClient, QdrantClient, Will, WillWit,
+        MemoryWit, Neo4jClient, QdrantClient, WillWit,
     };
 
     let narrator = OllamaProvider::new(chatter_host, chatter_model)?;
@@ -112,11 +112,10 @@ pub fn ollama_psyche(
         Box::new(OllamaProvider::new(wits_host, wits_model)?),
         wit_tx.clone(),
     ))));
-    let will = Arc::new(Will::with_debug(
-        Box::new(OllamaProvider::new(wits_host, wits_model)?),
-        wit_tx.clone(),
-    ));
-    psyche.register_typed_wit(Arc::new(WillWit::new(will, psyche.voice())));
+    psyche.register_typed_wit(Arc::new(WillWit::new(
+        psyche.topic_bus(),
+        Arc::new(OllamaProvider::new(wits_host, wits_model)?),
+    )));
     psyche.register_typed_wit(Arc::new(MemoryWit::with_debug(
         memory.clone(),
         wit_tx.clone(),

--- a/psyche/src/instruction.rs
+++ b/psyche/src/instruction.rs
@@ -1,0 +1,94 @@
+use quick_xml::{Reader, events::Event};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use tracing::debug;
+
+/// Discrete actions the host can execute.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Instruction {
+    /// Speak `text` optionally using a named `voice`.
+    Say { voice: Option<String>, text: String },
+    /// Change the expressed emotion.
+    Emote(String),
+    /// Move to the named location.
+    Move { to: String },
+}
+
+/// Parse a list of [`Instruction`]s from a short XML snippet.
+///
+/// Unknown tags are ignored with a debug log.
+///
+/// # Examples
+/// ```
+/// use psyche::{parse_instructions, Instruction};
+/// let out = "<say voice=\"kind\">Hi</say><emote>😊</emote>";
+/// let items = parse_instructions(out);
+/// assert_eq!(items[0], Instruction::Say { voice: Some("kind".into()), text: "Hi".into() });
+/// assert_eq!(items[1], Instruction::Emote("😊".into()));
+/// ```
+pub fn parse_instructions(text: &str) -> Vec<Instruction> {
+    let mut reader = Reader::from_str(text);
+    reader.trim_text(true);
+    let mut buf = Vec::new();
+    let mut current: Option<(String, HashMap<String, String>)> = None;
+    let mut content = String::new();
+    let mut out = Vec::new();
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Start(e)) => {
+                let name = String::from_utf8_lossy(e.name().as_ref()).to_string();
+                let mut attrs = HashMap::new();
+                for a in e.attributes().flatten() {
+                    let key = String::from_utf8_lossy(a.key.as_ref()).to_string();
+                    let val = a.unescape_value().unwrap_or_default().to_string();
+                    attrs.insert(key, val);
+                }
+                current = Some((name, attrs));
+            }
+            Ok(Event::Text(t)) => {
+                if current.is_some() {
+                    content.push_str(&t.unescape().unwrap_or_default());
+                }
+            }
+            Ok(Event::End(_)) => {
+                if let Some((name, attrs)) = current.take() {
+                    match name.as_str() {
+                        "say" => out.push(Instruction::Say {
+                            voice: attrs.get("voice").cloned(),
+                            text: content.clone(),
+                        }),
+                        "emote" => out.push(Instruction::Emote(content.clone())),
+                        "move" => out.push(Instruction::Move {
+                            to: attrs.get("to").cloned().unwrap_or_default(),
+                        }),
+                        other => debug!(%other, "unknown instruction tag"),
+                    }
+                    content.clear();
+                }
+            }
+            Ok(Event::Empty(e)) => {
+                let name = String::from_utf8_lossy(e.name().as_ref()).to_string();
+                let mut attrs = HashMap::new();
+                for a in e.attributes().flatten() {
+                    let key = String::from_utf8_lossy(a.key.as_ref()).to_string();
+                    let val = a.unescape_value().unwrap_or_default().to_string();
+                    attrs.insert(key, val);
+                }
+                match name.as_str() {
+                    "move" => out.push(Instruction::Move {
+                        to: attrs.get("to").cloned().unwrap_or_default(),
+                    }),
+                    other => debug!(%other, "unknown empty instruction"),
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(e) => {
+                debug!(error = ?e, "error parsing instructions");
+                break;
+            }
+            _ => {}
+        }
+        buf.clear();
+    }
+    out
+}

--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -1,5 +1,6 @@
 //! Core cognitive engine powering Pete.
 
+mod instruction;
 pub mod psyche;
 pub mod sensation;
 pub mod topics;
@@ -67,6 +68,7 @@ mod types;
 
 pub use and_mouth::AndMouth;
 pub use debug::{DebugHandle, DebugInfo, debug_enabled, disable_debug, enable_debug};
+pub use instruction::{Instruction, parse_instructions};
 pub use model::{Experience, Impression, Stimulus};
 pub use motor::{Motor, NoopMotor};
 pub use plain_mouth::PlainMouth;

--- a/psyche/src/wits/will_wit.rs
+++ b/psyche/src/wits/will_wit.rs
@@ -1,87 +1,123 @@
-use crate::{Impression, Stimulus, Summarizer, voice::Voice, wit::Wit, wits::Will};
+use crate::instruction::{Instruction, parse_instructions};
+use crate::ling::{Doer, Instruction as LlmInstruction};
+use crate::prompt::{PromptBuilder, WillPrompt};
+use crate::topics::{Topic, TopicBus};
+use crate::{Impression, Stimulus, WitReport};
 use async_trait::async_trait;
-use std::sync::{
-    Arc, Mutex,
-    atomic::{AtomicUsize, Ordering},
-};
+use futures::StreamExt;
+use std::sync::{Arc, Mutex};
+use tokio::sync::broadcast;
+use tracing::debug;
 
-/// Wit driving Pete's actions via the [`Will`] summarizer.
-///
-/// Accumulates awareness statements and periodically decides what to do or
-/// say next. After generating a decision it commands the [`Voice`] to speak.
+/// Wit that decides Pete's next action and publishes [`Instruction`]s.
 pub struct WillWit {
-    will: Arc<Will>,
-    buffer: Mutex<Vec<Impression<String>>>,
-    voice: Arc<Voice>,
-    ticks: AtomicUsize,
+    bus: TopicBus,
+    doer: Arc<dyn Doer>,
+    prompt: WillPrompt,
+    buffer: Arc<Mutex<Vec<String>>>,
+    tx: Option<broadcast::Sender<WitReport>>,
 }
 
 impl WillWit {
-    /// Debug label for this Wit.
+    /// Debug label used for debugging filters.
     pub const LABEL: &'static str = "WillWit";
-    /// Create a new `WillWit` using `will` to decide actions and allowing
-    /// `voice` to speak.
-    pub fn new(will: Arc<Will>, voice: Arc<Voice>) -> Self {
-        voice.set_will(will.clone());
-        Self {
-            will,
-            buffer: Mutex::new(Vec::new()),
-            voice,
-            ticks: AtomicUsize::new(0),
-        }
+
+    /// Create a new `WillWit` subscribed to `bus` using `doer`.
+    pub fn new(bus: TopicBus, doer: Arc<dyn Doer>) -> Self {
+        Self::with_debug(bus, doer, None)
     }
 
-    /// Override the [`Voice`] prompt builder.
-    pub fn set_prompt<P>(&self, prompt: P)
-    where
-        P: crate::prompt::PromptBuilder + Send + Sync + 'static,
-    {
-        self.voice.set_prompt(prompt);
+    /// Create a new `WillWit` emitting [`WitReport`]s via `tx`.
+    pub fn with_debug(
+        bus: TopicBus,
+        doer: Arc<dyn Doer>,
+        tx: Option<broadcast::Sender<WitReport>>,
+    ) -> Self {
+        let buffer = Arc::new(Mutex::new(Vec::new()));
+        let buf_clone = buffer.clone();
+        let bus_clone = bus.clone();
+        tokio::spawn(async move {
+            let inst = bus_clone.subscribe(Topic::Instant);
+            let mom = bus_clone.subscribe(Topic::Moment);
+            tokio::pin!(inst);
+            tokio::pin!(mom);
+            loop {
+                tokio::select! {
+                    Some(p) = inst.next() => {
+                        if let Ok(i) = Arc::downcast::<Impression<String>>(p) {
+                            buf_clone.lock().unwrap().push(i.summary.clone());
+                        }
+                    }
+                    Some(p) = mom.next() => {
+                        if let Ok(i) = Arc::downcast::<Impression<String>>(p) {
+                            buf_clone.lock().unwrap().push(i.summary.clone());
+                        }
+                    }
+                }
+            }
+        });
+        Self {
+            bus,
+            doer,
+            prompt: WillPrompt,
+            buffer,
+            tx,
+        }
     }
 }
 
 #[async_trait]
-impl Wit<Impression<String>, String> for WillWit {
-    async fn observe(&self, input: Impression<String>) {
-        self.buffer.lock().unwrap().push(input);
-    }
+impl crate::wit::Wit<(), Instruction> for WillWit {
+    async fn observe(&self, _: ()) {}
 
-    async fn tick(&self) -> Vec<Impression<String>> {
-        let inputs = {
+    async fn tick(&self) -> Vec<Impression<Instruction>> {
+        let items = {
             let mut buf = self.buffer.lock().unwrap();
             if buf.is_empty() {
                 return Vec::new();
             }
-            let data = buf.clone();
+            let out = buf.join(" \n");
             buf.clear();
-            data
+            out
         };
-        let decision = match self.will.digest(&inputs).await {
-            Ok(d) => d,
-            Err(_) => return Vec::new(),
-        };
-
-        let count = self.ticks.fetch_add(1, Ordering::SeqCst) + 1;
-        let mut prompt = None;
-        if count % 3 == 0 {
-            prompt = Some("share a brief update".to_string());
-        }
-        if inputs
-            .iter()
-            .any(|i| i.stimuli.iter().any(|s| s.what.contains('?')))
+        let prompt_text = self.prompt.build(&items);
+        let resp = match self
+            .doer
+            .follow(LlmInstruction {
+                command: prompt_text.clone(),
+                images: Vec::new(),
+            })
+            .await
         {
-            prompt = Some("answer the user's question".to_string());
+            Ok(r) => r,
+            Err(e) => {
+                debug!(?e, "will wit doer failed");
+                return Vec::new();
+            }
+        };
+        let instructions = parse_instructions(&resp);
+        for ins in &instructions {
+            self.bus.publish(Topic::Instruction, ins.clone());
         }
-
-        let mut out = vec![decision];
-        if let Some(p) = prompt {
-            out.push(Impression::new(
-                vec![Stimulus::new(format!("<take_turn>{}</take_turn>", p))],
-                "take_turn",
-                None::<String>,
-            ));
+        if let Some(tx) = &self.tx {
+            if crate::debug::debug_enabled(Self::LABEL).await {
+                let _ = tx.send(WitReport {
+                    name: Self::LABEL.into(),
+                    prompt: prompt_text,
+                    output: resp.clone(),
+                });
+            }
         }
-        out
+        instructions
+            .into_iter()
+            .map(|ins| {
+                Impression::new(
+                    vec![Stimulus::new(ins.clone())],
+                    format!("{:?}", ins),
+                    None::<String>,
+                )
+            })
+            .collect()
     }
 
     fn debug_label(&self) -> &'static str {


### PR DESCRIPTION
## Summary
- add `Instruction` enum and parser for XML tags
- redesign `WillWit` to publish structured instructions
- register new `WillWit` in the psyche factory
- provide unit tests for instruction emission

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68575b23859883209e50c605e86dd898