### PR TITLE
Add retro tab styling

### DIFF
--- a/frontend/dist/app.js
+++ b/frontend/dist/app.js
@@ -15,6 +15,12 @@
   const witDebugContainer = document.getElementById("wit-debug");
   let playing = false;
 
+  document.addEventListener("keydown", (e) => {
+    if (e.altKey && e.code === "Backquote") {
+      document.body.classList.toggle("retro-tabs");
+    }
+  });
+
   function getWitDetail(name) {
     let entry = witDetails[name];
     if (!entry) {

--- a/frontend/dist/styles.css
+++ b/frontend/dist/styles.css
@@ -253,3 +253,34 @@ details > summary::-webkit-details-marker {
 details > summary:hover {
     background-color: var(--panel-hover);
 }
+/* Retro mode styling */
+body.retro-tabs details {
+    background: linear-gradient(to bottom, #dcdcdc, #c0c0c0);
+    border: 2px solid #808080;
+    box-shadow: inset -1px -1px 0 #404040, inset 1px 1px 0 #fff;
+    border-radius: 6px;
+    padding: 0.5em;
+    margin-bottom: 1em;
+}
+body.retro-tabs details > summary {
+    font-variant: small-caps;
+    font-family: system-ui, sans-serif;
+    text-shadow: 1px 1px #fff;
+    background: linear-gradient(to bottom, #dcdcdc, #c0c0c0);
+    border-radius: 6px;
+    padding: 0.25em 0.5em;
+    cursor: pointer;
+    user-select: none;
+}
+body.retro-tabs details > summary:hover,
+body.retro-tabs details > summary:focus {
+    background: linear-gradient(to bottom, #c0c0c0, #a0a0a0);
+}
+body.retro-tabs details[open] {
+    animation: retro-flicker 0.2s ease-in-out;
+}
+@keyframes retro-flicker {
+    0% { filter: brightness(1); }
+    50% { filter: brightness(1.2); }
+    100% { filter: brightness(1); }
+}


### PR DESCRIPTION
## Summary
- style `details` panels in retro mode via `.retro-tabs`
- allow toggling retro mode with `Alt+~`

## Testing
- `cargo fmt`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685791aac27c8320b067704f95d853d1