### PR TITLE
Rename FondDuCoeurWit to IdentityWit

### DIFF
--- a/pete/src/psyche_factory.rs
+++ b/pete/src/psyche_factory.rs
@@ -76,8 +76,8 @@ pub fn ollama_psyche(
     use crate::LoggingMotor;
     use psyche::ling::OllamaProvider;
     use psyche::wits::{
-        BasicMemory, Combobulator, CombobulatorWit, FondDuCoeur, FondDuCoeurWit, HeartWit,
-        MemoryWit, Neo4jClient, QdrantClient, WillWit,
+        BasicMemory, Combobulator, CombobulatorWit, FondDuCoeur, HeartWit, IdentityWit, MemoryWit,
+        Neo4jClient, QdrantClient, WillWit,
     };
 
     let narrator = OllamaProvider::new(chatter_host, chatter_model)?;
@@ -129,7 +129,7 @@ pub fn ollama_psyche(
         Arc::new(LoggingMotor),
         wit_tx.clone(),
     )));
-    psyche.register_typed_wit(Arc::new(FondDuCoeurWit::new(FondDuCoeur::with_debug(
+    psyche.register_typed_wit(Arc::new(IdentityWit::new(FondDuCoeur::with_debug(
         Box::new(OllamaProvider::new(wits_host, wits_model)?),
         wit_tx.clone(),
     ))));

--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -26,8 +26,8 @@ pub mod wits {
     pub mod episode_wit;
     pub mod face_memory_wit;
     pub mod fond_du_coeur;
-    pub mod fond_du_coeur_wit;
     pub mod heart_wit;
+    pub mod identity_wit;
     pub mod instant_wit;
     pub mod memory;
     pub mod memory_wit;
@@ -43,8 +43,8 @@ pub mod wits {
     pub use episode_wit::EpisodeWit;
     pub use face_memory_wit::FaceMemoryWit;
     pub use fond_du_coeur::FondDuCoeur;
-    pub use fond_du_coeur_wit::FondDuCoeurWit;
     pub use heart_wit::HeartWit;
+    pub use identity_wit::IdentityWit;
     pub use instant_wit::InstantWit;
     pub use memory::{BasicMemory, GraphStore, Memory, Neo4jClient, NoopMemory, QdrantClient};
     pub use memory_wit::MemoryWit;
@@ -98,7 +98,7 @@ pub use sensors::{DummyDetector, FaceDetector, FaceInfo, FaceSensor};
 pub use traits::{Ear, ErasedWit, Mouth, SensationObserver, Summarizer, Wit, WitAdapter};
 pub use voice::{Voice, extract_emojis};
 pub use wits::{
-    BasicMemory, CombobulatorWit, EntityWit, EpisodeWit, FaceMemoryWit, FondDuCoeur,
-    FondDuCoeurWit, GraphStore, HeartWit, Memory, MemoryWit, Neo4jClient, NoopMemory, QdrantClient,
-    VisionWit, Will, WillWit,
+    BasicMemory, CombobulatorWit, EntityWit, EpisodeWit, FaceMemoryWit, FondDuCoeur, GraphStore,
+    HeartWit, IdentityWit, Memory, MemoryWit, Neo4jClient, NoopMemory, QdrantClient, VisionWit,
+    Will, WillWit,
 };

--- a/psyche/src/wits/identity_wit.rs
+++ b/psyche/src/wits/identity_wit.rs
@@ -7,15 +7,15 @@ use async_trait::async_trait;
 use std::sync::Mutex;
 
 /// Wit that produces a single-paragraph life story from recent moments.
-pub struct FondDuCoeurWit {
+pub struct IdentityWit {
     summarizer: FondDuCoeur,
     buffer: Mutex<Vec<Impression<Moment>>>,
 }
 
-impl FondDuCoeurWit {
+impl IdentityWit {
     /// Debug label for this Wit.
-    pub const LABEL: &'static str = "FondDuCoeurWit";
-    /// Create a new `FondDuCoeurWit` using the given summarizer.
+    pub const LABEL: &'static str = "IdentityWit";
+    /// Create a new `IdentityWit` using the given summarizer.
     pub fn new(summarizer: FondDuCoeur) -> Self {
         Self {
             summarizer,
@@ -25,7 +25,7 @@ impl FondDuCoeurWit {
 }
 
 #[async_trait]
-impl Wit<Impression<Moment>, String> for FondDuCoeurWit {
+impl Wit<Impression<Moment>, String> for IdentityWit {
     async fn observe(&self, input: Impression<Moment>) {
         self.buffer.lock().unwrap().push(input);
     }

--- a/psyche/tests/identity_wit.rs
+++ b/psyche/tests/identity_wit.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use psyche::ling::{Doer, Instruction};
 use psyche::wit::{Moment, Wit};
-use psyche::wits::{FondDuCoeur, FondDuCoeurWit};
+use psyche::wits::{FondDuCoeur, IdentityWit};
 use psyche::{Impression, Stimulus};
 use tokio::sync::broadcast;
 
@@ -20,7 +20,7 @@ async fn summarizes_moments_into_story() {
     let (tx, mut rx) = broadcast::channel(8);
     psyche::enable_debug("Story").await;
     let summarizer = FondDuCoeur::with_debug(Box::new(Dummy), tx);
-    let wit = FondDuCoeurWit::new(summarizer.clone());
+    let wit = IdentityWit::new(summarizer.clone());
     wit.observe(Impression::new(
         vec![Stimulus::new(Moment {
             summary: "Pete woke".into(),


### PR DESCRIPTION
## Summary
- rename `FondDuCoeurWit` to `IdentityWit`
- update imports and registration
- adjust tests for new name

## Testing
- `cargo fetch`
- `cargo fmt`
- `RUST_LOG=debug cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68581f71a8e48320be9b591c088efa11