### PR TITLE
Implement contextual prompt builder for Voice

### DIFF
--- a/pete/src/psyche_factory.rs
+++ b/pete/src/psyche_factory.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
-use psyche::Psyche;
 use psyche::ling::{Chatter, Doer, Instruction, Message, Vectorizer};
+use psyche::{ContextualPrompt, Psyche};
 use std::sync::Arc;
 use tracing::info;
 
@@ -50,6 +50,9 @@ pub fn dummy_psyche() -> Psyche {
     )));
     psyche.register_observing_wit(Arc::new(psyche::FaceMemoryWit::with_debug(wit_tx)));
     psyche.set_turn_limit(usize::MAX);
+    psyche
+        .voice()
+        .set_prompt(ContextualPrompt::new(psyche.topic_bus()));
     info!("created dummy psyche");
     psyche
 }
@@ -129,6 +132,9 @@ pub fn ollama_psyche(
         wit_tx.clone(),
     ))));
     psyche.set_turn_limit(usize::MAX);
+    psyche
+        .voice()
+        .set_prompt(ContextualPrompt::new(psyche.topic_bus()));
     info!(
         %chatter_host,
         %chatter_model,

--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -81,7 +81,7 @@ pub use model::{Experience, Impression, Stimulus};
 pub use motor::{Motor, NoopMotor};
 pub use plain_mouth::PlainMouth;
 pub use prehension::Prehension;
-pub use prompt::{CombobulatorPrompt, PromptBuilder, VoicePrompt, WillPrompt};
+pub use prompt::{CombobulatorPrompt, ContextualPrompt, PromptBuilder, VoicePrompt, WillPrompt};
 pub use psyche::DEFAULT_SYSTEM_PROMPT;
 pub use sensor::Sensor;
 pub use topics::{Topic, TopicBus, TopicMessage};

--- a/psyche/src/prompt.rs
+++ b/psyche/src/prompt.rs
@@ -39,3 +39,71 @@ impl PromptBuilder for CombobulatorPrompt {
         format!("Summarize Pete's current awareness in one or two sentences:\n{input}")
     }
 }
+
+/// Prompt builder that injects recent context from the `TopicBus`.
+#[derive(Clone)]
+pub struct ContextualPrompt {
+    identity: std::sync::Arc<std::sync::Mutex<Option<String>>>,
+    situation: std::sync::Arc<std::sync::Mutex<Option<String>>>,
+    moment: std::sync::Arc<std::sync::Mutex<Option<String>>>,
+    instant: std::sync::Arc<std::sync::Mutex<Option<String>>>,
+}
+
+impl ContextualPrompt {
+    /// Create a new prompt builder subscribed to `bus`.
+    pub fn new(bus: crate::topics::TopicBus) -> Self {
+        use crate::topics::Topic;
+        use futures::StreamExt;
+        let identity = std::sync::Arc::new(std::sync::Mutex::new(None));
+        let situation = std::sync::Arc::new(std::sync::Mutex::new(None));
+        let moment = std::sync::Arc::new(std::sync::Mutex::new(None));
+        let instant = std::sync::Arc::new(std::sync::Mutex::new(None));
+        let subs = [
+            (Topic::Identity, identity.clone()),
+            (Topic::Situation, situation.clone()),
+            (Topic::Moment, moment.clone()),
+            (Topic::Instant, instant.clone()),
+        ];
+        for (topic, store) in subs.into_iter() {
+            let b = bus.clone();
+            let s = store.clone();
+            tokio::spawn(async move {
+                let mut stream = b.subscribe(topic);
+                tokio::pin!(stream);
+                while let Some(payload) = stream.next().await {
+                    if let Ok(sval) = std::sync::Arc::downcast::<String>(payload.clone()) {
+                        *s.lock().unwrap() = Some((*sval).clone());
+                        continue;
+                    }
+                    if let Ok(imp) = std::sync::Arc::downcast::<crate::Impression<String>>(payload)
+                    {
+                        *s.lock().unwrap() = Some(imp.summary.clone());
+                    }
+                }
+            });
+        }
+        Self {
+            identity,
+            situation,
+            moment,
+            instant,
+        }
+    }
+
+    fn latest(store: &std::sync::Arc<std::sync::Mutex<Option<String>>>) -> String {
+        store.lock().unwrap().clone().unwrap_or_default()
+    }
+}
+
+impl PromptBuilder for ContextualPrompt {
+    fn build(&self, input: &str) -> String {
+        let id = Self::latest(&self.identity);
+        let sit = Self::latest(&self.situation);
+        let mom = Self::latest(&self.moment);
+        let ins = Self::latest(&self.instant);
+        tracing::debug!(%id, %sit, %mom, %ins, "injecting context");
+        format!(
+            "Pete’s context:\nIdentity: {id}\nSituation: {sit}\nMoment: {mom}\nInstant: {ins}\n\nRespond in character:\n{input}"
+        )
+    }
+}

--- a/psyche/tests/contextual_prompt.rs
+++ b/psyche/tests/contextual_prompt.rs
@@ -1,0 +1,60 @@
+use psyche::topics::{Topic, TopicBus};
+use psyche::{ContextualPrompt, Impression, PromptBuilder, Stimulus};
+use tokio::time::{Duration, sleep};
+
+#[tokio::test]
+async fn includes_all_context() {
+    let bus = TopicBus::new(8);
+    let prompt = ContextualPrompt::new(bus.clone());
+    sleep(Duration::from_millis(100)).await;
+    bus.publish(Topic::Identity, "I am Pete".to_string());
+    sleep(Duration::from_millis(10)).await;
+    bus.publish(
+        Topic::Situation,
+        Impression::new(
+            vec![Stimulus::new("s".to_string())],
+            "on porch",
+            None::<String>,
+        ),
+    );
+    sleep(Duration::from_millis(10)).await;
+    bus.publish(
+        Topic::Moment,
+        Impression::new(
+            vec![Stimulus::new("m".to_string())],
+            "wind blew",
+            None::<String>,
+        ),
+    );
+    sleep(Duration::from_millis(10)).await;
+    bus.publish(
+        Topic::Instant,
+        Impression::new(
+            vec![Stimulus::new("i".to_string())],
+            "user said hi",
+            None::<String>,
+        ),
+    );
+    sleep(Duration::from_millis(50)).await;
+    let out = prompt.build("hi");
+    println!("{}", out);
+    assert!(out.contains("Identity: I am Pete"));
+    assert!(out.contains("Situation: on porch"));
+    assert!(out.contains("Moment: wind blew"));
+    assert!(out.contains("Instant: user said hi"));
+}
+
+#[tokio::test]
+async fn missing_context_is_empty() {
+    let bus = TopicBus::new(8);
+    let prompt = ContextualPrompt::new(bus.clone());
+    sleep(Duration::from_millis(20)).await;
+    bus.publish(Topic::Identity, "Pete".to_string());
+    sleep(Duration::from_millis(20)).await;
+    let out = prompt.build("hi");
+    println!("{}", out);
+    assert!(out.contains("Identity: Pete"));
+    assert!(out.contains("Situation: "));
+    assert!(out.contains("Moment: "));
+    assert!(out.contains("Instant: "));
+}


### PR DESCRIPTION
## Summary
- create `ContextualPrompt` for Voice to include identity, situation, moment, and instant context
- export new prompt builder in `psyche` crate and apply in psyche factories
- hook up prompt builder in dummy and Ollama psyche setups
- add tests confirming context injection

## Testing
- `cargo test --test contextual_prompt -- --nocapture`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68577fae80a88320931322becd3a2c56