### PR TITLE
Rename ChatStream to TextStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ impl Ear for DummyEar {
 struct DummyVoice;
 #[async_trait]
 impl psyche::ling::Chatter for DummyVoice {
-    async fn chat(&self, _s: &str, _h: &[psyche::ling::Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+    async fn chat(&self, _s: &str, _h: &[psyche::ling::Message]) -> anyhow::Result<psyche::ling::TextStream> {
         Ok(Box::pin(tokio_stream::once(Ok("😊".to_string()))))
     }
 }

--- a/lingproc/src/provider.rs
+++ b/lingproc/src/provider.rs
@@ -1,6 +1,6 @@
 //! Providers implementing the [`Doer`], [`Chatter`], and [`Vectorizer`] traits.
 
-use crate::types::{ChatStream, Chatter, Doer, Instruction, Message, Role, Vectorizer};
+use crate::types::{Chatter, Doer, Instruction, Message, Role, TextStream, Vectorizer};
 use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use ollama_rs::{
@@ -57,7 +57,7 @@ impl Doer for OllamaProvider {
 
 #[async_trait]
 impl Chatter for OllamaProvider {
-    async fn chat(&self, system_prompt: &str, history: &[Message]) -> Result<ChatStream> {
+    async fn chat(&self, system_prompt: &str, history: &[Message]) -> Result<TextStream> {
         let mut prompt = system_prompt.to_string();
         for note in crate::types::take_prompt_context().await {
             prompt.push('\n');

--- a/lingproc/src/types.rs
+++ b/lingproc/src/types.rs
@@ -116,11 +116,15 @@ impl Message {
     }
 }
 
-/// An asynchronous stream of `Result<String>` response chunks from the LLM.
+/// An asynchronous stream of textual chunks.
 ///
-/// Used by [`Chatter::chat`]. Typically emits partial sentences or word
-/// fragments. Terminates when the full response has been streamed.
-pub type ChatStream = Pin<Box<dyn Stream<Item = Result<String>> + Send>>;
+/// The error type defaults to [`anyhow::Error`], matching most provider
+/// implementations.  Use it whenever streaming strings.
+pub type TextStream<E = anyhow::Error> = Pin<Box<dyn Stream<Item = Result<String, E>> + Send>>;
+
+/// Backwards-compatibility alias.
+#[deprecated(note = "use `TextStream` instead")]
+pub type ChatStream = TextStream;
 
 /// Trait for conversational generation. Produces a stream of natural language chunks.
 ///
@@ -128,7 +132,7 @@ pub type ChatStream = Pin<Box<dyn Stream<Item = Result<String>> + Send>>;
 /// It receives a system prompt and conversation history, and returns a stream of
 /// partial strings.
 ///
-/// The returned [`ChatStream`] emits chunks progressively, enabling real-time
+/// The returned [`TextStream`] emits chunks progressively, enabling real-time
 /// speech synthesis.
 ///
 /// ## Example
@@ -160,7 +164,7 @@ pub trait Chatter: Send + Sync {
     /// Start a chat session using `system_prompt` and `history`.
     ///
     /// Returns a stream of response chunks from the language model.
-    async fn chat(&self, system_prompt: &str, history: &[Message]) -> Result<ChatStream>;
+    async fn chat(&self, system_prompt: &str, history: &[Message]) -> Result<TextStream>;
 
     /// Update additional context for future prompts.
     ///

--- a/pete/src/psyche_factory.rs
+++ b/pete/src/psyche_factory.rs
@@ -21,7 +21,7 @@ pub fn dummy_psyche() -> Psyche {
 
     #[async_trait]
     impl Chatter for Dummy {
-        async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+        async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<psyche::ling::TextStream> {
             Ok(Box::pin(tokio_stream::once(Ok("hi".to_string()))))
         }
     }

--- a/pete/tests/e2e.rs
+++ b/pete/tests/e2e.rs
@@ -3,7 +3,7 @@ use cucumber::{World as _, given, then, when};
 use pete::{ChannelEar, ChannelMouth, EventBus};
 use psyche::{
     self, Ear, Event, Mouth,
-    ling::{ChatStream, Chatter, Doer, Instruction, Message, Vectorizer},
+    ling::{Chatter, Doer, Instruction, Message, TextStream, Vectorizer},
 };
 use std::sync::{Arc, atomic::AtomicBool};
 use tokio::sync::{Mutex, broadcast};
@@ -32,7 +32,7 @@ struct FixedLLM {
 
 #[async_trait]
 impl Chatter for FixedLLM {
-    async fn chat(&self, _s: &str, _h: &[Message]) -> anyhow::Result<ChatStream> {
+    async fn chat(&self, _s: &str, _h: &[Message]) -> anyhow::Result<TextStream> {
         Ok(Box::pin(once(Ok(self.reply.clone()))))
     }
     async fn update_prompt_context(&self, _c: &str) {}

--- a/pete/tests/psyche_loop.rs
+++ b/pete/tests/psyche_loop.rs
@@ -78,7 +78,7 @@
 
 // fn test_psyche(mouth: Arc<dyn Mouth>, ear: Arc<dyn Ear>) -> psyche::Psyche {
 //     use futures::stream;
-//     use psyche::ling::{ChatStream, Chatter, Doer, Instruction, Message, Vectorizer};
+//     use psyche::ling::{TextStream, Chatter, Doer, Instruction, Message, Vectorizer};
 //     use std::pin::Pin;
 
 //     struct DummyLLM;
@@ -96,7 +96,7 @@
 //             &self,
 //             _system_prompt: &str,
 //             _history: &[Message],
-//         ) -> anyhow::Result<ChatStream> {
+//         ) -> anyhow::Result<TextStream> {
 //             Ok(Box::pin(stream::iter(vec![Ok("Hi".into())])))
 //         }
 //     }

--- a/psyche/tests/channel_capacity.rs
+++ b/psyche/tests/channel_capacity.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use psyche::ling::{Chatter, Doer, Instruction, Message, Vectorizer};
+use psyche::ling::{Chatter, Doer, Instruction, Message, TextStream, Vectorizer};
 use psyche::wits::memory::Memory;
 use psyche::{Ear, Mouth, Psyche};
 use serde_json::Value;
@@ -26,7 +26,7 @@ impl Ear for Dummy {
 
 #[async_trait]
 impl Chatter for Dummy {
-    async fn chat(&self, _s: &str, _h: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+    async fn chat(&self, _s: &str, _h: &[Message]) -> anyhow::Result<TextStream> {
         Ok(Box::pin(once(Ok("ok".into()))))
     }
     async fn update_prompt_context(&self, _c: &str) {}

--- a/psyche/tests/experience_tick.rs
+++ b/psyche/tests/experience_tick.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use psyche::ling::{Chatter, Doer, Instruction, Message, Vectorizer};
+use psyche::ling::{Chatter, Doer, Instruction, Message, TextStream, Vectorizer};
 use psyche::{Ear, Impression, Mouth, Psyche, wit::Wit};
 use std::sync::{
     Arc,
@@ -28,7 +28,7 @@ impl Ear for Dummy {
 
 #[async_trait]
 impl Chatter for Dummy {
-    async fn chat(&self, _s: &str, _h: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+    async fn chat(&self, _s: &str, _h: &[Message]) -> anyhow::Result<TextStream> {
         Ok(Box::pin(once(Ok("ok".into()))))
     }
     async fn update_prompt_context(&self, _c: &str) {}

--- a/psyche/tests/face_sensor.rs
+++ b/psyche/tests/face_sensor.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use futures::{StreamExt, pin_mut};
-use psyche::ling::{Chatter, Doer, Instruction, Message, Vectorizer};
+use psyche::ling::{Chatter, Doer, Instruction, Message, TextStream, Vectorizer};
 use psyche::{
     Ear, ImageData, Mouth, Psyche, Sensation, Sensor, Topic,
     sensors::face::{DummyDetector, FaceDetector, FaceInfo, FaceSensor},
@@ -33,7 +33,7 @@ async fn emits_face_info() {
     }
     #[async_trait]
     impl Chatter for Dummy {
-        async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+        async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<TextStream> {
             Ok(Box::pin(tokio_stream::once(Ok("hi".to_string()))))
         }
     }

--- a/psyche/tests/ling.rs
+++ b/psyche/tests/ling.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use psyche::ling::{Chatter, Doer, Instruction, Message, Vectorizer};
+use psyche::ling::{Chatter, Doer, Instruction, Message, TextStream, Vectorizer};
 use tokio_stream::StreamExt;
 
 struct Dummy;
@@ -13,7 +13,7 @@ impl Doer for Dummy {
 
 #[async_trait]
 impl Chatter for Dummy {
-    async fn chat(&self, _s: &str, h: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+    async fn chat(&self, _s: &str, h: &[Message]) -> anyhow::Result<TextStream> {
         let msg = format!("say:{}", h.len());
         Ok(Box::pin(tokio_stream::once(Ok(msg))))
     }

--- a/psyche/tests/liveness.rs
+++ b/psyche/tests/liveness.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use psyche::ling::{Chatter, Doer, Instruction, Message, Vectorizer};
+use psyche::ling::{Chatter, Doer, Instruction, Message, TextStream, Vectorizer};
 use psyche::{Ear, Mouth, Psyche};
 use std::sync::{
     Arc,
@@ -31,7 +31,7 @@ impl Ear for Dummy {
 
 #[async_trait]
 impl Chatter for Dummy {
-    async fn chat(&self, _s: &str, _h: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+    async fn chat(&self, _s: &str, _h: &[Message]) -> anyhow::Result<TextStream> {
         Ok(Box::pin(once(Ok("ok".into()))))
     }
     async fn update_prompt_context(&self, _c: &str) {}

--- a/psyche/tests/prompt.rs
+++ b/psyche/tests/prompt.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use psyche::ling::{Chatter, Doer, Instruction, Message, Vectorizer};
+use psyche::ling::{Chatter, Doer, Instruction, Message, TextStream, Vectorizer};
 use psyche::{DEFAULT_SYSTEM_PROMPT, Ear, Mouth, Psyche};
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -38,7 +38,7 @@ impl Doer for Dummy {
 
 #[async_trait]
 impl Chatter for Dummy {
-    async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+    async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<TextStream> {
         Ok(Box::pin(tokio_stream::once(Ok("hi".to_string()))))
     }
 }

--- a/psyche/tests/topic_bus.rs
+++ b/psyche/tests/topic_bus.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use futures::{StreamExt, pin_mut};
-use psyche::ling::{Chatter, Doer, Instruction, Message, Vectorizer};
+use psyche::ling::{Chatter, Doer, Instruction, Message, TextStream, Vectorizer};
 use psyche::{Ear, Mouth, Psyche, Topic};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -40,7 +40,7 @@ impl Doer for Dummy {
 
 #[async_trait]
 impl Chatter for Dummy {
-    async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+    async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<TextStream> {
         Ok(Box::pin(tokio_stream::once(Ok("hi".to_string()))))
     }
 }

--- a/psyche/tests/voice.rs
+++ b/psyche/tests/voice.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use psyche::ling::{ChatStream, Chatter, Doer, Instruction, Message};
+use psyche::ling::{Chatter, Doer, Instruction, Message, TextStream};
 use psyche::{Event, Mouth};
 use psyche::{Voice, extract_emojis};
 use std::sync::Arc;
@@ -11,7 +11,7 @@ struct DummyLLM;
 
 #[async_trait]
 impl Chatter for DummyLLM {
-    async fn chat(&self, _s: &str, _h: &[Message]) -> anyhow::Result<ChatStream> {
+    async fn chat(&self, _s: &str, _h: &[Message]) -> anyhow::Result<TextStream> {
         Ok(Box::pin(once(Ok("Hi 😊".to_string()))))
     }
     async fn update_prompt_context(&self, _c: &str) {}
@@ -50,7 +50,7 @@ struct SpyLLM(Arc<tokio::sync::Mutex<Vec<String>>>);
 
 #[async_trait]
 impl Chatter for SpyLLM {
-    async fn chat(&self, s: &str, _h: &[Message]) -> anyhow::Result<ChatStream> {
+    async fn chat(&self, s: &str, _h: &[Message]) -> anyhow::Result<TextStream> {
         self.0.lock().await.push(s.to_string());
         Ok(Box::pin(once(Ok("ok".into()))))
     }

--- a/psyche/tests/voice_control.rs
+++ b/psyche/tests/voice_control.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use psyche::ling::{ChatStream, Chatter, Doer, Instruction, Message, Vectorizer};
+use psyche::ling::{Chatter, Doer, Instruction, Message, TextStream, Vectorizer};
 use psyche::{Ear, Impression, Mouth, Psyche, Sensation, Stimulus, wit::Wit};
 use std::sync::{
     Arc,
@@ -14,7 +14,7 @@ struct RecLLM(Arc<TokioMutex<Vec<String>>>);
 
 #[async_trait]
 impl Chatter for RecLLM {
-    async fn chat(&self, s: &str, _h: &[Message]) -> anyhow::Result<ChatStream> {
+    async fn chat(&self, s: &str, _h: &[Message]) -> anyhow::Result<TextStream> {
         self.0.lock().await.push(s.to_string());
         Ok(Box::pin(once(Ok("ok".into()))))
     }

--- a/psyche/tests/wit_panic.rs
+++ b/psyche/tests/wit_panic.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use psyche::ling::{Chatter, Doer, Instruction, Message, Vectorizer};
+use psyche::ling::{Chatter, Doer, Instruction, Message, TextStream, Vectorizer};
 use psyche::{Ear, Impression, Mouth, Psyche, Wit};
 use std::sync::Arc;
 use std::time::Duration;
@@ -25,7 +25,7 @@ impl Ear for Dummy {
 
 #[async_trait]
 impl Chatter for Dummy {
-    async fn chat(&self, _s: &str, _h: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+    async fn chat(&self, _s: &str, _h: &[Message]) -> anyhow::Result<TextStream> {
         Ok(Box::pin(once(Ok("ok".into()))))
     }
     async fn update_prompt_context(&self, _c: &str) {}


### PR DESCRIPTION
## Summary
- rename `ChatStream` to `TextStream`
- update provider and helpers to use the new name
- return `TextStream` from segmentation utilities
- adjust tests and README

## Testing
- `cargo test` *(fails: output truncated)*

------
https://chatgpt.com/codex/tasks/task_e_6858d5a572548320bd4609973832d20f