### PR TITLE
Finalize Quick ring buffer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,10 +142,13 @@ The previous Deno-based client has been removed. Update the files in
 
 ### Quick
 
-🧠 The Quick is Pete’s first-level integrator of sensation. It listens to raw
-Sensations and bundles them into an Instant, which is a short-lived,
-fast-turnaround Impression. The Quick fires often and helps higher-level Wits
-(like Will or Memory) act and reflect on what Pete just experienced.
+The Quick is Pete’s first-stage integrator. It buffers raw `Sensation`s over a short window (a few seconds) and emits an `Instant` — a coherent, narrative `Impression` of what Pete just experienced.
+
+- Input: `Sensation` (from webcam, mic, face detector, etc.)
+- Output: `Instant` (e.g., “I hear Travis say, 'Hiya Pete.'”)
+- Consumed by: `Will`, `Memory`, `Heart`
+
+🧠 The Quick does **not** act — it observes and narrates.
 
 This document reflects the current cognitive and runtime architecture of Pete Daringsby. Keep it consistent with the latest design discussions and behavior changes.
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ The unified cognitive model centers on two types:
 * `Impression<T>` – interprets stimuli into a summarized thought with an optional emoji.
 * `Experience<T>` – a stored impression paired with a vector embedding and unique id.
 
+The first layer, **Quick**, groups raw `Sensation`s from sensors into an `Instant`. Higher Wits such as `Will`, `Memory`, and `Heart` react to these Instants.
+
 `Psyche` starts with a prompt asking the LLM to respond in one or two sentences at most. You can override it with `set_system_prompt`.
 Pete's mouth streams audio one sentence at a time so long replies don't block.
 


### PR DESCRIPTION
## Summary
- document Quick as reflexive sensorium
- keep recent sensations in a ring buffer
- log emitted instant summaries
- document Quick in AGENTS and README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685896c00b94832089b926be40986d19