### PR TITLE
Improve pending_turn concurrency

### DIFF
--- a/psyche/Cargo.toml
+++ b/psyche/Cargo.toml
@@ -21,6 +21,7 @@ unicode-segmentation = "1"
 emojis = "0.6"
 pulldown-cmark = "0.9"
 quick-xml = "0.31"
+crossbeam-utils = "0.8"
 once_cell = "1"
 image = { version = "0.24", default-features = false, features = ["png", "jpeg"] }
 base64 = "0.21"

--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -73,6 +73,7 @@ pub mod sensors {
     #[cfg(feature = "face")]
     pub use face::{DummyDetector, FaceDetector, FaceInfo, FaceSensor};
 }
+mod pending_turn;
 mod trim_mouth;
 mod types;
 
@@ -81,6 +82,7 @@ pub use debug::{DebugHandle, DebugInfo, debug_enabled, disable_debug, enable_deb
 pub use instruction::{Instruction, parse_instructions};
 pub use model::{Experience, Impression, Stimulus};
 pub use motor::{Motor, NoopMotor};
+pub use pending_turn::PendingTurn;
 pub use plain_mouth::PlainMouth;
 pub use prehension::Prehension;
 pub use prompt::{CombobulatorPrompt, ContextualPrompt, PromptBuilder, VoicePrompt, WillPrompt};

--- a/psyche/src/pending_turn.rs
+++ b/psyche/src/pending_turn.rs
@@ -1,0 +1,41 @@
+//! Lightweight atomic buffer for a pending user turn.
+//!
+//! `PendingTurn` avoids mutex contention by using an [`AtomicCell`]
+//! to store an optional prompt string. It provides simple `set` and
+//! `take` operations for producers and consumers.
+//!
+//! ```
+//! use psyche::PendingTurn;
+//! let buf = PendingTurn::new();
+//! buf.set("hi".to_string());
+//! assert_eq!(buf.take(), Some("hi".to_string()));
+//! assert_eq!(buf.take(), None);
+//! ```
+//!
+//! The cell is lock-free on supported platforms and falls back to a
+//! global lock otherwise.
+
+use crossbeam_utils::atomic::AtomicCell;
+
+/// Atomically shared pending turn buffer.
+#[derive(Default)]
+pub struct PendingTurn {
+    inner: AtomicCell<Option<String>>,
+}
+
+impl PendingTurn {
+    /// Create an empty buffer.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Store `prompt` for later retrieval, replacing any existing value.
+    pub fn set(&self, prompt: String) {
+        self.inner.store(Some(prompt));
+    }
+
+    /// Take the pending prompt if present.
+    pub fn take(&self) -> Option<String> {
+        self.inner.take()
+    }
+}

--- a/psyche/src/psyche.rs
+++ b/psyche/src/psyche.rs
@@ -17,6 +17,7 @@ pub const DEFAULT_SYSTEM_PROMPT: &str = "You are PETE — an experimental, auton
 const DEFAULT_EXPERIENCE_TICK: Duration = Duration::from_secs(60);
 #[cfg(test)]
 const DEFAULT_EXPERIENCE_TICK: Duration = Duration::from_millis(10);
+use crate::pending_turn::PendingTurn;
 use chrono::{DateTime, Utc};
 use futures::FutureExt;
 use quick_xml::{Reader, events::Event as XmlEvent};
@@ -100,7 +101,7 @@ pub struct Psyche {
     observers: Vec<Arc<dyn crate::traits::observer::SensationObserver + Send + Sync>>,
     sensation_buffer: Arc<Mutex<VecDeque<Arc<Sensation>>>>,
     last_ticks: Arc<Mutex<HashMap<String, DateTime<Utc>>>>,
-    pending_turn: Arc<Mutex<Option<String>>>,
+    pending_turn: Arc<PendingTurn>,
     topic_bus: crate::topics::TopicBus,
 }
 
@@ -165,7 +166,7 @@ impl Psyche {
             DEFAULT_SYSTEM_PROMPT,
             conversation.clone(),
         )));
-        let pending_turn = Arc::new(Mutex::new(None));
+        let pending_turn = Arc::new(PendingTurn::default());
         Self {
             narrator,
             voice: Arc::new(voice),
@@ -492,7 +493,7 @@ impl Psyche {
                 }
             }
 
-            if let Some(extra) = self.pending_turn.lock().await.take() {
+            if let Some(extra) = self.pending_turn.take() {
                 let history = {
                     self.ling
                         .lock()
@@ -547,7 +548,7 @@ impl Psyche {
         ticks: Arc<Mutex<HashMap<String, DateTime<Utc>>>>,
         mem: Arc<dyn Memory>,
         ling: Arc<Mutex<crate::Ling>>,
-        pending_turn: Arc<Mutex<Option<String>>>,
+        pending_turn: Arc<PendingTurn>,
         tick: Duration,
     ) {
         loop {
@@ -564,7 +565,7 @@ impl Psyche {
                 for stim in &imp.stimuli {
                     if let serde_json::Value::String(s) = &stim.what {
                         if let Some(p) = extract_tag(s, "take_turn") {
-                            *pending_turn.lock().await = Some(p);
+                            pending_turn.set(p);
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- introduce `PendingTurn` using `AtomicCell` to avoid lock contention
- expose new type in public API
- refactor `Psyche` to use `PendingTurn`
- document usage with doctest
- add `crossbeam-utils` dependency

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68582ceb9ea08320b9f301bbb810fad1