### PR TITLE
Document prompt context helpers

### DIFF
--- a/lingproc/tests/prompt_context.rs
+++ b/lingproc/tests/prompt_context.rs
@@ -1,0 +1,14 @@
+use lingproc::{push_prompt_context, take_prompt_context};
+
+#[tokio::test]
+async fn notes_are_consumed_after_take() {
+    // clear any leftover state
+    take_prompt_context().await;
+    push_prompt_context("alpha").await;
+    push_prompt_context("beta").await;
+    assert_eq!(
+        take_prompt_context().await,
+        vec!["alpha".to_string(), "beta".to_string()]
+    );
+    assert!(take_prompt_context().await.is_empty());
+}


### PR DESCRIPTION
## Summary
- document `push_prompt_context` and `take_prompt_context` with usage examples
- add a regression test for prompt context behaviour

## Testing
- `cargo test` *(fails: the option `Z` is only accepted on the nightly compiler)*
- `RUST_LOG=debug cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6858d50d36888320bef0e2fe6a281605