### PR TITLE
Rename add_user and add AI counterpart

### DIFF
--- a/pete/tests/conversation.rs
+++ b/pete/tests/conversation.rs
@@ -10,7 +10,7 @@ use std::sync::{
 async fn returns_log_json() {
     let mut psyche = dummy_psyche();
     let conversation = psyche.conversation();
-    conversation.lock().await.add_user("hi".into());
+    conversation.lock().await.add_message_from_user("hi".into());
     let ear = Arc::new(ChannelEar::new(
         psyche.input_sender(),
         Arc::new(AtomicBool::new(false)),

--- a/psyche/src/psyche.rs
+++ b/psyche/src/psyche.rs
@@ -45,11 +45,12 @@ pub struct Conversation {
 
 impl Conversation {
     /// Append a user message to the log, merging with the previous user entry when possible.
-    pub fn add_user(&mut self, content: String) {
+    pub fn add_message_from_user(&mut self, content: String) {
         self.append_or_new(Role::User, content);
     }
 
-    fn add_assistant(&mut self, content: String) {
+    /// Append an AI generated message to the log, merging consecutive assistant entries.
+    pub fn add_message_from_ai(&mut self, content: String) {
         self.append_or_new(Role::Assistant, content);
     }
 
@@ -548,12 +549,12 @@ impl Psyche {
                 match &*arc {
                     Sensation::HeardOwnVoice(msg) => {
                         let mut conv = self.conversation.lock().await;
-                        conv.add_assistant(msg.clone());
+                        conv.add_message_from_ai(msg.clone());
                         self.buffer_self_speech(msg).await;
                     }
                     Sensation::HeardUserVoice(msg) => {
                         let mut conv = self.conversation.lock().await;
-                        conv.add_user(msg.clone());
+                        conv.add_message_from_user(msg.clone());
                         self.buffer_user_speech(msg).await;
                         if self.pending_turn.is_empty() && self.fallback_turn {
                             self.pending_turn.set("I'm listening.".to_string());

--- a/psyche/tests/conversation_merge.rs
+++ b/psyche/tests/conversation_merge.rs
@@ -3,7 +3,15 @@ use psyche::Conversation;
 #[test]
 fn consecutive_user_messages_are_spaced_and_trimmed() {
     let mut c = Conversation::default();
-    c.add_user("hi".into());
-    c.add_user("there  ".into());
+    c.add_message_from_user("hi".into());
+    c.add_message_from_user("there  ".into());
     assert_eq!(c.all()[0].content, "hi there");
+}
+
+#[test]
+fn consecutive_ai_messages_are_spaced_and_trimmed() {
+    let mut c = Conversation::default();
+    c.add_message_from_ai("hello".into());
+    c.add_message_from_ai("world  ".into());
+    assert_eq!(c.all()[0].content, "hello world");
 }


### PR DESCRIPTION
## Summary
- rename `Conversation::add_user` to `add_message_from_user`
- add public `add_message_from_ai` method
- update conversation loop and tests for new names
- test merging for assistant messages

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6858d40c8a108320b631e29962ae2b04