### PR TITLE
Add MomentWit summarizer

### DIFF
--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -29,6 +29,7 @@ pub mod wits {
     pub mod instant_wit;
     pub mod memory;
     pub mod memory_wit;
+    pub mod moment_wit;
     pub mod vision_wit;
     pub mod will;
     pub mod will_wit;
@@ -42,6 +43,7 @@ pub mod wits {
     pub use instant_wit::InstantWit;
     pub use memory::{BasicMemory, GraphStore, Memory, Neo4jClient, NoopMemory, QdrantClient};
     pub use memory_wit::MemoryWit;
+    pub use moment_wit::MomentWit;
     pub use vision_wit::VisionWit;
     pub use will::Will;
     pub use will_wit::WillWit;

--- a/psyche/src/wits/moment_wit.rs
+++ b/psyche/src/wits/moment_wit.rs
@@ -1,0 +1,103 @@
+use crate::ling::{Doer, Instruction};
+use crate::topics::{Topic, TopicBus};
+use crate::{Impression, Stimulus, WitReport};
+use async_trait::async_trait;
+use futures::StreamExt;
+use std::sync::{Arc, Mutex};
+use tokio::sync::broadcast;
+use tracing::debug;
+
+/// Wit summarizing recent instant impressions into a single moment.
+pub struct MomentWit {
+    buffer: Arc<Mutex<Vec<String>>>,
+    bus: TopicBus,
+    doer: Arc<dyn Doer>,
+    tx: Option<broadcast::Sender<WitReport>>,
+}
+
+impl MomentWit {
+    /// Debug label for filtering reports.
+    pub const LABEL: &'static str = "MomentWit";
+
+    /// Create a new `MomentWit` subscribed to `bus` using `doer`.
+    pub fn new(bus: TopicBus, doer: Arc<dyn Doer>) -> Self {
+        Self::with_debug(bus, doer, None)
+    }
+
+    /// Create a `MomentWit` that emits [`WitReport`]s via `tx`.
+    pub fn with_debug(
+        bus: TopicBus,
+        doer: Arc<dyn Doer>,
+        tx: Option<broadcast::Sender<WitReport>>,
+    ) -> Self {
+        let buffer = Arc::new(Mutex::new(Vec::new()));
+        let buf_clone = buffer.clone();
+        let bus_clone = bus.clone();
+        tokio::spawn(async move {
+            let mut stream = bus_clone.subscribe(Topic::Instant);
+            tokio::pin!(stream);
+            while let Some(payload) = stream.next().await {
+                if let Ok(i) = Arc::downcast::<Impression<String>>(payload) {
+                    buf_clone.lock().unwrap().push(i.summary.clone());
+                }
+            }
+        });
+        Self {
+            buffer,
+            bus,
+            doer,
+            tx,
+        }
+    }
+}
+
+#[async_trait]
+impl crate::wit::Wit<(), String> for MomentWit {
+    async fn observe(&self, _: ()) {}
+
+    async fn tick(&self) -> Vec<Impression<String>> {
+        const MIN_ITEMS: usize = 3;
+        let items = {
+            let mut buf = self.buffer.lock().unwrap();
+            if buf.len() < MIN_ITEMS {
+                return Vec::new();
+            }
+            buf.drain(..).collect::<Vec<_>>()
+        };
+        debug!(count = items.len(), "moment wit summarizing instants");
+        let prompt = format!("Summarize these recent events:\n- {}", items.join("\n- "));
+        let resp = match self
+            .doer
+            .follow(Instruction {
+                command: prompt.clone(),
+                images: Vec::new(),
+            })
+            .await
+        {
+            Ok(s) => s.trim().to_string(),
+            Err(e) => {
+                debug!(?e, "moment wit doer failed");
+                String::new()
+            }
+        };
+        if resp.is_empty() {
+            return Vec::new();
+        }
+        if let Some(tx) = &self.tx {
+            if crate::debug::debug_enabled(Self::LABEL).await {
+                let _ = tx.send(WitReport {
+                    name: Self::LABEL.into(),
+                    prompt: prompt.clone(),
+                    output: resp.clone(),
+                });
+            }
+        }
+        let imp = Impression::new(vec![Stimulus::new(resp.clone())], resp, None::<String>);
+        self.bus.publish(Topic::Moment, imp.clone());
+        vec![imp]
+    }
+
+    fn debug_label(&self) -> &'static str {
+        Self::LABEL
+    }
+}

--- a/psyche/tests/moment_wit.rs
+++ b/psyche/tests/moment_wit.rs
@@ -1,0 +1,70 @@
+use async_trait::async_trait;
+use psyche::ling::{Doer, Instruction as LlmInstruction};
+use psyche::topics::{Topic, TopicBus};
+use psyche::wits::MomentWit;
+use psyche::{Impression, Stimulus, Wit};
+use std::sync::Arc;
+use tokio::time::{Duration, sleep};
+
+#[derive(Clone)]
+struct DummyDoer;
+
+#[async_trait]
+impl Doer for DummyDoer {
+    async fn follow(&self, i: LlmInstruction) -> anyhow::Result<String> {
+        Ok(format!("SUMMARY:{}", i.command))
+    }
+}
+
+fn publish_instants(bus: &TopicBus, count: usize) {
+    for i in 0..count {
+        bus.publish(
+            Topic::Instant,
+            Impression::new(
+                vec![Stimulus::new(format!("i{i}"))],
+                format!("i{i}"),
+                None::<String>,
+            ),
+        );
+    }
+}
+
+#[tokio::test]
+async fn publishes_summary_after_three_instants() {
+    let bus = TopicBus::new(8);
+    let wit = MomentWit::new(bus.clone(), Arc::new(DummyDoer));
+    sleep(Duration::from_millis(20)).await;
+    publish_instants(&bus, 3);
+    sleep(Duration::from_millis(50)).await;
+    let out = wit.tick().await;
+    assert_eq!(out.len(), 1);
+    assert!(out[0].summary.starts_with("SUMMARY:"));
+}
+
+#[tokio::test]
+async fn does_nothing_with_fewer_instants() {
+    let bus = TopicBus::new(8);
+    let wit = MomentWit::new(bus.clone(), Arc::new(DummyDoer));
+    sleep(Duration::from_millis(20)).await;
+    publish_instants(&bus, 2);
+    sleep(Duration::from_millis(50)).await;
+    let out = wit.tick().await;
+    assert!(out.is_empty());
+}
+
+#[tokio::test]
+async fn debug_report_contains_prompt_and_summary() {
+    let bus = TopicBus::new(8);
+    let (tx, mut rx) = tokio::sync::broadcast::channel(8);
+    psyche::enable_debug("MomentWit").await;
+    let wit = MomentWit::with_debug(bus.clone(), Arc::new(DummyDoer), Some(tx));
+    sleep(Duration::from_millis(20)).await;
+    publish_instants(&bus, 3);
+    sleep(Duration::from_millis(50)).await;
+    let _ = wit.tick().await;
+    let report = rx.recv().await.unwrap();
+    assert_eq!(report.name, "MomentWit");
+    assert!(report.prompt.contains("Summarize"));
+    assert!(report.output.contains("SUMMARY:"));
+    psyche::disable_debug("MomentWit").await;
+}


### PR DESCRIPTION
## Summary
- implement `MomentWit` to collect Instant summaries via `TopicBus`
- export the new wit
- test moment summarization and debug reporting

## Testing
- `cargo test --test moment_wit -- --nocapture`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685761dc20808320b200c76d4c986aa8