### PR TITLE
Implement fallback turn, safer mouth and debug logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ cargo run -p pete --features tts -- \
   --tts-speaker-id p376
 
 Use `--auto-voice N` to have Pete speak automatically every N seconds during development.
+The default fallback response of "I'm listening." can be disabled with `--no-fallback-turn`.
 
 To serve the interface over HTTPS provide a certificate and key:
 

--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -79,6 +79,9 @@ struct Cli {
     /// Allow the voice to speak every N seconds automatically
     #[arg(long)]
     auto_voice: Option<u64>,
+    /// Disable the fallback <take_turn> when no Wit suggests one
+    #[arg(long)]
+    no_fallback_turn: bool,
     /// URL of the Qdrant service
     #[arg(long, env = "QDRANT_URL", default_value = "http://localhost:6333")]
     qdrant_url: String,
@@ -117,6 +120,7 @@ async fn main() -> anyhow::Result<()> {
         &cli.neo4j_pass,
     )?;
     psyche.enable_all_debug().await;
+    psyche.set_fallback_turn_enabled(!cli.no_fallback_turn);
     let speaking = Arc::new(AtomicBool::new(false));
     let connections = Arc::new(AtomicUsize::new(0));
     #[cfg(feature = "tts")]

--- a/psyche/src/pending_turn.rs
+++ b/psyche/src/pending_turn.rs
@@ -10,6 +10,7 @@
 //! buf.set("hi".to_string());
 //! assert_eq!(buf.take(), Some("hi".to_string()));
 //! assert_eq!(buf.take(), None);
+//! assert!(buf.is_empty());
 //! ```
 //!
 //! The cell is lock-free on supported platforms and falls back to a
@@ -37,5 +38,15 @@ impl PendingTurn {
     /// Take the pending prompt if present.
     pub fn take(&self) -> Option<String> {
         self.inner.take()
+    }
+
+    /// Return `true` when no turn is pending.
+    pub fn is_empty(&self) -> bool {
+        let cur = self.inner.take();
+        let empty = cur.is_none();
+        if let Some(val) = cur {
+            self.inner.store(Some(val));
+        }
+        empty
     }
 }


### PR DESCRIPTION
## Summary
- add `is_empty` to `PendingTurn`
- refactor `Voice` mouth handling using a `Mutex`
- support fallback turns with config and logging
- expose fallback control via CLI and docs
- test default fallback reply

## Testing
- `cargo fetch`
- `RUST_LOG=debug cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68584b44ada48320a2c899875c68ec35