### PR TITLE
Improve thought bubble style

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ The previous Deno-based client has been removed. Update the files in
 * After playing speech audio, send an `Echo` message with the spoken text so the conversation log records assistant dialogue.
 * Define CSS variables in `styles.css` to control colors and fonts.
 * Keep the thought bubble hidden until there is text to display.
+* Style the thought bubble with cloud-like lobes and center-bottom connectors.
 * Serve over HTTPS by passing `--tls-cert` and `--tls-key` to the `pete` binary.
 * Canvas elements that repeatedly call `getImageData` must obtain their context
   with `{ willReadFrequently: true }`.

--- a/frontend/dist/styles.css
+++ b/frontend/dist/styles.css
@@ -71,7 +71,12 @@ main {
   color: #000;
   padding: 1rem;
   border-radius: 2rem;
-  box-shadow: 0 0 1rem rgba(0, 0, 0, 0.2);
+  box-shadow:
+    -1rem -1rem 0 -0.5rem #fff,
+    1rem -1rem 0 -0.5rem #fff,
+    -1rem 1rem 0 -0.5rem #fff,
+    1rem 1rem 0 -0.5rem #fff,
+    0 0 1rem rgba(0, 0, 0, 0.2);
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -85,20 +90,20 @@ main {
   position: absolute;
   background-color: #fff;
   border-radius: 50%;
+  left: 50%;
+  transform: translateX(-50%);
 }
 
 #thought::before {
   width: 1rem;
   height: 1rem;
   bottom: -0.6rem;
-  left: 1.5rem;
 }
 
 #thought::after {
   width: 0.6rem;
   height: 0.6rem;
   bottom: -1.3rem;
-  left: 0.5rem;
 }
 
 #thought-image {


### PR DESCRIPTION
## Summary
- make the thought bubble look like a cloud
- center the connector circles below the bubble
- document the style requirement in AGENTS

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68582192fee48320848e22765efed0d5