### PR TITLE
Fix details width

### DIFF
--- a/frontend/dist/styles.css
+++ b/frontend/dist/styles.css
@@ -232,6 +232,9 @@ details {
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
     padding: 1em;
     margin-bottom: 1em;
+    max-width: 50vw;
+    overflow-wrap: anywhere;
+    word-break: break-word;
 }
 
 details > summary {


### PR DESCRIPTION
## Summary
- limit `details` elements to half the viewport width
- ensure conversation text wraps cleanly in debug panel

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685790033e188320977a677dc165bd25