### PR TITLE
Show per-wit debug panels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,8 +63,8 @@ The previous Deno-based client has been removed. Update the files in
 
 * Expose WebSocket chat at `/ws`, forwarding all `Psyche` events.
 * Debug information from Wits streams via `/debug`.
-* The `EventBus` retains the last `WitReport` so new `/debug` subscribers see
-  recent output immediately.
+* The `EventBus` retains the most recent `WitReport` for each Wit so new
+  `/debug` subscribers see existing output immediately.
 * SSE endpoints like `/chat` are deprecated; use WebSocket only.
 * Text messages no longer trigger `Heard` responses.
 

--- a/pete/src/web.rs
+++ b/pete/src/web.rs
@@ -172,9 +172,11 @@ async fn handle_log_socket(mut socket: WebSocket, state: AppState) {
 
 async fn handle_wit_socket(mut socket: WebSocket, state: AppState) {
     info!("wit websocket connected");
-    if let Some(last) = state.bus.latest_wit() {
+    for last in state.bus.latest_wits() {
         let msg = serde_json::to_string(&WsResponse::Think(last)).unwrap();
-        let _ = socket.send(WsMessage::Text(msg.into())).await;
+        if socket.send(WsMessage::Text(msg.into())).await.is_err() {
+            return;
+        }
     }
     let mut rx = state.bus.subscribe_wits();
     while let Ok(report) = rx.recv().await {


### PR DESCRIPTION
## Summary
- keep the latest report for each wit in `EventBus`
- send all stored reports to new debug websocket clients
- document per-wit retention in `AGENTS.md`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6857aa7ce9148320b50cdea6817be16a