### PR TITLE
Implement grid-based layout

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -11,18 +11,18 @@
 </head>
 <body>
   <video id="webcam" autoplay muted playsinline></video>
-  <img id="image-thumbnail" class="image-thumbnail" alt="Last sent image" style="display:none;" />
-  <div id="face" class="face" style="position:relative;width:100vw;height:100vh;overflow:hidden;">
+  <img id="image-thumbnail" class="image-thumbnail" alt="Last sent image" />
+  <div id="face" class="face">
     <div id="mien" class="mien">😐</div>
-    <div id="thought" class="thought-bubble" style="display:none;position:absolute;top:10%;left:50%;transform:translateX(-50%);">
-      <img id="thought-image" alt="Webcam thumbnail" style="display:none;" />
+    <div id="thought" class="thought-bubble">
+      <img id="thought-image" alt="Webcam thumbnail" />
       <div id="thought-tabs"></div>
     </div>
-    <div id="words" class="spoken-words" style="position:absolute;bottom:10%;left:50%;transform:translateX(-50%);"></div>
-    <audio id="audio-player" style="display:none;position:absolute;bottom:0;left:0;width:100%;"></audio>
+    <div id="words" class="spoken-words"></div>
+    <audio id="audio-player"></audio>
   </div>
-  <form id="text-form" style="position:absolute;bottom:1rem;left:50%;transform:translateX(-50%);width:80%;display:flex;gap:0.5rem;">
-    <input id="text-input" class="form-control" type="text" style="flex:1;" autofocus />
+  <form id="text-form">
+    <input id="text-input" class="form-control" type="text" autofocus />
     <button type="submit" class="btn btn-primary">Send</button>
   </form>
   <details style="position:absolute;top:1rem;left:1rem;max-height:40vh;overflow:auto;">

--- a/frontend/dist/styles.css
+++ b/frontend/dist/styles.css
@@ -13,10 +13,25 @@ body {
   color: white;
   overflow: hidden;
   font-family: var(--font-family);
+  height: 100vh;
+  margin: 0;
+  display: grid;
+  grid-template-rows: 1fr auto;
 }
 
 .face {
   color: white;
+  display: grid;
+  grid-template-rows: 1fr auto;
+  grid-template-areas:
+    'mien'
+    'words';
+  justify-items: center;
+  align-items: end;
+  width: 100vw;
+  height: 100vh;
+  position: relative;
+  overflow: hidden;
 }
 
 .face .mien {
@@ -36,6 +51,11 @@ body {
   vertical-align: middle;
   font-size: 10vw;
   line-height: 2;
+}
+
+#mien {
+  grid-area: mien;
+  place-self: center;
 }
 
 video {
@@ -63,6 +83,10 @@ video {
   overflow-wrap: anywhere;
   white-space: normal;
   margin-top: 1rem;
+  grid-area: words;
+  justify-self: center;
+  align-self: end;
+  margin-bottom: 10%;
 }
 
 .spoken-words::before {
@@ -150,7 +174,11 @@ details.updated {
 }
 
 .thought-bubble {
-  display: flex;
+  display: none;
+  position: absolute;
+  top: 10%;
+  left: 50%;
+  transform: translateX(-50%);
   align-items: center;
   justify-content: center;
   background-color: #fff;
@@ -158,7 +186,6 @@ details.updated {
   border-radius: 30px;
   margin: 20px;
   text-align: center;
-  position: relative;
 }
 
 .thought-bubble::before,
@@ -196,7 +223,12 @@ details.updated {
   max-height: 60px;
 }
 
+#thought-image {
+  display: none;
+}
+
 #image-thumbnail {
+  display: none;
   position: absolute;
   bottom: 0.5rem;
   left: 0.5rem;
@@ -231,6 +263,26 @@ details.updated {
 .form-control:focus {
   border-color: var(--bs-primary);
   box-shadow: 0 0 0 0.2rem rgba(13, 110, 253, 0.25);
+}
+
+#text-form {
+  grid-row: 2;
+  display: flex;
+  gap: 0.5rem;
+  width: 80%;
+  margin: 0 auto 1rem;
+}
+
+#text-input {
+  flex: 1;
+}
+
+#audio-player {
+  display: none;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
 }
 
 .lieve-connection {


### PR DESCRIPTION
## Summary
- rely on CSS Grid for page layout
- keep thought bubble hidden by default
- clean up inline styles in `index.html`

## Testing
- `cargo fmt`
- `cargo fetch`
- `RUST_LOG=debug cargo test --workspace`


------
https://chatgpt.com/codex/tasks/task_e_6857a57bc7d88320b0fccb403271b9e5