### PR TITLE
Improve system prompt and UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ This repository is a Rust workspace.
 ## Running & Testing
 
 * Run tests with `cargo test` from the repository root.
+* Some tests check debug logs; set `RUST_LOG=debug` when running them.
 * Format with `cargo fmt`.
 * Use `tracing` macros for all logging.
 * Initialize logging in binaries with `tracing_subscriber::fmt::init()`.

--- a/frontend/dist/app.js
+++ b/frontend/dist/app.js
@@ -230,7 +230,12 @@
     try {
       const resp = await fetch("/conversation");
       const msgs = await resp.json();
+      const system = document.getElementById("system-prompt");
+      if (system && msgs.length) {
+        system.textContent = msgs[0].content;
+      }
       document.getElementById("conversation-log").textContent = msgs
+        .slice(1)
         .map((m) => `${m.role}: ${m.content}`)
         .join("\n");
     } catch (e) {

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -24,6 +24,7 @@
   </form>
   <details style="position:absolute;top:1rem;left:1rem;max-height:40vh;overflow:auto;">
     <summary>Conversation</summary>
+    <pre id="system-prompt" style="white-space:pre-wrap;"></pre>
     <pre id="conversation-log" style="white-space:pre-wrap;"></pre>
   </details>
   <div id="wit-debug" style="position:absolute;top:1rem;right:1rem;max-height:40vh;overflow:auto;"></div>

--- a/pete/src/ear.rs
+++ b/pete/src/ear.rs
@@ -35,6 +35,9 @@ impl ChannelEar {
             voice,
         }
     }
+
+    /// Human readable description of this sense.
+    pub const DESCRIPTION: &'static str = "Pete hears audio from the user, transcribed as text. He can respond to spoken questions and converse naturally.";
 }
 
 #[cfg(feature = "ear")]

--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -1,5 +1,6 @@
 use axum_server::tls_rustls::RustlsConfig;
 use clap::Parser;
+use dotenvy::dotenv;
 #[cfg(feature = "ear")]
 use pete::ChannelEar;
 #[cfg(feature = "eye")]
@@ -8,7 +9,6 @@ use pete::EyeSensor;
 use pete::FaceSensor;
 #[cfg(feature = "geo")]
 use pete::GeoSensor;
-use dotenvy::dotenv;
 use pete::{
     AppState, ChannelMouth, NoopEar, NoopSensor, app, init_logging, listen_user_input,
     ollama_psyche,
@@ -140,10 +140,9 @@ async fn main() -> anyhow::Result<()> {
     psyche.set_connection_counter(connections.clone());
     let conversation = psyche.conversation();
     let voice = psyche.voice();
-    let mut senses: Vec<&'static str> = Vec::new();
     #[cfg(feature = "ear")]
     let ear: Arc<dyn Ear> = {
-        senses.push("Audio input (user voice)");
+        psyche.add_sense(ChannelEar::DESCRIPTION.into());
         Arc::new(ChannelEar::new(
             psyche.input_sender(),
             speaking.clone(),
@@ -157,7 +156,7 @@ async fn main() -> anyhow::Result<()> {
     #[cfg(feature = "eye")]
     let eye: Arc<dyn Sensor<ImageData>> = {
         let sensor = Arc::new(EyeSensor::new(eye_tx)) as Arc<dyn Sensor<ImageData>>;
-        senses.push(sensor.describe());
+        psyche.add_sense(sensor.describe().into());
         sensor
     };
     #[cfg(not(feature = "eye"))]
@@ -171,7 +170,7 @@ async fn main() -> anyhow::Result<()> {
     ));
     #[cfg(feature = "face")]
     {
-        senses.push(face_sensor.describe());
+        psyche.add_sense(face_sensor.describe().into());
     }
     #[cfg(all(feature = "eye", feature = "face"))]
     {
@@ -192,7 +191,7 @@ async fn main() -> anyhow::Result<()> {
     #[cfg(feature = "geo")]
     let geo: Arc<dyn Sensor<GeoLoc>> = {
         let g = Arc::new(GeoSensor::new(psyche.input_sender())) as Arc<dyn Sensor<GeoLoc>>;
-        senses.push(g.describe());
+        psyche.add_sense(g.describe().into());
         g
     };
     #[cfg(not(feature = "geo"))]
@@ -225,10 +224,8 @@ async fn main() -> anyhow::Result<()> {
             bus_events.publish_event(evt);
         }
     });
-    let system_prompt = format!(
-        "These are the only senses Pete has:\n- {}",
-        senses.join("\n- ")
-    );
+    psyche.add_sense("Pete experiences a heartbeat sensation roughly every minute, which reminds him that time is passing.".into());
+    let system_prompt = psyche.described_system_prompt();
     psyche.set_system_prompt(system_prompt.clone());
     tokio::spawn(async move {
         psyche.run().await;

--- a/pete/src/sensor/eye.rs
+++ b/pete/src/sensor/eye.rs
@@ -25,6 +25,7 @@ impl Sensor<ImageData> for EyeSensor {
     }
 
     fn describe(&self) -> &'static str {
-        "Visual (images)"
+        "Pete can see through a webcam. Every few seconds, a new image is \
+passed to his perception system. He can describe what he sees and recognize people's faces."
     }
 }

--- a/pete/src/sensor/geo.rs
+++ b/pete/src/sensor/geo.rs
@@ -25,6 +25,7 @@ impl Sensor<GeoLoc> for GeoSensor {
     }
 
     fn describe(&self) -> &'static str {
-        "Geolocation (latitude/longitude)"
+        "Pete knows where he is in terms of latitude and longitude. This may \
+help him remember where events happened."
     }
 }

--- a/psyche/src/sensors/face.rs
+++ b/psyche/src/sensors/face.rs
@@ -104,6 +104,7 @@ impl Sensor<ImageData> for FaceSensor {
     }
 
     fn describe(&self) -> &'static str {
-        "Face detection (embeddings)"
+        "Pete tries to recognize faces in the images he sees. If he sees the \
+same face often, he may remember it."
     }
 }


### PR DESCRIPTION
## Summary
- restore automatic system prompt assembly and propagate through the UI
- add detailed sense descriptions for eye, geo and face sensors
- expose ear description constant
- display the system prompt in the web interface
- document using `RUST_LOG=debug` for tests

## Testing
- `cargo fmt`
- `RUST_LOG=debug cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68578f8dd5888320b05fde29bfb81698