### PR TITLE
Improve thought bubble style

### DIFF
--- a/frontend/dist/styles.css
+++ b/frontend/dist/styles.css
@@ -77,6 +77,29 @@ main {
   align-items: center;
   max-width: 80%;
   z-index: 1;
+  position: relative;
+}
+
+#thought::before,
+#thought::after {
+  content: "";
+  position: absolute;
+  background-color: #fff;
+  border-radius: 50%;
+}
+
+#thought::before {
+  width: 1rem;
+  height: 1rem;
+  bottom: -0.6rem;
+  left: 1.5rem;
+}
+
+#thought::after {
+  width: 0.6rem;
+  height: 0.6rem;
+  bottom: -1.3rem;
+  left: 0.5rem;
 }
 
 #thought-image {


### PR DESCRIPTION
## Summary
- style the thought bubble with small trailing circles so it's clearly internal dialogue

## Testing
- `cargo test --no-run`
- `RUST_LOG=debug cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68581cb174808320878440b74bb7d9e2