### PR TITLE
Add SituationWit summarizer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,7 @@ The previous Deno-based client has been removed. Update the files in
 * `FaceSensor` uses `DummyDetector` for tests; real detectors may require OpenCV.
 * There is no bundled frontend. Connect your own WebSocket client to
   `ws://localhost:3000/ws`.
+* Give every new Wit a `LABEL` constant and a `with_debug` constructor for emitting `WitReport`s.
 
 ## LLM Integration
 

--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -30,6 +30,7 @@ pub mod wits {
     pub mod memory;
     pub mod memory_wit;
     pub mod moment_wit;
+    pub mod situation_wit;
     pub mod vision_wit;
     pub mod will;
     pub mod will_wit;
@@ -44,6 +45,7 @@ pub mod wits {
     pub use memory::{BasicMemory, GraphStore, Memory, Neo4jClient, NoopMemory, QdrantClient};
     pub use memory_wit::MemoryWit;
     pub use moment_wit::MomentWit;
+    pub use situation_wit::SituationWit;
     pub use vision_wit::VisionWit;
     pub use will::Will;
     pub use will_wit::WillWit;

--- a/psyche/src/wits/situation_wit.rs
+++ b/psyche/src/wits/situation_wit.rs
@@ -1,0 +1,115 @@
+use crate::ling::{Doer, Instruction};
+use crate::topics::{Topic, TopicBus};
+use crate::{Impression, Stimulus, WitReport};
+use async_trait::async_trait;
+use futures::StreamExt;
+use std::sync::{Arc, Mutex};
+use tokio::sync::broadcast;
+use tracing::debug;
+
+/// Wit that summarizes recent moments into an ongoing situation.
+pub struct SituationWit {
+    buffer: Arc<Mutex<Vec<String>>>,
+    bus: TopicBus,
+    doer: Arc<dyn Doer>,
+    last: Arc<Mutex<Option<String>>>,
+    tx: Option<broadcast::Sender<WitReport>>,
+}
+
+impl SituationWit {
+    /// Debug label for filtering reports.
+    pub const LABEL: &'static str = "SituationWit";
+
+    /// Create a new `SituationWit` subscribed to `bus` using `doer`.
+    pub fn new(bus: TopicBus, doer: Arc<dyn Doer>) -> Self {
+        Self::with_debug(bus, doer, None)
+    }
+
+    /// Create a `SituationWit` that emits [`WitReport`]s via `tx`.
+    pub fn with_debug(
+        bus: TopicBus,
+        doer: Arc<dyn Doer>,
+        tx: Option<broadcast::Sender<WitReport>>,
+    ) -> Self {
+        let buffer = Arc::new(Mutex::new(Vec::new()));
+        let last = Arc::new(Mutex::new(None));
+        let buf_clone = buffer.clone();
+        let bus_clone = bus.clone();
+        tokio::spawn(async move {
+            let mut stream = bus_clone.subscribe(Topic::Moment);
+            tokio::pin!(stream);
+            while let Some(payload) = stream.next().await {
+                if let Ok(i) = Arc::downcast::<Impression<String>>(payload) {
+                    buf_clone.lock().unwrap().push(i.summary.clone());
+                }
+            }
+        });
+        Self {
+            buffer,
+            bus,
+            doer,
+            last,
+            tx,
+        }
+    }
+}
+
+#[async_trait]
+impl crate::wit::Wit<(), String> for SituationWit {
+    async fn observe(&self, _: ()) {}
+
+    async fn tick(&self) -> Vec<Impression<String>> {
+        const MIN_ITEMS: usize = 3;
+        let items = {
+            let mut buf = self.buffer.lock().unwrap();
+            if buf.len() < MIN_ITEMS {
+                return Vec::new();
+            }
+            buf.drain(..).collect::<Vec<_>>()
+        };
+        debug!(count = items.len(), "situation wit summarizing moments");
+        let previous = self.last.lock().unwrap().clone();
+        let mut prompt = String::new();
+        if let Some(prev) = previous {
+            if !prev.trim().is_empty() {
+                prompt.push_str(&format!("Previous situation: {}\n", prev));
+            }
+        }
+        prompt.push_str("Given the following recent moments, summarize the ongoing situation in one sentence:\n- ");
+        prompt.push_str(&items.join("\n- "));
+        let resp = match self
+            .doer
+            .follow(Instruction {
+                command: prompt.clone(),
+                images: Vec::new(),
+            })
+            .await
+        {
+            Ok(s) => s.trim().to_string(),
+            Err(e) => {
+                debug!(?e, "situation wit doer failed");
+                String::new()
+            }
+        };
+        if resp.is_empty() {
+            return Vec::new();
+        }
+        *self.last.lock().unwrap() = Some(resp.clone());
+        if let Some(tx) = &self.tx {
+            if crate::debug::debug_enabled(Self::LABEL).await {
+                let _ = tx.send(WitReport {
+                    name: Self::LABEL.into(),
+                    prompt: prompt.clone(),
+                    output: resp.clone(),
+                });
+            }
+        }
+        let imp = Impression::new(vec![Stimulus::new(resp.clone())], resp, None::<String>);
+        self.bus.publish(Topic::Situation, imp.clone());
+        vec![imp]
+    }
+
+    fn debug_label(&self) -> &'static str {
+        Self::LABEL
+    }
+}

--- a/psyche/tests/situation_wit.rs
+++ b/psyche/tests/situation_wit.rs
@@ -1,0 +1,70 @@
+use async_trait::async_trait;
+use psyche::ling::{Doer, Instruction as LlmInstruction};
+use psyche::topics::{Topic, TopicBus};
+use psyche::wits::SituationWit;
+use psyche::{Impression, Stimulus, Wit};
+use std::sync::Arc;
+use tokio::time::{Duration, sleep};
+
+#[derive(Clone)]
+struct DummyDoer;
+
+#[async_trait]
+impl Doer for DummyDoer {
+    async fn follow(&self, i: LlmInstruction) -> anyhow::Result<String> {
+        Ok(format!("SUM:{}", i.command))
+    }
+}
+
+fn publish_moments(bus: &TopicBus, count: usize) {
+    for i in 0..count {
+        bus.publish(
+            Topic::Moment,
+            Impression::new(
+                vec![Stimulus::new(format!("m{i}"))],
+                format!("m{i}"),
+                None::<String>,
+            ),
+        );
+    }
+}
+
+#[tokio::test]
+async fn publishes_summary_after_three_moments() {
+    let bus = TopicBus::new(8);
+    let wit = SituationWit::new(bus.clone(), Arc::new(DummyDoer));
+    sleep(Duration::from_millis(20)).await;
+    publish_moments(&bus, 3);
+    sleep(Duration::from_millis(50)).await;
+    let out = wit.tick().await;
+    assert_eq!(out.len(), 1);
+    assert!(out[0].summary.contains("SUM:"));
+}
+
+#[tokio::test]
+async fn does_nothing_with_fewer_moments() {
+    let bus = TopicBus::new(8);
+    let wit = SituationWit::new(bus.clone(), Arc::new(DummyDoer));
+    sleep(Duration::from_millis(20)).await;
+    publish_moments(&bus, 2);
+    sleep(Duration::from_millis(50)).await;
+    let out = wit.tick().await;
+    assert!(out.is_empty());
+}
+
+#[tokio::test]
+async fn debug_report_contains_prompt_and_summary() {
+    let bus = TopicBus::new(8);
+    let (tx, mut rx) = tokio::sync::broadcast::channel(8);
+    psyche::enable_debug("SituationWit").await;
+    let wit = SituationWit::with_debug(bus.clone(), Arc::new(DummyDoer), Some(tx));
+    sleep(Duration::from_millis(20)).await;
+    publish_moments(&bus, 3);
+    sleep(Duration::from_millis(50)).await;
+    let _ = wit.tick().await;
+    let report = rx.recv().await.unwrap();
+    assert_eq!(report.name, "SituationWit");
+    assert!(report.prompt.contains("recent moments"));
+    assert!(report.output.contains("SUM:"));
+    psyche::disable_debug("SituationWit").await;
+}


### PR DESCRIPTION
## Summary
- add `SituationWit` that buffers recent moments and publishes a situation summary
- expose new wit through `psyche` crate
- cover behaviour with new unit tests
- document debug constructor convention in AGENTS

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6857657baccc832083d73d30ea97f2c6