### PR TITLE
Show Wit debug panels

### DIFF
--- a/frontend/dist/styles.css
+++ b/frontend/dist/styles.css
@@ -140,6 +140,15 @@ details pre {
   margin: 1em;
 }
 
+details.updated {
+  animation: flash 0.5s ease-in-out;
+}
+
+@keyframes flash {
+  from { background-color: #444; }
+  to { background-color: #222; }
+}
+
 .thought-bubble {
   display: flex;
   align-items: center;

--- a/pete/src/psyche_factory.rs
+++ b/pete/src/psyche_factory.rs
@@ -115,9 +115,10 @@ pub fn ollama_psyche(
         Box::new(OllamaProvider::new(wits_host, wits_model)?),
         wit_tx.clone(),
     ))));
-    psyche.register_typed_wit(Arc::new(WillWit::new(
+    psyche.register_typed_wit(Arc::new(WillWit::with_debug(
         psyche.topic_bus(),
         Arc::new(OllamaProvider::new(wits_host, wits_model)?),
+        Some(wit_tx.clone()),
     )));
     psyche.register_typed_wit(Arc::new(MemoryWit::with_debug(
         memory.clone(),


### PR DESCRIPTION
## Summary
- show a `<details>` panel for every active wit
- update panels live as `WitReport`s arrive
- highlight panel briefly when new data appears
- wire `WillWit` up for debug output

## Testing
- `cargo fetch`
- `cargo fmt`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6857a33f2f788320af9c57d48ac031f0