### PR TITLE
Enable .env support in CLI binary

### DIFF
--- a/pete/Cargo.toml
+++ b/pete/Cargo.toml
@@ -27,6 +27,7 @@ tower-http = { version = "0.6", features = ["fs"] }
 axum-server = { version = "0.7", features = ["tls-rustls"] }
 tokio-tungstenite = "0.27"
 mime_guess = "2"
+dotenvy = "0.15"
 
 [features]
 default = []

--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -1,5 +1,6 @@
 use axum_server::tls_rustls::RustlsConfig;
 use clap::Parser;
+use dotenvy::dotenv;
 use pete::{
     AppState, ChannelEar, ChannelMouth, app, init_logging, listen_user_input, ollama_psyche,
 };
@@ -88,6 +89,8 @@ async fn main() -> anyhow::Result<()> {
     let (bus, user_rx) = pete::EventBus::new();
     let bus = Arc::new(bus);
     init_logging(bus.log_sender());
+    dotenv().ok();
+    let _ = dbg!(std::env::var("CHATTER_MODEL"));
     let cli = Cli::parse();
 
     info!(%cli.addr, "starting server");


### PR DESCRIPTION
## Summary
- load `.env` before command line parsing in `pete` binary
- add `dotenvy` dependency to `pete`

## Testing
- `cargo test --all`

------
https://chatgpt.com/codex/tasks/task_e_68578784cc388320925e21f087e42d76