### PR TITLE
Refactor Wit spawn loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,8 @@ The previous Deno-based client has been removed. Update the files in
   timeout-related tests to avoid slow sleeps.
 * Deduplicate buffering logic when handling voice sensations to prevent
   duplicate entries.
+* Extract repeated asynchronous loops into helper functions to reduce
+  duplication.
 
 This document reflects the current cognitive and runtime architecture of Pete Daringsby. Keep it consistent with the latest design discussions and behavior changes.
 


### PR DESCRIPTION
## Summary
- add `wit_loop` helper to `Psyche` for repeated tick logic
- update guide to remind about extracting async helpers

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685827358aa08320bd220f47c1d42aa5