### PR TITLE
Add periodic HeartbeatSensor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,5 +134,6 @@ This document reflects the current cognitive and runtime architecture of Pete Da
 ## Sensor Features
 
 * Build with cargo features to include sensors.
-* Features: `eye`, `face`, `geo`, `ear`.
+* Features: `eye`, `face`, `geo`, `ear`, `heartbeat`.
 * `all-sensors` enables them all and is used by default.
+* `HeartbeatSensor::test_interval` helps with short test delays.

--- a/pete/Cargo.toml
+++ b/pete/Cargo.toml
@@ -28,6 +28,8 @@ axum-server = { version = "0.7", features = ["tls-rustls"] }
 tokio-tungstenite = "0.27"
 mime_guess = "2"
 dotenvy = "0.15"
+rand = "0.8"
+chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 
 [features]
 default = ["all-sensors"]

--- a/pete/src/lib.rs
+++ b/pete/src/lib.rs
@@ -29,6 +29,7 @@ pub use sensor::NoopSensor;
 pub use sensor::eye::EyeSensor;
 #[cfg(feature = "geo")]
 pub use sensor::geo::GeoSensor;
+pub use sensor::heartbeat::HeartbeatSensor;
 pub use simulator::Simulator;
 #[cfg(feature = "tts")]
 pub use tts_mouth::{CoquiTts, Tts, TtsMouth, TtsStream};

--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -1,5 +1,6 @@
 use axum_server::tls_rustls::RustlsConfig;
 use clap::Parser;
+use dotenvy::dotenv;
 #[cfg(feature = "ear")]
 use pete::ChannelEar;
 #[cfg(feature = "eye")]
@@ -8,7 +9,7 @@ use pete::EyeSensor;
 use pete::FaceSensor;
 #[cfg(feature = "geo")]
 use pete::GeoSensor;
-use dotenvy::dotenv;
+use pete::HeartbeatSensor;
 use pete::{
     AppState, ChannelMouth, NoopEar, NoopSensor, app, init_logging, listen_user_input,
     ollama_psyche,
@@ -197,6 +198,9 @@ async fn main() -> anyhow::Result<()> {
     };
     #[cfg(not(feature = "geo"))]
     let geo: Arc<dyn Sensor<GeoLoc>> = Arc::new(NoopSensor) as Arc<dyn Sensor<GeoLoc>>;
+
+    let heartbeat = HeartbeatSensor::new(psyche.input_sender());
+    senses.push(heartbeat.describe());
     tokio::spawn(listen_user_input(user_rx, ear.clone(), voice.clone()));
 
     if let Some(secs) = cli.auto_voice {

--- a/pete/src/sensor/heartbeat.rs
+++ b/pete/src/sensor/heartbeat.rs
@@ -1,0 +1,49 @@
+use async_trait::async_trait;
+use chrono::Utc;
+use psyche::{Heartbeat, Sensation, Sensor};
+use rand::Rng;
+use std::time::Duration;
+use tokio::sync::mpsc;
+use tracing::info;
+
+/// Sensor emitting a timestamp every ~60 seconds.
+#[derive(Clone)]
+pub struct HeartbeatSensor;
+
+impl HeartbeatSensor {
+    /// Spawn a new heartbeat loop forwarding sensations through `forward`.
+    pub fn new(forward: mpsc::UnboundedSender<Sensation>) -> Self {
+        Self::spawn(forward, Duration::from_secs(55), 10);
+        Self
+    }
+
+    #[cfg(test)]
+    pub fn test_interval(forward: mpsc::UnboundedSender<Sensation>, secs: u64) -> Self {
+        Self::spawn(forward, Duration::from_secs(secs), 0);
+        Self
+    }
+
+    fn spawn(forward: mpsc::UnboundedSender<Sensation>, base: Duration, range: u64) {
+        tokio::spawn(async move {
+            loop {
+                let secs = rand::thread_rng().gen_range(0..=range);
+                let wait = base + Duration::from_secs(secs);
+                tokio::time::sleep(wait).await;
+                let beat = Heartbeat {
+                    timestamp: Utc::now(),
+                };
+                info!("heartbeat");
+                let _ = forward.send(Sensation::Of(Box::new(beat)));
+            }
+        });
+    }
+}
+
+#[async_trait]
+impl Sensor<()> for HeartbeatSensor {
+    async fn sense(&self, _input: ()) {}
+
+    fn describe(&self) -> &'static str {
+        "Heartbeat: Announces the time periodically."
+    }
+}

--- a/pete/src/sensor/mod.rs
+++ b/pete/src/sensor/mod.rs
@@ -2,6 +2,7 @@
 pub mod eye;
 #[cfg(feature = "geo")]
 pub mod geo;
+pub mod heartbeat;
 
 use async_trait::async_trait;
 use psyche::Sensor;

--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -88,7 +88,7 @@ pub use psyche::DEFAULT_SYSTEM_PROMPT;
 pub use sensor::Sensor;
 pub use topics::{Topic, TopicBus, TopicMessage};
 pub use trim_mouth::TrimMouth;
-pub use types::{GeoLoc, ImageData, ObjectInfo};
+pub use types::{GeoLoc, Heartbeat, ImageData, ObjectInfo};
 
 pub use ling::{Feeling, Ling};
 pub use psyche::{Conversation, Psyche};

--- a/psyche/src/types.rs
+++ b/psyche/src/types.rs
@@ -20,3 +20,10 @@ pub struct ObjectInfo {
     pub label: Option<String>,
     pub embedding: Vec<f32>,
 }
+
+/// Timestamp emitted periodically by [`HeartbeatSensor`](crate::HeartbeatSensor).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Heartbeat {
+    /// Moment of the heartbeat.
+    pub timestamp: chrono::DateTime<chrono::Utc>,
+}


### PR DESCRIPTION
## Summary
- implement HeartbeatSensor that emits regular timestamp sensations
- expose Heartbeat type for use across crates
- wire sensor into main binary
- update build instructions with heartbeat feature

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68578e513d2883209346c4bb375dde91