### PR TITLE
Refactor voice concurrency

### DIFF
--- a/psyche/src/psyche.rs
+++ b/psyche/src/psyche.rs
@@ -380,7 +380,7 @@ impl Psyche {
 
     /// Swap out the [`Mouth`] used for speech output.
     pub fn set_mouth(&mut self, mouth: Arc<dyn Mouth>) {
-        self.voice.set_mouth(mouth);
+        Arc::make_mut(&mut self.voice).set_mouth(mouth);
     }
 
     /// Swap out the [`Memory`] implementation.


### PR DESCRIPTION
## Summary
- use `AtomicBool` for `Voice::ready`
- drop inner `Arc` from mouth field
- initialize `Segmenter` once
- warn on stream errors and log missing `Will`
- delay speech until emotion events send

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685837614c148320b47090238bce627f