### PR TITLE
Set p123 default voice for Coqui TTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ let tts = std::sync::Arc::new(psyche::PlainMouth::new(
         speaking.clone(),
         std::sync::Arc::new(pete::CoquiTts::new(
             "http://localhost:5002/api/tts",
-            Some("p376".into()),
-            None,
+            Some("p123".into()),
+            Some("en".into()),
         )),
     )) as std::sync::Arc<dyn Mouth>
 ));
@@ -144,7 +144,8 @@ cargo run -p pete --features tts -- \
   --neo4j-user neo4j \
   --neo4j-pass password \
   --tts-url http://localhost:5002/api/tts \
-  --tts-speaker-id p376
+  --tts-speaker-id p123 \
+  --tts-language-id en
 
 Use `--auto-voice N` to have Pete speak automatically every N seconds during development.
 The default fallback response of "I'm listening." can be disabled with `--no-fallback-turn`.

--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -64,12 +64,12 @@ struct Cli {
         default_value = "http://localhost:5002/api/tts"
     )]
     tts_url: String,
-    /// Optional speaker ID for the TTS voice
-    #[arg(long, env = "SPEAKER")]
-    tts_speaker_id: Option<String>,
-    /// Optional language ID for the TTS voice
-    #[arg(long)]
-    tts_language_id: Option<String>,
+    /// Speaker ID for the TTS voice
+    #[arg(long, env = "SPEAKER", default_value = "p123")]
+    tts_speaker_id: String,
+    /// Language ID for the TTS voice
+    #[arg(long, default_value = "en")]
+    tts_language_id: String,
     /// Path to TLS certificate in PEM format
     #[arg(long)]
     tls_cert: Option<String>,
@@ -187,8 +187,8 @@ async fn main() -> anyhow::Result<()> {
             speaking.clone(),
             Arc::new(CoquiTts::new(
                 cli.tts_url,
-                cli.tts_speaker_id,
-                cli.tts_language_id,
+                Some(cli.tts_speaker_id.clone()),
+                Some(cli.tts_language_id.clone()),
             )),
         )) as Arc<dyn Mouth>;
         Arc::new(PlainMouth::new(tts)) as Arc<dyn Mouth>

--- a/pete/src/tts_mouth.rs
+++ b/pete/src/tts_mouth.rs
@@ -62,13 +62,18 @@ impl Tts for CoquiTts {
             let mut qp = url.query_pairs_mut();
             qp.append_pair("text", text);
             // Always include speaker_id and language_id, using defaults if not provided
-            qp.append_pair("speaker_id", self.speaker_id.as_deref().unwrap_or("p340"));
-            qp.append_pair("language_id", self.language_id.as_deref().unwrap_or(""));
+            qp.append_pair("speaker_id", self.speaker_id.as_deref().unwrap_or("p123"));
+            qp.append_pair("language_id", self.language_id.as_deref().unwrap_or("en"));
             if let Some(ref l) = self.language_id {
                 qp.append_pair("language_id", l);
             }
         }
-        info!(%url, "requesting TTS");
+        info!(
+            %url,
+            speaker = %self.speaker_id.as_deref().unwrap_or("p123"),
+            language = %self.language_id.as_deref().unwrap_or("en"),
+            "requesting TTS"
+        );
         let resp = self.client.get(url).send().await?;
         let stream = resp
             .bytes_stream()

--- a/pete/tests/coqui.rs
+++ b/pete/tests/coqui.rs
@@ -29,3 +29,25 @@ async fn coqui_url_has_required_params() {
     }
     mock.assert_async().await;
 }
+
+#[tokio::test]
+async fn coqui_defaults_voice() {
+    let server = MockServer::start_async().await;
+    let mock = server
+        .mock_async(|when, then| {
+            when.method(GET)
+                .path("/api/tts")
+                .query_param("text", "hi")
+                .query_param("speaker_id", "p123")
+                .query_param("language_id", "en");
+            then.status(200).body("abcd");
+        })
+        .await;
+
+    let tts = CoquiTts::new(server.url("/api/tts"), None, None);
+    let mut stream = tts.stream_wav("hi").await.unwrap();
+    while let Some(chunk) = stream.next().await {
+        chunk.unwrap();
+    }
+    mock.assert_async().await;
+}


### PR DESCRIPTION
## Summary
- default CoquiTts voice to `p123` and language `en`
- expose the selected voice via CLI flags with defaults
- log the speaker/language on every TTS request
- document default voice in README
- test CoquiTts default parameters

## Testing
- `cargo fetch`
- `cargo fmt`
- `RUST_LOG=debug cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6858b5c12f50832080830f94e34ca430