### PR TITLE
Handle panicking wits

### DIFF
--- a/psyche/src/psyche.rs
+++ b/psyche/src/psyche.rs
@@ -18,8 +18,10 @@ const DEFAULT_EXPERIENCE_TICK: Duration = Duration::from_secs(60);
 #[cfg(test)]
 const DEFAULT_EXPERIENCE_TICK: Duration = Duration::from_millis(10);
 use chrono::{DateTime, Utc};
+use futures::FutureExt;
 use quick_xml::{Reader, events::Event as XmlEvent};
 use std::any::Any;
+use std::panic::AssertUnwindSafe;
 use tokio::sync::{Mutex, broadcast, mpsc};
 use tracing::{debug, error, info};
 
@@ -573,20 +575,29 @@ impl Psyche {
         let ling = self.ling.clone();
         let pending = self.pending_turn.clone();
 
+        let mut wit_handles = Vec::new();
         for wit in &self.wits {
             let wit = wit.clone();
             let ticks = ticks.clone();
             let mem = memory.clone();
             let ling = ling.clone();
             let pending_turn = pending.clone();
-            tokio::spawn(Self::wit_loop(
+            let name = wit.name().to_string();
+            let fut = AssertUnwindSafe(Self::wit_loop(
                 wit,
                 ticks,
                 mem,
                 ling,
                 pending_turn,
                 self.experience_tick,
-            ));
+            ))
+            .catch_unwind()
+            .map(move |res| {
+                if let Err(e) = res {
+                    error!(%name, ?e, "wit loop panicked");
+                }
+            });
+            wit_handles.push(tokio::spawn(fut));
         }
 
         let experience_handle =
@@ -595,6 +606,12 @@ impl Psyche {
         let psyche = converse_handle.await.expect("converse task panicked");
         experience_handle.abort();
         let _ = experience_handle.await;
+        for h in &wit_handles {
+            h.abort();
+        }
+        for h in wit_handles {
+            let _ = h.await;
+        }
         info!("psyche run finished");
         psyche
     }

--- a/psyche/tests/wit_panic.rs
+++ b/psyche/tests/wit_panic.rs
@@ -1,0 +1,78 @@
+use async_trait::async_trait;
+use psyche::ling::{Chatter, Doer, Instruction, Message, Vectorizer};
+use psyche::{Ear, Impression, Mouth, Psyche, Wit};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio_stream::once;
+
+#[derive(Clone, Default)]
+struct Dummy;
+
+#[async_trait]
+impl Mouth for Dummy {
+    async fn speak(&self, _t: &str) {}
+    async fn interrupt(&self) {}
+    fn speaking(&self) -> bool {
+        false
+    }
+}
+
+#[async_trait]
+impl Ear for Dummy {
+    async fn hear_self_say(&self, _t: &str) {}
+    async fn hear_user_say(&self, _t: &str) {}
+}
+
+#[async_trait]
+impl Chatter for Dummy {
+    async fn chat(&self, _s: &str, _h: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+        Ok(Box::pin(once(Ok("ok".into()))))
+    }
+    async fn update_prompt_context(&self, _c: &str) {}
+}
+
+#[async_trait]
+impl Doer for Dummy {
+    async fn follow(&self, _i: Instruction) -> anyhow::Result<String> {
+        Ok("ok".into())
+    }
+}
+
+#[async_trait]
+impl Vectorizer for Dummy {
+    async fn vectorize(&self, _t: &str) -> anyhow::Result<Vec<f32>> {
+        Ok(vec![0.0])
+    }
+}
+
+struct PanickyWit;
+
+#[async_trait]
+impl Wit<(), ()> for PanickyWit {
+    async fn observe(&self, _: ()) {}
+    async fn tick(&self) -> Vec<Impression<()>> {
+        panic!("boom");
+    }
+}
+
+#[tokio::test]
+async fn panicky_wit_does_not_crash_run() {
+    let mouth = Arc::new(Dummy::default());
+    let ear = mouth.clone();
+    let mut psyche = Psyche::new(
+        Box::new(Dummy::default()),
+        Box::new(Dummy::default()),
+        Box::new(Dummy::default()),
+        Arc::new(psyche::NoopMemory),
+        mouth,
+        ear,
+    );
+    psyche.set_turn_limit(3);
+    psyche.set_speak_when_spoken_to(true);
+    psyche.register_typed_wit(Arc::new(PanickyWit));
+    let handle = tokio::spawn(async move { psyche.run().await });
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert!(!handle.is_finished());
+    handle.abort();
+    let _ = handle.await;
+}


### PR DESCRIPTION
## Summary
- log and clean up if a Wit panics during `run`
- test that a panicking Wit does not crash the runtime

## Testing
- `cargo fmt`
- `cargo fetch`
- `RUST_LOG=debug cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68582ac0bd888320847b9a983d224870