### PR TITLE
Fix HeartWit debug and log all Wit ticks

### DIFF
--- a/pete/src/psyche_factory.rs
+++ b/pete/src/psyche_factory.rs
@@ -124,9 +124,10 @@ pub fn ollama_psyche(
         memory.clone(),
         wit_tx.clone(),
     )));
-    psyche.register_typed_wit(Arc::new(HeartWit::new(
+    psyche.register_typed_wit(Arc::new(HeartWit::with_debug(
         Box::new(OllamaProvider::new(wits_host, wits_model)?),
         Arc::new(LoggingMotor),
+        wit_tx.clone(),
     )));
     psyche.register_typed_wit(Arc::new(FondDuCoeurWit::new(FondDuCoeur::with_debug(
         Box::new(OllamaProvider::new(wits_host, wits_model)?),

--- a/psyche/src/psyche.rs
+++ b/psyche/src/psyche.rs
@@ -537,7 +537,9 @@ impl Psyche {
             tokio::spawn(async move {
                 loop {
                     let name = wit.name();
+                    debug!(%name, "tick start");
                     let imps = wit.tick_erased().await;
+                    debug!(%name, count = imps.len(), "tick finished");
                     let now = Utc::now();
                     {
                         let mut map = ticks.lock().await;


### PR DESCRIPTION
## Summary
- emit `WitReport`s from `HeartWit`
- expose `HeartWit::with_debug` and use it in the Ollama psyche factory
- log the start and end of each Wit tick for easier diagnosis

## Testing
- `cargo test -q`

------
https://chatgpt.com/codex/tasks/task_e_68581c46bfcc83209e3256a536733d30