### PR TITLE
Make channel capacities configurable

### DIFF
--- a/pete/src/event_bus.rs
+++ b/pete/src/event_bus.rs
@@ -14,13 +14,32 @@ pub struct EventBus {
 }
 
 impl EventBus {
-    /// Create a new `EventBus` wrapping existing channels.
+    /// Default broadcast capacity for event and wit channels.
+    pub const DEFAULT_EVENT_CAPACITY: usize = 16;
+    /// Default broadcast capacity for log messages.
+    pub const DEFAULT_LOG_CAPACITY: usize = 100;
+
+    /// Create a new `EventBus` wrapping existing channels using default
+    /// capacities.
     ///
     /// Returns the bus and a receiver for user input.
     pub fn new() -> (Self, mpsc::UnboundedReceiver<String>) {
-        let (events, _) = broadcast::channel(16);
-        let (logs, _) = broadcast::channel(100);
-        let (wits, _) = broadcast::channel(16);
+        Self::with_capacities(
+            Self::DEFAULT_EVENT_CAPACITY,
+            Self::DEFAULT_LOG_CAPACITY,
+            Self::DEFAULT_EVENT_CAPACITY,
+        )
+    }
+
+    /// Create a bus using custom broadcast channel capacities.
+    pub fn with_capacities(
+        event_capacity: usize,
+        log_capacity: usize,
+        wit_capacity: usize,
+    ) -> (Self, mpsc::UnboundedReceiver<String>) {
+        let (events, _) = broadcast::channel(event_capacity);
+        let (logs, _) = broadcast::channel(log_capacity);
+        let (wits, _) = broadcast::channel(wit_capacity);
         let (input, rx) = mpsc::unbounded_channel();
         let latest_wits = Arc::new(Mutex::new(HashMap::new()));
         (

--- a/pete/tests/event_bus_capacity.rs
+++ b/pete/tests/event_bus_capacity.rs
@@ -1,0 +1,12 @@
+use pete::EventBus;
+
+#[test]
+fn custom_capacities() {
+    let custom = 8;
+    let (bus, _rx) = EventBus::with_capacities(custom, custom * 2, custom);
+    bus.publish_event(psyche::Event::EmotionChanged("🙂".into()));
+    bus.log("ok");
+    // Custom constructor should operate like the default without panicking
+    let _ = bus.subscribe_events();
+    let _ = bus.subscribe_logs();
+}

--- a/psyche/src/psyche.rs
+++ b/psyche/src/psyche.rs
@@ -17,6 +17,8 @@ pub const DEFAULT_SYSTEM_PROMPT: &str = "You are PETE — an experimental, auton
 const DEFAULT_EXPERIENCE_TICK: Duration = Duration::from_secs(60);
 #[cfg(test)]
 const DEFAULT_EXPERIENCE_TICK: Duration = Duration::from_millis(10);
+/// Default size for internal broadcast channels.
+pub const DEFAULT_CHANNEL_CAPACITY: usize = 16;
 use chrono::{DateTime, Utc};
 use quick_xml::{Reader, events::Event as XmlEvent};
 use std::any::Any;
@@ -154,8 +156,29 @@ impl Psyche {
         mouth: Arc<dyn Mouth>,
         ear: Arc<dyn Ear>,
     ) -> Self {
-        let (events_tx, _r) = broadcast::channel(16);
-        let (wit_tx, _r2) = broadcast::channel(16);
+        Self::with_channel_capacity(
+            narrator,
+            voice,
+            vectorizer,
+            memory,
+            mouth,
+            ear,
+            DEFAULT_CHANNEL_CAPACITY,
+        )
+    }
+
+    /// Construct a [`Psyche`] with custom broadcast channel capacity.
+    pub fn with_channel_capacity(
+        narrator: Box<dyn Doer>,
+        voice: Box<dyn Chatter>,
+        vectorizer: Box<dyn Vectorizer>,
+        memory: Arc<dyn Memory>,
+        mouth: Arc<dyn Mouth>,
+        ear: Arc<dyn Ear>,
+        capacity: usize,
+    ) -> Self {
+        let (events_tx, _r) = broadcast::channel(capacity);
+        let (wit_tx, _r2) = broadcast::channel(capacity);
         let (input_tx, input_rx) = mpsc::unbounded_channel();
         let voice = crate::voice::Voice::new(Arc::from(voice), mouth, events_tx.clone());
         let conversation = Arc::new(Mutex::new(Conversation::default()));
@@ -191,7 +214,7 @@ impl Psyche {
             sensation_buffer: Arc::new(Mutex::new(VecDeque::<Arc<Sensation>>::new())),
             last_ticks: Arc::new(Mutex::new(HashMap::new())),
             pending_turn,
-            topic_bus: crate::topics::TopicBus::new(16),
+            topic_bus: crate::topics::TopicBus::new(capacity),
         }
     }
 

--- a/psyche/tests/channel_capacity.rs
+++ b/psyche/tests/channel_capacity.rs
@@ -1,0 +1,73 @@
+use async_trait::async_trait;
+use psyche::ling::{Chatter, Doer, Instruction, Message, Vectorizer};
+use psyche::wits::memory::Memory;
+use psyche::{Ear, Mouth, Psyche};
+use serde_json::Value;
+use std::sync::Arc;
+use tokio_stream::once;
+
+#[derive(Clone, Default)]
+struct Dummy;
+
+#[async_trait]
+impl Mouth for Dummy {
+    async fn speak(&self, _t: &str) {}
+    async fn interrupt(&self) {}
+    fn speaking(&self) -> bool {
+        false
+    }
+}
+
+#[async_trait]
+impl Ear for Dummy {
+    async fn hear_self_say(&self, _t: &str) {}
+    async fn hear_user_say(&self, _t: &str) {}
+}
+
+#[async_trait]
+impl Chatter for Dummy {
+    async fn chat(&self, _s: &str, _h: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+        Ok(Box::pin(once(Ok("ok".into()))))
+    }
+    async fn update_prompt_context(&self, _c: &str) {}
+}
+
+#[async_trait]
+impl Doer for Dummy {
+    async fn follow(&self, _i: Instruction) -> anyhow::Result<String> {
+        Ok("ok".into())
+    }
+}
+
+#[async_trait]
+impl Vectorizer for Dummy {
+    async fn vectorize(&self, _t: &str) -> anyhow::Result<Vec<f32>> {
+        Ok(vec![0.0])
+    }
+}
+
+#[async_trait]
+impl Memory for Dummy {
+    async fn store(&self, _i: &psyche::Impression<serde_json::Value>) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn custom_channel_capacity() {
+    let capacity = 32;
+    let psyche = Psyche::with_channel_capacity(
+        Box::new(Dummy),
+        Box::new(Dummy),
+        Box::new(Dummy),
+        Arc::new(Dummy),
+        Arc::new(Dummy),
+        Arc::new(Dummy),
+        capacity,
+    );
+    // Custom channel capacity constructor should behave like default
+    let _ = psyche
+        .event_sender()
+        .send(psyche::Event::EmotionChanged("🙂".into()));
+    let _ = psyche.wit_sender();
+}


### PR DESCRIPTION
## Summary
- add capacity constants and `with_capacities` constructor for `EventBus`
- add `DEFAULT_CHANNEL_CAPACITY` constant and `with_channel_capacity` constructor in `Psyche`
- test custom constructors compile
- exercise new constructors in unit tests

## Testing
- `cargo fmt`
- `RUST_LOG=debug cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68582b03246c8320b424d1890f7f02eb