### PR TITLE
Document conversation tail

### DIFF
--- a/psyche/src/ling.rs
+++ b/psyche/src/ling.rs
@@ -87,6 +87,9 @@ impl Ling {
     }
 
     /// Return the most recent `n` messages.
+    ///
+    /// [`Psyche`](crate::Psyche) fetches the tail when constructing prompts for
+    /// the [`Chatter`](crate::ling::Chatter) so only a short history is sent.
     pub async fn get_conversation_tail(&self, n: usize) -> Vec<Message> {
         self.conversation.lock().await.tail(n)
     }

--- a/psyche/src/psyche.rs
+++ b/psyche/src/psyche.rs
@@ -68,6 +68,11 @@ impl Conversation {
         self.log.push(Message { role, content });
     }
 
+    /// Return the last `n` messages from the conversation.
+    ///
+    /// [`Ling`](crate::Ling) calls this when assembling a prompt for the
+    /// [`Chatter`](crate::ling::Chatter) so that only recent dialogue is
+    /// forwarded. Trimming history keeps model prompts a manageable size.
     pub fn tail(&self, n: usize) -> Vec<Message> {
         let len = self.log.len();
         self.log[len.saturating_sub(n)..].to_vec()

--- a/psyche/tests/conversation_tail.rs
+++ b/psyche/tests/conversation_tail.rs
@@ -1,0 +1,22 @@
+use psyche::Conversation;
+
+#[test]
+fn tail_returns_last_n_messages() {
+    let mut c = Conversation::default();
+    c.add_message_from_user("hello".into());
+    c.add_message_from_ai("hi".into());
+    c.add_message_from_user("world".into());
+    let tail = c.tail(2);
+    assert_eq!(tail.len(), 2);
+    assert_eq!(tail[0].content, "hi");
+    assert_eq!(tail[1].content, "world");
+}
+
+#[test]
+fn tail_does_not_panic_with_large_n() {
+    let mut c = Conversation::default();
+    c.add_message_from_user("one".into());
+    let tail = c.tail(5);
+    assert_eq!(tail.len(), 1);
+    assert_eq!(tail[0].content, "one");
+}


### PR DESCRIPTION
## Summary
- add docs for `Conversation::tail`
- document that `Ling` fetches the tail for prompts
- add tests for conversation history tail

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6858d78751e8832090cd38e514108c69