### PR TITLE
Rename InstantWit to Quick

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,7 +131,7 @@ The previous Deno-based client has been removed. Update the files in
 * Log all LLM prompts and final responses to stdout using `tracing` macros.
 * When introducing new CLI arguments or environment variables, update
   `.env.example` and README examples accordingly.
-* Log unknown sensation types in `InstantWit::describe` to surface missing
+* Log unknown sensation types in `Quick::describe` to surface missing
   downcasts.
 * Use `#[tokio::test(start_paused = true)]` and `tokio::time::advance` for
   timeout-related tests to avoid slow sleeps.
@@ -139,6 +139,13 @@ The previous Deno-based client has been removed. Update the files in
   duplicate entries.
 * Extract repeated asynchronous loops into helper functions to reduce
   duplication.
+
+### Quick
+
+🧠 The Quick is Pete’s first-level integrator of sensation. It listens to raw
+Sensations and bundles them into an Instant, which is a short-lived,
+fast-turnaround Impression. The Quick fires often and helps higher-level Wits
+(like Will or Memory) act and reflect on what Pete just experienced.
 
 This document reflects the current cognitive and runtime architecture of Pete Daringsby. Keep it consistent with the latest design discussions and behavior changes.
 

--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -28,10 +28,10 @@ pub mod wits {
     pub mod fond_du_coeur;
     pub mod heart_wit;
     pub mod identity_wit;
-    pub mod instant_wit;
     pub mod memory;
     pub mod memory_wit;
     pub mod moment_wit;
+    pub mod quick;
     pub mod situation_wit;
     pub mod vision_wit;
     pub mod will;
@@ -45,10 +45,10 @@ pub mod wits {
     pub use fond_du_coeur::FondDuCoeur;
     pub use heart_wit::HeartWit;
     pub use identity_wit::IdentityWit;
-    pub use instant_wit::InstantWit;
     pub use memory::{BasicMemory, GraphStore, Memory, Neo4jClient, NoopMemory, QdrantClient};
     pub use memory_wit::MemoryWit;
     pub use moment_wit::MomentWit;
+    pub use quick::Quick;
     pub use situation_wit::SituationWit;
     pub use vision_wit::VisionWit;
     pub use will::Will;


### PR DESCRIPTION
## Summary
- rename InstantWit module to `quick`
- refactor struct and docs explaining Quick's role
- update AGENTS instructions for Quick
- export Quick from the library

## Testing
- `cargo fmt --all`
- `RUST_LOG=debug cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6858902b7e288320aeb1ba7361e11bb6