### PR TITLE
Fix prompt context default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,9 @@ This repository is a Rust workspace.
 * Only the `Psyche` loop should append to `Conversation`; `Ear` implementations forward sensations without modifying the log.
 * Use the `Motor` trait for host actions. Implementations live in `pete`.
 * Track spawned task `JoinHandle`s in a `TaskGroup` so `drop` aborts them.
+* `lingproc::push_prompt_context` and `lingproc::take_prompt_context` manage
+  temporary prompt notes. `Chatter::update_prompt_context` uses them by
+  default to append text to future prompts.
 
 ## Frontend
 

--- a/lingproc/Cargo.toml
+++ b/lingproc/Cargo.toml
@@ -13,6 +13,7 @@ pragmatic-segmenter = "0.1"
 unicode-segmentation = "1"
 futures = "0.3"
 tracing = "0.1"
+once_cell = "1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/lingproc/src/provider.rs
+++ b/lingproc/src/provider.rs
@@ -58,8 +58,14 @@ impl Doer for OllamaProvider {
 #[async_trait]
 impl Chatter for OllamaProvider {
     async fn chat(&self, system_prompt: &str, history: &[Message]) -> Result<ChatStream> {
+        let mut prompt = system_prompt.to_string();
+        for note in crate::types::take_prompt_context().await {
+            prompt.push('\n');
+            prompt.push_str(&note);
+        }
+
         let mut msgs = Vec::with_capacity(history.len() + 1);
-        msgs.push(ChatMessage::system(system_prompt.to_string()));
+        msgs.push(ChatMessage::system(prompt.clone()));
         for m in history {
             let m = match m.role {
                 Role::Assistant => ChatMessage::assistant(m.content.clone()),
@@ -68,7 +74,7 @@ impl Chatter for OllamaProvider {
             msgs.push(m);
         }
         info!(history_len = history.len(), "ollama chat");
-        debug!(%system_prompt, ?history, "ollama chat request");
+        debug!(%prompt, ?history, "ollama chat request");
         let req = ChatMessageRequest::new(self.model.clone(), msgs);
         let stream = self
             .client
@@ -87,8 +93,6 @@ impl Chatter for OllamaProvider {
             });
         Ok(Box::pin(stream))
     }
-
-    async fn update_prompt_context(&self, _context: &str) {}
 }
 
 #[async_trait]


### PR DESCRIPTION
## Summary
- append prompt context to future prompts via default helpers
- plumb prompt notes through Ollama provider
- document global prompt context helpers

## Testing
- `cargo fetch`
- `RUST_LOG=debug cargo test` *(fails: instant_summary_triggers_instruction running over 60s)*

------
https://chatgpt.com/codex/tasks/task_e_6858d05a4b848320aa5a883fa940d17f