### PR TITLE
Add console logging for LLM prompts and responses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,7 @@ The previous Deno-based client has been removed. Update the files in
 * Log Coqui TTS request URLs with `info!(%url, "requesting TTS")` to ease debugging misconfigured endpoints.
 * Log each Wit tick with its name and keep loops alive even when idle.
 * Log Ollama prompts and streamed chunks with `debug!` for troubleshooting.
+* Log all LLM prompts and final responses to stdout using `tracing` macros.
 * When introducing new CLI arguments or environment variables, update
   `.env.example` and README examples accordingly.
 * Log unknown sensation types in `InstantWit::describe` to surface missing

--- a/psyche/src/psyche.rs
+++ b/psyche/src/psyche.rs
@@ -480,6 +480,7 @@ impl Psyche {
                 let mut prompt = { self.ling.lock().await.build_prompt().await };
                 prompt.push('\n');
                 prompt.push_str(&extra);
+                info!(%prompt, "conversation prompt");
                 self.is_speaking = true;
                 if let Err(e) = self.voice.take_turn(&prompt, &history).await {
                     error!(?e, "voice chat failed");

--- a/psyche/src/voice.rs
+++ b/psyche/src/voice.rs
@@ -101,6 +101,7 @@ impl Voice {
         } else {
             base
         };
+        info!(%prompt, "voice prompt");
         if let Ok(mut stream) = self.chatter.chat(&prompt, history).await {
             let mut buf = String::new();
             let mut full = String::new();
@@ -141,6 +142,7 @@ impl Voice {
             while let Some(sentence) = pending.pop_front() {
                 self.emit_sentence(&sentence).await;
             }
+            info!(%full, "voice full response");
             let will = { self.will.lock().unwrap().clone() };
             if let Some(w) = will {
                 w.handle_llm_output(&full).await;

--- a/psyche/src/wits/will.rs
+++ b/psyche/src/wits/will.rs
@@ -9,6 +9,7 @@ use quick_xml::{Reader, events::Event};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::broadcast;
+use tracing::info;
 
 /// Decide Pete's next action or speech using a language model.
 ///
@@ -141,7 +142,9 @@ impl Summarizer<String, String> for Will {
             command: self.prompt.build(&input),
             images: Vec::new(),
         };
+        info!(prompt = %instruction.command, "will prompt");
         let resp = self.doer.follow(instruction.clone()).await?;
+        info!(response = %resp, "will response");
         let decision = resp.trim().to_string();
         if let Some(tx) = &self.tx {
             if crate::debug::debug_enabled(Self::LABEL).await {

--- a/psyche/src/wits/will_wit.rs
+++ b/psyche/src/wits/will_wit.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use futures::StreamExt;
 use std::sync::{Arc, Mutex};
 use tokio::sync::broadcast;
-use tracing::debug;
+use tracing::{debug, info};
 
 /// Wit that decides Pete's next action and publishes [`Instruction`]s.
 pub struct WillWit {
@@ -89,6 +89,7 @@ impl crate::wit::Wit<(), Instruction> for WillWit {
             out
         };
         let prompt_text = self.prompt.build(&items);
+        info!(prompt = %prompt_text, "will_wit prompt");
         let resp = match self
             .doer
             .follow(LlmInstruction {
@@ -103,6 +104,7 @@ impl crate::wit::Wit<(), Instruction> for WillWit {
                 return Vec::new();
             }
         };
+        info!(response = %resp, "will_wit response");
         let instructions = parse_instructions(&resp);
         let unique = {
             let mut hist = self.history.lock().unwrap();


### PR DESCRIPTION
## Summary
- log prompts and responses in `Voice`, `Will`, and `WillWit`
- emit conversation prompt from `Psyche`
- document logging requirement in `AGENTS.md`

## Testing
- `cargo fmt`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68577ebc854083209d19f0918a5e2aa0