### PR TITLE
Apply concurrency fixes and add jitter

### DIFF
--- a/pete/src/ear.rs
+++ b/pete/src/ear.rs
@@ -16,7 +16,7 @@ use tracing::{debug, info};
 /// [`Ear`] implementation that forwards heard text through a channel.
 #[derive(Clone)]
 pub struct ChannelEar {
-    forward: mpsc::UnboundedSender<Sensation>,
+    forward: mpsc::Sender<Sensation>,
     speaking: Arc<AtomicBool>,
     voice: Arc<Voice>,
 }
@@ -25,7 +25,7 @@ pub struct ChannelEar {
 impl ChannelEar {
     /// Create a new `ChannelEar` wired to the given channels.
     pub fn new(
-        forward: mpsc::UnboundedSender<Sensation>,
+        forward: mpsc::Sender<Sensation>,
         speaking: Arc<AtomicBool>,
         voice: Arc<Voice>,
     ) -> Self {
@@ -50,7 +50,8 @@ impl Ear for ChannelEar {
         self.voice.permit(None);
         let _ = self
             .forward
-            .send(Sensation::HeardOwnVoice(text.to_string()));
+            .send(Sensation::HeardOwnVoice(text.to_string()))
+            .await;
     }
 
     async fn hear_user_say(&self, text: &str) {
@@ -58,7 +59,8 @@ impl Ear for ChannelEar {
         debug!("ear heard user say: {}", text);
         let _ = self
             .forward
-            .send(Sensation::HeardUserVoice(text.to_string()));
+            .send(Sensation::HeardUserVoice(text.to_string()))
+            .await;
     }
 }
 

--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -153,7 +153,7 @@ async fn main() -> anyhow::Result<()> {
     #[cfg(not(feature = "ear"))]
     let ear: Arc<dyn Ear> = Arc::new(NoopEar) as Arc<dyn Ear>;
     #[cfg(feature = "eye")]
-    let (eye_tx, mut eye_rx) = mpsc::unbounded_channel();
+    let (eye_tx, mut eye_rx) = mpsc::channel(16);
     #[cfg(feature = "eye")]
     let eye: Arc<dyn Sensor<ImageData>> = {
         let sensor = Arc::new(EyeSensor::new(eye_tx)) as Arc<dyn Sensor<ImageData>>;
@@ -184,7 +184,7 @@ async fn main() -> anyhow::Result<()> {
                         face_clone.sense(img.clone()).await;
                     }
                 }
-                let _ = forward.send(s);
+                let _ = forward.send(s).await;
             }
         });
     }

--- a/pete/src/sensor/eye.rs
+++ b/pete/src/sensor/eye.rs
@@ -7,13 +7,13 @@ use tracing::{debug, info};
 /// Sensor that forwards webcam images to the psyche.
 #[derive(Clone)]
 pub struct EyeSensor {
-    forward: mpsc::UnboundedSender<Sensation>,
+    forward: mpsc::Sender<Sensation>,
     latest: Option<Arc<Mutex<Option<ImageData>>>>,
 }
 
 impl EyeSensor {
     /// Create a new `EyeSensor` using the provided channel.
-    pub fn new(forward: mpsc::UnboundedSender<Sensation>) -> Self {
+    pub fn new(forward: mpsc::Sender<Sensation>) -> Self {
         Self {
             forward,
             latest: None,
@@ -22,7 +22,7 @@ impl EyeSensor {
 
     /// Create a new `EyeSensor` that also writes the latest image to `latest`.
     pub fn with_latest(
-        forward: mpsc::UnboundedSender<Sensation>,
+        forward: mpsc::Sender<Sensation>,
         latest: Arc<Mutex<Option<ImageData>>>,
     ) -> Self {
         Self {
@@ -40,7 +40,7 @@ impl Sensor<ImageData> for EyeSensor {
         if let Some(buf) = &self.latest {
             *buf.lock().unwrap() = Some(image.clone());
         }
-        let _ = self.forward.send(Sensation::Of(Box::new(image)));
+        let _ = self.forward.send(Sensation::Of(Box::new(image))).await;
     }
 
     fn describe(&self) -> &'static str {

--- a/pete/src/sensor/geo.rs
+++ b/pete/src/sensor/geo.rs
@@ -6,12 +6,12 @@ use tracing::{debug, info};
 /// Sensor forwarding geolocation updates to the psyche.
 #[derive(Clone)]
 pub struct GeoSensor {
-    forward: mpsc::UnboundedSender<Sensation>,
+    forward: mpsc::Sender<Sensation>,
 }
 
 impl GeoSensor {
     /// Create a new `GeoSensor` using the provided channel.
-    pub fn new(forward: mpsc::UnboundedSender<Sensation>) -> Self {
+    pub fn new(forward: mpsc::Sender<Sensation>) -> Self {
         Self { forward }
     }
 }
@@ -21,7 +21,7 @@ impl Sensor<GeoLoc> for GeoSensor {
     async fn sense(&self, loc: GeoLoc) {
         info!("geo sensor received location");
         debug!("geo sensor received location");
-        let _ = self.forward.send(Sensation::Of(Box::new(loc)));
+        let _ = self.forward.send(Sensation::Of(Box::new(loc))).await;
     }
 
     fn describe(&self) -> &'static str {

--- a/pete/src/sensor/heartbeat.rs
+++ b/pete/src/sensor/heartbeat.rs
@@ -12,18 +12,18 @@ pub struct HeartbeatSensor;
 
 impl HeartbeatSensor {
     /// Spawn a new heartbeat loop forwarding sensations through `forward`.
-    pub fn new(forward: mpsc::UnboundedSender<Sensation>) -> Self {
+    pub fn new(forward: mpsc::Sender<Sensation>) -> Self {
         Self::spawn(forward, Duration::from_secs(55), 10);
         Self
     }
 
     #[cfg(test)]
-    pub fn test_interval(forward: mpsc::UnboundedSender<Sensation>, secs: u64) -> Self {
+    pub fn test_interval(forward: mpsc::Sender<Sensation>, secs: u64) -> Self {
         Self::spawn(forward, Duration::from_secs(secs), 0);
         Self
     }
 
-    fn spawn(forward: mpsc::UnboundedSender<Sensation>, base: Duration, range: u64) {
+    fn spawn(forward: mpsc::Sender<Sensation>, base: Duration, range: u64) {
         tokio::spawn(async move {
             loop {
                 let secs = rand::thread_rng().gen_range(0..=range);
@@ -33,7 +33,7 @@ impl HeartbeatSensor {
                     timestamp: Utc::now(),
                 };
                 info!("heartbeat");
-                let _ = forward.send(Sensation::Of(Box::new(beat)));
+                let _ = forward.send(Sensation::Of(Box::new(beat))).await;
             }
         });
     }

--- a/pete/tests/wits_loop.rs
+++ b/pete/tests/wits_loop.rs
@@ -15,6 +15,7 @@ async fn vision_wit_receives_images() {
         mime: "image/png".into(),
         base64: "zzz".into(),
     })))
+    .await
     .unwrap();
 
     let mut got = false;

--- a/pete/tests/ws_geolocate.rs
+++ b/pete/tests/ws_geolocate.rs
@@ -18,7 +18,7 @@ async fn websocket_forwards_geolocation() {
         psyche.voice(),
     ));
     // capture sensations sent by geo sensor
-    let (tx, mut rx) = mpsc::unbounded_channel();
+    let (tx, mut rx) = mpsc::channel(16);
     let eye = Arc::new(EyeSensor::new(psyche.input_sender()));
     let geo = Arc::new(GeoSensor::new(tx));
     psyche.add_sense(eye.description());

--- a/psyche/Cargo.toml
+++ b/psyche/Cargo.toml
@@ -25,6 +25,7 @@ crossbeam-utils = "0.8"
 once_cell = "1"
 image = { version = "0.24", default-features = false, features = ["png", "jpeg"] }
 base64 = "0.21"
+rand = "0.8"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/psyche/tests/voice_control.rs
+++ b/psyche/tests/voice_control.rs
@@ -94,7 +94,10 @@ async fn no_speech_without_command() {
     psyche.set_turn_limit(1);
     let input = psyche.input_sender();
     let handle = tokio::spawn(async move { psyche.run().await });
-    input.send(Sensation::HeardUserVoice("hi".into())).unwrap();
+    input
+        .send(Sensation::HeardUserVoice("hi".into()))
+        .await
+        .unwrap();
     tokio::time::sleep(Duration::from_millis(50)).await;
     handle.abort();
     let _ = handle.await;


### PR DESCRIPTION
## Summary
- use `mpsc::channel` for bounded input queues
- guard `Psyche::is_speaking` with `AtomicBool`
- log and fall back when tag extraction fails
- jitter background loops and handle input via `Sender`
- update sensors and tests for bounded channels

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68583365d5e4832098496ff8d47bf655