### PR TITLE
Display webcam as translucent background

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/styles.css">
 </head>
 <body>
-  <video id="webcam" autoplay muted playsinline style="display:none"></video>
+  <video id="webcam" autoplay muted playsinline></video>
   <img id="image-thumbnail" class="image-thumbnail" alt="Last sent image" style="display:none;" />
   <div id="face" class="face" style="position:relative;width:100vw;height:100vh;overflow:hidden;">
     <div id="mien" class="mien" style="z-index:1;position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);">😐</div>

--- a/frontend/dist/styles.css
+++ b/frontend/dist/styles.css
@@ -99,6 +99,7 @@
     width: 100vw;
     height: 100vh;
     object-fit: cover;
+    pointer-events: none;
     /* To ensure the video covers the entire area without distortion */
 }
 


### PR DESCRIPTION
## Summary
- show webcam video element and overlay it as a translucent backdrop
- keep video from intercepting pointer events

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68578c95c490832089fdc005137ff2c6