### PR TITLE
Fix Coqui URL params

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,8 @@ The previous Deno-based client has been removed. Update the files in
 * Configure with `--tts-url` CLI flag.
 * Build the `pete` binary with `--features tts` to enable audio.
 * Stub TTS in tests to avoid delays.
-* Do not include the `style_wav` parameter when calling Coqui TTS.
+* Include the `style_wav` parameter when calling Coqui TTS. Use an empty value
+  if no style WAV is configured.
 * Speech is emitted via `Event::Speech { text, audio }`.
 
 ## Specialized Notes

--- a/pete/src/tts_mouth.rs
+++ b/pete/src/tts_mouth.rs
@@ -32,16 +32,16 @@ pub struct CoquiTts {
     url: String,
     client: Client,
     speaker_id: Option<String>,
-    /// Optional language code passed as the `lang` query parameter
+    /// Optional language code passed as the `language_id` query parameter
     language_id: Option<String>,
 }
 
 impl CoquiTts {
     /// Create a new client targeting `url` (e.g. `http://localhost:5002/api/tts`).
     ///
-    /// Optional `speaker_id` selects the voice. `language_id` sets the
-    /// `lang` parameter on the TTS server so audio is produced in the
-    /// desired language.
+    /// Optional `speaker_id` selects the voice. `language_id` is passed as the
+    /// corresponding query parameter so audio is produced in the desired
+    /// language.
     pub fn new(
         url: impl Into<String>,
         speaker_id: Option<String>,
@@ -63,9 +63,11 @@ impl Tts for CoquiTts {
         {
             let mut qp = url.query_pairs_mut();
             qp.append_pair("text", text);
-            // Always include speaker_id and lang parameters with defaults
+            // Always include speaker_id, style_wav and language_id parameters
+            // providing defaults when values are not configured
             qp.append_pair("speaker_id", self.speaker_id.as_deref().unwrap_or("p123"));
-            qp.append_pair("lang", self.language_id.as_deref().unwrap_or("en"));
+            qp.append_pair("style_wav", "");
+            qp.append_pair("language_id", self.language_id.as_deref().unwrap_or(""));
         }
         info!(
             %url,

--- a/pete/src/tts_mouth.rs
+++ b/pete/src/tts_mouth.rs
@@ -65,7 +65,7 @@ impl Tts for CoquiTts {
             qp.append_pair("text", text);
             // Always include speaker_id, style_wav and language_id parameters
             // providing defaults when values are not configured
-            qp.append_pair("speaker_id", self.speaker_id.as_deref().unwrap_or("p123"));
+            qp.append_pair("speaker_id", self.speaker_id.as_deref().unwrap_or("p376"));
             qp.append_pair("style_wav", "");
             qp.append_pair("language_id", self.language_id.as_deref().unwrap_or(""));
         }

--- a/pete/src/tts_mouth.rs
+++ b/pete/src/tts_mouth.rs
@@ -32,14 +32,16 @@ pub struct CoquiTts {
     url: String,
     client: Client,
     speaker_id: Option<String>,
+    /// Optional language code passed as the `lang` query parameter
     language_id: Option<String>,
 }
 
 impl CoquiTts {
     /// Create a new client targeting `url` (e.g. `http://localhost:5002/api/tts`).
     ///
-    /// Optional `speaker_id` and `language_id` parameters allow selecting a
-    /// specific voice and language on the TTS server.
+    /// Optional `speaker_id` selects the voice. `language_id` sets the
+    /// `lang` parameter on the TTS server so audio is produced in the
+    /// desired language.
     pub fn new(
         url: impl Into<String>,
         speaker_id: Option<String>,
@@ -61,12 +63,9 @@ impl Tts for CoquiTts {
         {
             let mut qp = url.query_pairs_mut();
             qp.append_pair("text", text);
-            // Always include speaker_id and language_id, using defaults if not provided
+            // Always include speaker_id and lang parameters with defaults
             qp.append_pair("speaker_id", self.speaker_id.as_deref().unwrap_or("p123"));
-            qp.append_pair("language_id", self.language_id.as_deref().unwrap_or("en"));
-            if let Some(ref l) = self.language_id {
-                qp.append_pair("language_id", l);
-            }
+            qp.append_pair("lang", self.language_id.as_deref().unwrap_or("en"));
         }
         info!(
             %url,

--- a/pete/tests/coqui.rs
+++ b/pete/tests/coqui.rs
@@ -12,12 +12,8 @@ async fn coqui_url_has_required_params() {
                 .path("/api/tts")
                 .query_param("text", "hello")
                 .query_param("speaker_id", "p1")
-                .query_param("lang", "en")
-                .matches(|req| {
-                    req.query_params
-                        .as_ref()
-                        .map_or(true, |qp| !qp.iter().any(|(k, _)| k == "style_wav"))
-                });
+                .query_param("style_wav", "")
+                .query_param("language_id", "en");
             then.status(200).body("abcd");
         })
         .await;
@@ -39,7 +35,8 @@ async fn coqui_defaults_voice() {
                 .path("/api/tts")
                 .query_param("text", "hi")
                 .query_param("speaker_id", "p123")
-                .query_param("lang", "en");
+                .query_param("style_wav", "")
+                .query_param("language_id", "");
             then.status(200).body("abcd");
         })
         .await;

--- a/pete/tests/coqui.rs
+++ b/pete/tests/coqui.rs
@@ -12,7 +12,7 @@ async fn coqui_url_has_required_params() {
                 .path("/api/tts")
                 .query_param("text", "hello")
                 .query_param("speaker_id", "p1")
-                .query_param("language_id", "en")
+                .query_param("lang", "en")
                 .matches(|req| {
                     req.query_params
                         .as_ref()
@@ -39,7 +39,7 @@ async fn coqui_defaults_voice() {
                 .path("/api/tts")
                 .query_param("text", "hi")
                 .query_param("speaker_id", "p123")
-                .query_param("language_id", "en");
+                .query_param("lang", "en");
             then.status(200).body("abcd");
         })
         .await;


### PR DESCRIPTION
## Summary
- ensure `lang` parameter is always included in Coqui TTS requests
- update tests for new `lang` behaviour

## Testing
- `cargo test coqui`

------
https://chatgpt.com/codex/tasks/task_e_6858b9bb08508320b835fccc954c7241