### PR TITLE
Implement EpisodeWit for narrative episodes

### DIFF
--- a/psyche/src/instruction.rs
+++ b/psyche/src/instruction.rs
@@ -12,6 +12,8 @@ pub enum Instruction {
     Emote(String),
     /// Move to the named location.
     Move { to: String },
+    /// End the current episode and summarize it.
+    BreakEpisode,
 }
 
 /// Parse a list of [`Instruction`]s from a short XML snippet.
@@ -61,6 +63,7 @@ pub fn parse_instructions(text: &str) -> Vec<Instruction> {
                         "move" => out.push(Instruction::Move {
                             to: attrs.get("to").cloned().unwrap_or_default(),
                         }),
+                        "break-episode" => out.push(Instruction::BreakEpisode),
                         other => debug!(%other, "unknown instruction tag"),
                     }
                     content.clear();
@@ -78,6 +81,7 @@ pub fn parse_instructions(text: &str) -> Vec<Instruction> {
                     "move" => out.push(Instruction::Move {
                         to: attrs.get("to").cloned().unwrap_or_default(),
                     }),
+                    "break-episode" => out.push(Instruction::BreakEpisode),
                     other => debug!(%other, "unknown empty instruction"),
                 }
             }

--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -22,6 +22,7 @@ pub mod wit;
 pub mod wits {
     pub mod combobulator;
     pub mod combobulator_wit;
+    pub mod episode_wit;
     pub mod face_memory_wit;
     pub mod fond_du_coeur;
     pub mod fond_du_coeur_wit;
@@ -37,6 +38,7 @@ pub mod wits {
 
     pub use combobulator::Combobulator;
     pub use combobulator_wit::CombobulatorWit;
+    pub use episode_wit::EpisodeWit;
     pub use face_memory_wit::FaceMemoryWit;
     pub use fond_du_coeur::FondDuCoeur;
     pub use fond_du_coeur_wit::FondDuCoeurWit;
@@ -91,6 +93,7 @@ pub use sensors::{DummyDetector, FaceDetector, FaceInfo, FaceSensor};
 pub use traits::{Ear, ErasedWit, Mouth, SensationObserver, Summarizer, Wit, WitAdapter};
 pub use voice::{Voice, extract_emojis};
 pub use wits::{
-    BasicMemory, CombobulatorWit, FaceMemoryWit, FondDuCoeur, FondDuCoeurWit, GraphStore, HeartWit,
-    Memory, MemoryWit, Neo4jClient, NoopMemory, QdrantClient, VisionWit, Will, WillWit,
+    BasicMemory, CombobulatorWit, EpisodeWit, FaceMemoryWit, FondDuCoeur, FondDuCoeurWit,
+    GraphStore, HeartWit, Memory, MemoryWit, Neo4jClient, NoopMemory, QdrantClient, VisionWit,
+    Will, WillWit,
 };

--- a/psyche/src/topics.rs
+++ b/psyche/src/topics.rs
@@ -12,6 +12,7 @@ pub enum Topic {
     Instant,
     Moment,
     Situation,
+    Episode,
     Identity,
     Instruction,
     FaceInfo,

--- a/psyche/src/wits/episode_wit.rs
+++ b/psyche/src/wits/episode_wit.rs
@@ -1,0 +1,132 @@
+use crate::Instruction;
+use crate::ling::{Doer, Instruction as LlmInstruction};
+use crate::topics::{Topic, TopicBus};
+use crate::{Impression, Stimulus, WitReport};
+use async_trait::async_trait;
+use futures::StreamExt;
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicBool, Ordering},
+};
+use tokio::sync::broadcast;
+use tracing::debug;
+
+/// Wit that groups situations into higher-level narrative episodes.
+pub struct EpisodeWit {
+    buffer: Arc<Mutex<Vec<String>>>,
+    bus: TopicBus,
+    doer: Arc<dyn Doer>,
+    break_flag: Arc<AtomicBool>,
+    tx: Option<broadcast::Sender<WitReport>>,
+}
+
+impl EpisodeWit {
+    /// Debug label for filtering reports.
+    pub const LABEL: &'static str = "EpisodeWit";
+
+    /// Create a new `EpisodeWit` subscribed to `bus` using `doer`.
+    pub fn new(bus: TopicBus, doer: Arc<dyn Doer>) -> Self {
+        Self::with_debug(bus, doer, None)
+    }
+
+    /// Create an `EpisodeWit` that emits [`WitReport`]s via `tx`.
+    pub fn with_debug(
+        bus: TopicBus,
+        doer: Arc<dyn Doer>,
+        tx: Option<broadcast::Sender<WitReport>>,
+    ) -> Self {
+        let buffer = Arc::new(Mutex::new(Vec::new()));
+        let break_flag = Arc::new(AtomicBool::new(false));
+        let buf_clone = buffer.clone();
+        let bus_clone = bus.clone();
+        tokio::spawn(async move {
+            let mut stream = bus_clone.subscribe(Topic::Situation);
+            tokio::pin!(stream);
+            while let Some(payload) = stream.next().await {
+                if let Ok(i) = Arc::downcast::<Impression<String>>(payload) {
+                    buf_clone.lock().unwrap().push(i.summary.clone());
+                }
+            }
+        });
+
+        let break_clone = break_flag.clone();
+        let bus_clone = bus.clone();
+        tokio::spawn(async move {
+            let mut stream = bus_clone.subscribe(Topic::Instruction);
+            tokio::pin!(stream);
+            while let Some(payload) = stream.next().await {
+                if let Ok(i) = Arc::downcast::<Instruction>(payload) {
+                    if matches!(*i, Instruction::BreakEpisode) {
+                        break_clone.store(true, Ordering::SeqCst);
+                    }
+                }
+            }
+        });
+
+        Self {
+            buffer,
+            bus,
+            doer,
+            break_flag,
+            tx,
+        }
+    }
+}
+
+#[async_trait]
+impl crate::wit::Wit<(), String> for EpisodeWit {
+    async fn observe(&self, _: ()) {}
+
+    async fn tick(&self) -> Vec<Impression<String>> {
+        const MIN_ITEMS: usize = 3;
+        let should_break = self.break_flag.swap(false, Ordering::SeqCst);
+        let items = {
+            let mut buf = self.buffer.lock().unwrap();
+            if buf.is_empty() {
+                return Vec::new();
+            }
+            if buf.len() < MIN_ITEMS && !should_break {
+                return Vec::new();
+            }
+            buf.drain(..).collect::<Vec<_>>()
+        };
+        debug!(count = items.len(), "episode wit summarizing situations");
+        let prompt = format!(
+            "The following situations form a coherent story. Write a one-sentence summary suitable for a chapter heading.\n- {}",
+            items.join("\n- ")
+        );
+        let resp = match self
+            .doer
+            .follow(LlmInstruction {
+                command: prompt.clone(),
+                images: Vec::new(),
+            })
+            .await
+        {
+            Ok(s) => s.trim().to_string(),
+            Err(e) => {
+                debug!(?e, "episode wit doer failed");
+                String::new()
+            }
+        };
+        if resp.is_empty() {
+            return Vec::new();
+        }
+        if let Some(tx) = &self.tx {
+            if crate::debug::debug_enabled(Self::LABEL).await {
+                let _ = tx.send(WitReport {
+                    name: Self::LABEL.into(),
+                    prompt: prompt.clone(),
+                    output: resp.clone(),
+                });
+            }
+        }
+        let imp = Impression::new(vec![Stimulus::new(resp.clone())], resp, None::<String>);
+        self.bus.publish(Topic::Episode, imp.clone());
+        vec![imp]
+    }
+
+    fn debug_label(&self) -> &'static str {
+        Self::LABEL
+    }
+}

--- a/psyche/tests/episode_wit.rs
+++ b/psyche/tests/episode_wit.rs
@@ -1,0 +1,64 @@
+use async_trait::async_trait;
+use psyche::ling::{Doer, Instruction as LlmInstruction};
+use psyche::topics::{Topic, TopicBus};
+use psyche::wits::EpisodeWit;
+use psyche::{Impression, Instruction, Stimulus, Wit};
+use std::sync::Arc;
+use tokio::time::{Duration, sleep};
+
+#[derive(Clone)]
+struct DummyDoer;
+
+#[async_trait]
+impl Doer for DummyDoer {
+    async fn follow(&self, i: LlmInstruction) -> anyhow::Result<String> {
+        Ok(format!("EPISUM:{}", i.command))
+    }
+}
+
+fn publish_situations(bus: &TopicBus, count: usize) {
+    for i in 0..count {
+        bus.publish(
+            Topic::Situation,
+            Impression::new(
+                vec![Stimulus::new(format!("s{i}"))],
+                format!("s{i}"),
+                None::<String>,
+            ),
+        );
+    }
+}
+
+#[tokio::test]
+async fn emits_summary_on_break() {
+    let bus = TopicBus::new(8);
+    let wit = EpisodeWit::new(bus.clone(), Arc::new(DummyDoer));
+    sleep(Duration::from_millis(20)).await;
+    publish_situations(&bus, 3);
+    sleep(Duration::from_millis(20)).await;
+    bus.publish(Topic::Instruction, Instruction::BreakEpisode);
+    sleep(Duration::from_millis(20)).await;
+    let out = wit.tick().await;
+    assert_eq!(out.len(), 1);
+    assert!(out[0].summary.contains("EPISUM:"));
+}
+
+#[tokio::test]
+async fn no_emit_without_break_or_enough_items() {
+    let bus = TopicBus::new(8);
+    let wit = EpisodeWit::new(bus.clone(), Arc::new(DummyDoer));
+    sleep(Duration::from_millis(20)).await;
+    publish_situations(&bus, 2);
+    sleep(Duration::from_millis(20)).await;
+    let out = wit.tick().await;
+    assert!(out.is_empty());
+}
+
+#[tokio::test]
+async fn empty_buffer_emits_nothing() {
+    let bus = TopicBus::new(8);
+    let wit = EpisodeWit::new(bus.clone(), Arc::new(DummyDoer));
+    sleep(Duration::from_millis(20)).await;
+    let out = wit.tick().await;
+    assert!(out.is_empty());
+}


### PR DESCRIPTION
## Summary
- add `Episode` topic and `BreakEpisode` instruction variant
- implement `EpisodeWit` to group situations
- export new Wit and update topics
- test EpisodeWit behaviour

## Testing
- `cargo fmt`
- `cargo fetch`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6857692495608320bf4a212876867721