### PR TITLE
Fix voice buffering logic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,8 @@ The previous Deno-based client has been removed. Update the files in
   downcasts.
 * Use `#[tokio::test(start_paused = true)]` and `tokio::time::advance` for
   timeout-related tests to avoid slow sleeps.
+* Deduplicate buffering logic when handling voice sensations to prevent
+  duplicate entries.
 
 This document reflects the current cognitive and runtime architecture of Pete Daringsby. Keep it consistent with the latest design discussions and behavior changes.
 

--- a/psyche/src/psyche.rs
+++ b/psyche/src/psyche.rs
@@ -422,23 +422,18 @@ impl Psyche {
                     Sensation::HeardOwnVoice(msg) => {
                         let mut conv = self.conversation.lock().await;
                         conv.add_assistant(msg.clone());
+                        self.buffer_self_speech(msg).await;
                     }
                     Sensation::HeardUserVoice(msg) => {
                         let mut conv = self.conversation.lock().await;
                         conv.add_user(msg.clone());
-                    }
-                    Sensation::Of(_) => {}
-                }
-                self.notify_observers(arc.as_ref()).await;
-                match &*arc {
-                    Sensation::HeardOwnVoice(msg) => {
-                        self.buffer_self_speech(msg).await;
-                    }
-                    Sensation::HeardUserVoice(msg) => {
                         self.buffer_user_speech(msg).await;
                     }
-                    Sensation::Of(_) => self.sensation_buffer.lock().await.push_back(arc.clone()),
+                    Sensation::Of(_) => {
+                        self.sensation_buffer.lock().await.push_back(arc.clone());
+                    }
                 }
+                self.notify_observers(arc.as_ref()).await;
             }
             if self.speak_when_spoken_to && !self.pending_user_message {
                 match self.input_rx.recv().await {


### PR DESCRIPTION
## Summary
- simplify buffering logic for HeardOwnVoice and HeardUserVoice
- note voice buffering rule in AGENTS guidelines

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685824a1b62c8320ac95d4510c3b784c