### PR TITLE
Add dedupe for FaceSensor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,7 @@ The previous Deno-based client has been removed. Update the files in
 * Favor TDD/BDD when adding features; write failing tests first.
 * Provide stub implementations for external ML components so tests run offline.
 * `FaceSensor` uses `DummyDetector` for tests; real detectors may require OpenCV.
+* `FaceSensor` caches the last embedding to avoid redundant vectors.
 * There is no bundled frontend. Connect your own WebSocket client to
   `ws://localhost:3000/ws`.
 * Give every new Wit a `LABEL` constant and a `with_debug` constructor for emitting `WitReport`s.

--- a/psyche/src/sensors/face.rs
+++ b/psyche/src/sensors/face.rs
@@ -4,8 +4,8 @@ use crate::wits::memory::QdrantClient;
 use crate::{ImageData, Sensation};
 use anyhow::Result;
 use async_trait::async_trait;
-use std::sync::Arc;
-use tracing::error;
+use std::sync::{Arc, Mutex};
+use tracing::{debug, error};
 
 /// Information about a detected face.
 use serde::{Deserialize, Serialize};
@@ -36,11 +36,22 @@ impl FaceDetector for DummyDetector {
     }
 }
 
+fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    if a.is_empty() || b.is_empty() {
+        return 0.0;
+    }
+    let dot: f32 = a.iter().zip(b).map(|(x, y)| x * y).sum();
+    let norm_a: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+    let norm_b: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+    dot / (norm_a * norm_b + 1e-5)
+}
+
 /// Sensor that emits [`FaceInfo`] sensations.
 pub struct FaceSensor {
     detector: Arc<dyn FaceDetector>,
     qdrant: QdrantClient,
     bus: TopicBus,
+    last_face: Mutex<Option<Vec<f32>>>,
 }
 
 impl FaceSensor {
@@ -50,6 +61,7 @@ impl FaceSensor {
             detector,
             qdrant,
             bus,
+            last_face: Mutex::new(None),
         }
     }
 }
@@ -60,6 +72,20 @@ impl Sensor<ImageData> for FaceSensor {
         match self.detector.detect_faces(&input).await {
             Ok(faces) => {
                 for (crop, embed) in faces {
+                    let skip = {
+                        let mut last = self.last_face.lock().unwrap();
+                        let similar = last
+                            .as_ref()
+                            .map_or(false, |p| cosine_similarity(p, &embed) > 0.95);
+                        if !similar {
+                            *last = Some(embed.clone());
+                        }
+                        similar
+                    };
+                    if skip {
+                        debug!("skipping similar face detection");
+                        continue;
+                    }
                     if let Err(e) = self.qdrant.store_face_vector(&embed).await {
                         error!(?e, "failed storing face vector");
                     }


### PR DESCRIPTION
## Summary
- cache last face embedding to skip similar detections
- test that duplicates are ignored and different faces pass through
- capture log output when skipping
- document FaceSensor caching in AGENTS notes

## Testing
- `cargo fmt`
- `cargo fetch`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68577b44788c8320b2366716255373fc