### PR TITLE
Implement dynamic experience tick

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,7 @@ The previous Deno-based client has been removed. Update the files in
   available during tests.
 * Tests expecting a `WitReport` must enable the matching debug label with
   `psyche::debug::enable_debug(label).await`.
+* `Psyche` uses `active_experience_tick` when speaking to process sensations more frequently.
 
 ## Contributor Notes
 


### PR DESCRIPTION
## Summary
- add `active_experience_tick` setting for faster updates while speaking
- vary the experience loop interval depending on conversation state
- document the new behaviour in `AGENTS.md`

## Testing
- `RUST_LOG=debug cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_685880e17370832083a63ce6a429a6bc