### PR TITLE
Add info-level tracing

### DIFF
--- a/pete/src/ear.rs
+++ b/pete/src/ear.rs
@@ -5,7 +5,7 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
 };
 use tokio::sync::mpsc;
-use tracing::debug;
+use tracing::{debug, info};
 
 /// [`Ear`] implementation that forwards heard text through a channel.
 #[derive(Clone)]
@@ -34,6 +34,7 @@ impl ChannelEar {
 impl Ear for ChannelEar {
     async fn hear_self_say(&self, text: &str) {
         self.speaking.store(false, Ordering::SeqCst);
+        info!(%text, "ear heard self say");
         debug!("ear heard self say: {}", text);
         self.voice.permit(None);
         let _ = self
@@ -42,6 +43,7 @@ impl Ear for ChannelEar {
     }
 
     async fn hear_user_say(&self, text: &str) {
+        info!(%text, "ear heard user say");
         debug!("ear heard user say: {}", text);
         let _ = self
             .forward

--- a/pete/src/mouth.rs
+++ b/pete/src/mouth.rs
@@ -5,7 +5,7 @@ use std::sync::{
     Arc,
     atomic::{AtomicBool, Ordering},
 };
-use tracing::debug;
+use tracing::{debug, info};
 
 /// Simple mouth implementation that does not produce audio.
 ///
@@ -29,6 +29,7 @@ impl ChannelMouth {
 impl Mouth for ChannelMouth {
     async fn speak(&self, text: &str) {
         self.speaking.store(true, Ordering::SeqCst);
+        info!(%text, "mouth speaking");
         debug!("mouth speaking: {}", text);
         let seg = pragmatic_segmenter::Segmenter::new().expect("segmenter init");
         for sentence in seg.segment(text) {
@@ -44,6 +45,7 @@ impl Mouth for ChannelMouth {
     }
     async fn interrupt(&self) {
         self.speaking.store(false, Ordering::SeqCst);
+        info!("mouth interrupted");
         debug!("mouth interrupted");
     }
     fn speaking(&self) -> bool {

--- a/pete/src/sensor/eye.rs
+++ b/pete/src/sensor/eye.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use psyche::{ImageData, Sensation, Sensor};
 use tokio::sync::mpsc;
-use tracing::debug;
+use tracing::{debug, info};
 
 /// Sensor that forwards webcam images to the psyche.
 #[derive(Clone)]
@@ -19,6 +19,7 @@ impl EyeSensor {
 #[async_trait]
 impl Sensor<ImageData> for EyeSensor {
     async fn sense(&self, image: ImageData) {
+        info!("eye sensed image");
         debug!("eye sensed image");
         let _ = self.forward.send(Sensation::Of(Box::new(image)));
     }

--- a/pete/src/sensor/geo.rs
+++ b/pete/src/sensor/geo.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use psyche::{GeoLoc, Sensation, Sensor};
 use tokio::sync::mpsc;
-use tracing::debug;
+use tracing::{debug, info};
 
 /// Sensor forwarding geolocation updates to the psyche.
 #[derive(Clone)]
@@ -19,6 +19,7 @@ impl GeoSensor {
 #[async_trait]
 impl Sensor<GeoLoc> for GeoSensor {
     async fn sense(&self, loc: GeoLoc) {
+        info!("geo sensor received location");
         debug!("geo sensor received location");
         let _ = self.forward.send(Sensation::Of(Box::new(loc)));
     }

--- a/pete/src/simulator.rs
+++ b/pete/src/simulator.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use psyche::{Ear, ImageData, Sensor};
+use tracing::info;
 
 /// Utility for feeding fake sensations to a [`Psyche`].
 #[derive(Clone)]
@@ -19,11 +20,13 @@ impl Simulator {
 
     /// Send a text message as if spoken by the user.
     pub async fn text(&self, msg: &str) {
+        info!(%msg, "simulator text");
         self.ear.hear_user_say(msg).await;
     }
 
     /// Send raw image bytes with MIME type to the psyche.
     pub async fn image(&self, mime: &str, bytes: &[u8]) {
+        info!(%mime, size = bytes.len(), "simulator image");
         let data = BASE64.encode(bytes);
         let img = ImageData {
             mime: mime.to_string(),

--- a/psyche/src/wits/face_memory_wit.rs
+++ b/psyche/src/wits/face_memory_wit.rs
@@ -8,6 +8,7 @@ use std::sync::{
     atomic::{AtomicUsize, Ordering},
 };
 use tokio::sync::broadcast;
+use tracing::info;
 
 /// Wit that notes when familiar or new faces appear.
 pub struct FaceMemoryWit {
@@ -63,6 +64,7 @@ impl Wit<FaceInfo, FaceInfo> for FaceMemoryWit {
                 self.ticks_without_face.fetch_add(1, Ordering::SeqCst);
                 if self.ticks_without_face.load(Ordering::SeqCst) >= 5 {
                     self.ticks_without_face.store(0, Ordering::SeqCst);
+                    info!("no faces detected for a while");
                     return vec![Impression::new(
                         vec![],
                         "No faces detected for a while now.",
@@ -91,6 +93,7 @@ impl Wit<FaceInfo, FaceInfo> for FaceMemoryWit {
                 };
                 *last = Some(info.embedding.clone());
             }
+            info!(%summary, "face memory observation");
             if let Some(tx) = &self.tx {
                 if crate::debug::debug_enabled(Self::LABEL).await {
                     let _ = tx.send(crate::WitReport {

--- a/psyche/src/wits/memory.rs
+++ b/psyche/src/wits/memory.rs
@@ -161,6 +161,7 @@ pub struct BasicMemory {
 #[async_trait]
 impl Memory for BasicMemory {
     async fn store(&self, impression: &Impression<Value>) -> Result<()> {
+        info!(summary = %impression.summary, "memory store");
         let vector = self.vectorizer.vectorize(&impression.summary).await?;
         self.qdrant
             .store_vector(&impression.summary, &vector)


### PR DESCRIPTION
## Summary
- integrate info! tracing in simulator and channels
- log provider actions with info-level tracing
- surface face memory and memory store logs
- trace mouth and sensor activity at info level

## Testing
- `cargo fmt`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6857823201648320b5245ed990549c5a