### PR TITLE
Add fade effect for conversation panel

### DIFF
--- a/frontend/dist/styles.css
+++ b/frontend/dist/styles.css
@@ -200,9 +200,24 @@ button:hover {
   border: 1px solid #333;
   padding: 0.5rem;
   color: white;
+  position: relative;
+  overflow: hidden;
+}
+
+.sidebar details::before {
+  content: "";
+  position: sticky;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2rem;
+  pointer-events: none;
+  background-image: linear-gradient(#580F41, rgba(88, 15, 65, 0));
+  z-index: 1;
 }
 
 .sidebar details summary {
+  display: block;
   padding: 0.5rem;
   background-color: #580F41; /* aubergine */
   color: #fff;


### PR DESCRIPTION
## Summary
- hide details content behind sticky summary
- fade conversation log as it scrolls under the heading

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_6857b86bb95c8320b0cbd27914e82681