### PR TITLE
Remove psyche::ling, use lingproc directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository contains a Rust workspace with three crates:
 
 - **psyche** – a library crate providing the `Psyche` type
-- **lingproc** – helper LLM abstractions re-exported by `psyche`
+- **lingproc** – helper LLM abstractions
 - **pete** – a binary crate depending on `psyche`
 
 The `psyche` crate also defines a `Summarizer` trait used to build modular
@@ -27,7 +27,7 @@ Pete's mouth streams audio one sentence at a time so long replies don't block.
 Example with the `OllamaProvider`:
 
 ```rust,no_run
-use psyche::ling::OllamaProvider;
+use lingproc::OllamaProvider;
 use psyche::Psyche;
 
 let narrator = OllamaProvider::new("http://localhost:11434", "mistral").unwrap();
@@ -53,8 +53,8 @@ impl Ear for DummyEar {
 
 struct DummyVoice;
 #[async_trait]
-impl psyche::ling::Chatter for DummyVoice {
-    async fn chat(&self, _s: &str, _h: &[psyche::ling::Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+impl lingproc::Chatter for DummyVoice {
+    async fn chat(&self, _s: &str, _h: &[lingproc::Message]) -> anyhow::Result<lingproc::ChatStream> {
         Ok(Box::pin(tokio_stream::once(Ok("😊".to_string()))))
     }
 }

--- a/pete/Cargo.toml
+++ b/pete/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 psyche = { path = "../psyche" }
+lingproc = { path = "../lingproc" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 anyhow = "1"
 async-trait = "0.1"

--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -107,7 +107,7 @@ async fn main() -> anyhow::Result<()> {
 
     info!(%cli.addr, "starting server");
 
-    use psyche::ling::OllamaProvider;
+    use lingproc::OllamaProvider;
     use psyche::wits::{
         BasicMemory, Combobulator, CombobulatorSummarizer, FaceMemoryWit, FondDuCoeur, HeartWit,
         IdentityWit, MemoryWit, Neo4jClient, QdrantClient, VisionWit, Will, WillSummarizer,

--- a/pete/src/psyche_factory.rs
+++ b/pete/src/psyche_factory.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use psyche::ling::{Chatter, Doer, Instruction, Message, Vectorizer};
+use lingproc::{Chatter, Doer, Instruction, Message, Vectorizer};
 use psyche::{ContextualPrompt, Psyche};
 use std::sync::Arc;
 use tracing::info;
@@ -21,7 +21,7 @@ pub fn dummy_psyche() -> Psyche {
 
     #[async_trait]
     impl Chatter for Dummy {
-        async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+        async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<lingproc::ChatStream> {
             Ok(Box::pin(tokio_stream::once(Ok("hi".to_string()))))
         }
     }
@@ -59,7 +59,7 @@ pub fn dummy_psyche() -> Psyche {
 
 /// Create a psyche backed by an Ollama server.
 ///
-/// This uses [`OllamaProvider`](psyche::ling::OllamaProvider) for all language
+/// This uses [`OllamaProvider`](lingproc::OllamaProvider) for all language
 /// capabilities and the no-op ear and mouth implementations.
 pub fn ollama_psyche(
     chatter_host: &str,
@@ -74,7 +74,7 @@ pub fn ollama_psyche(
     neo4j_pass: &str,
 ) -> anyhow::Result<Psyche> {
     use crate::LoggingMotor;
-    use psyche::ling::OllamaProvider;
+    use lingproc::OllamaProvider;
     use psyche::wits::{
         BasicMemory, Combobulator, CombobulatorSummarizer, FondDuCoeur, HeartWit, IdentityWit,
         MemoryWit, Neo4jClient, QdrantClient, Will, WillSummarizer,

--- a/pete/src/web.rs
+++ b/pete/src/web.rs
@@ -18,7 +18,8 @@ use tower_http::services::ServeDir;
 use tracing::{debug, error, info};
 
 use crate::EventBus;
-use psyche::{Ear, Event, GeoLoc, ImageData, Sensor, WitReport, ling::Role};
+use lingproc::Role;
+use psyche::{Ear, Event, GeoLoc, ImageData, Sensor, WitReport};
 
 /// State shared across HTTP handlers and WebSocket tasks.
 #[derive(Clone)]

--- a/pete/tests/psyche_loop.rs
+++ b/pete/tests/psyche_loop.rs
@@ -78,7 +78,7 @@
 
 // fn test_psyche(mouth: Arc<dyn Mouth>, ear: Arc<dyn Ear>) -> psyche::Psyche {
 //     use futures::stream;
-//     use psyche::ling::{ChatStream, Chatter, Doer, Instruction, Message, Vectorizer};
+//     use lingproc::{ChatStream, Chatter, Doer, Instruction, Message, Vectorizer};
 //     use std::pin::Pin;
 
 //     struct DummyLLM;

--- a/psyche/src/ling.rs
+++ b/psyche/src/ling.rs
@@ -1,6 +1,6 @@
 //! Linguistic helpers and prompt assembly utilities.
 
-pub use lingproc::*;
+use lingproc::Message;
 
 use crate::{Conversation, Impression};
 use tokio::sync::Mutex;

--- a/psyche/src/psyche.rs
+++ b/psyche/src/psyche.rs
@@ -1,9 +1,9 @@
-use crate::ling::{Chatter, Doer, Message, Role, Vectorizer};
 use crate::sensation::{Event, Sensation, WitReport};
 use crate::traits::wit;
 use crate::traits::wit::{ErasedWit, Wit};
 use crate::traits::{Ear, Mouth};
 use crate::wits::memory::Memory;
+use lingproc::{Chatter, Doer, Message, Role, Vectorizer};
 use serde::Serialize;
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;

--- a/psyche/src/traits/wit.rs
+++ b/psyche/src/traits/wit.rs
@@ -1,5 +1,6 @@
-use crate::{Impression, Sensation, Stimulus, ling::Instruction};
+use crate::{Impression, Sensation, Stimulus};
 use async_trait::async_trait;
+use lingproc::Instruction;
 use serde::{Deserialize, Serialize};
 use serde_json::{self, Value};
 use std::sync::Arc;
@@ -135,12 +136,12 @@ pub struct Episode {
 
 /// A Wit turning [`Sensation`]s into [`Instant`]s.
 pub struct InstantWit {
-    doer: Arc<dyn crate::ling::Doer>,
+    doer: Arc<dyn lingproc::Doer>,
 }
 
 impl InstantWit {
     /// Create a new `InstantWit` using the provided [`Doer`].
-    pub fn new(doer: Box<dyn crate::ling::Doer>) -> Self {
+    pub fn new(doer: Box<dyn lingproc::Doer>) -> Self {
         Self { doer: doer.into() }
     }
 }
@@ -151,11 +152,8 @@ impl Default for InstantWit {
         struct Dummy;
 
         #[async_trait]
-        impl crate::ling::Doer for Dummy {
-            async fn follow(
-                &self,
-                instruction: crate::ling::Instruction,
-            ) -> anyhow::Result<String> {
+        impl lingproc::Doer for Dummy {
+            async fn follow(&self, instruction: lingproc::Instruction) -> anyhow::Result<String> {
                 Ok(instruction.command)
             }
         }
@@ -206,12 +204,12 @@ impl Summarizer<Sensation, Instant> for InstantWit {
 /// A Wit summarizing [`Instant`]s into a [`Moment`].
 #[derive(Clone)]
 pub struct MomentWit {
-    doer: Arc<dyn crate::ling::Doer>,
+    doer: Arc<dyn lingproc::Doer>,
 }
 
 impl MomentWit {
     /// Create a new `MomentWit` using the provided [`Doer`].
-    pub fn new(doer: Box<dyn crate::ling::Doer>) -> Self {
+    pub fn new(doer: Box<dyn lingproc::Doer>) -> Self {
         Self { doer: doer.into() }
     }
 }
@@ -222,11 +220,8 @@ impl Default for MomentWit {
         struct Dummy;
 
         #[async_trait]
-        impl crate::ling::Doer for Dummy {
-            async fn follow(
-                &self,
-                instruction: crate::ling::Instruction,
-            ) -> anyhow::Result<String> {
+        impl lingproc::Doer for Dummy {
+            async fn follow(&self, instruction: lingproc::Instruction) -> anyhow::Result<String> {
                 Ok(instruction.command)
             }
         }
@@ -258,7 +253,7 @@ impl Summarizer<Instant, Moment> for MomentWit {
         // For now we simply echo the prompt as the model response.
         let resp = self
             .doer
-            .follow(crate::ling::Instruction {
+            .follow(lingproc::Instruction {
                 command: prompt,
                 images: Vec::new(),
             })
@@ -277,12 +272,12 @@ impl Summarizer<Instant, Moment> for MomentWit {
 
 /// A Wit distilling [`Moment`]s into a [`Situation`].
 pub struct SituationWit {
-    doer: Arc<dyn crate::ling::Doer>,
+    doer: Arc<dyn lingproc::Doer>,
 }
 
 impl SituationWit {
     /// Create a new `SituationWit` using the provided [`Doer`].
-    pub fn new(doer: Box<dyn crate::ling::Doer>) -> Self {
+    pub fn new(doer: Box<dyn lingproc::Doer>) -> Self {
         Self { doer: doer.into() }
     }
 }
@@ -293,11 +288,8 @@ impl Default for SituationWit {
         struct Dummy;
 
         #[async_trait]
-        impl crate::ling::Doer for Dummy {
-            async fn follow(
-                &self,
-                instruction: crate::ling::Instruction,
-            ) -> anyhow::Result<String> {
+        impl lingproc::Doer for Dummy {
+            async fn follow(&self, instruction: lingproc::Instruction) -> anyhow::Result<String> {
                 Ok(instruction.command)
             }
         }
@@ -342,12 +334,12 @@ impl Summarizer<Moment, Situation> for SituationWit {
 
 /// A Wit summarizing [`Situation`]s into an [`Episode`].
 pub struct EpisodeWit {
-    doer: Arc<dyn crate::ling::Doer>,
+    doer: Arc<dyn lingproc::Doer>,
 }
 
 impl EpisodeWit {
     /// Create a new `EpisodeWit` using the provided [`Doer`].
-    pub fn new(doer: Box<dyn crate::ling::Doer>) -> Self {
+    pub fn new(doer: Box<dyn lingproc::Doer>) -> Self {
         Self { doer: doer.into() }
     }
 }
@@ -358,11 +350,8 @@ impl Default for EpisodeWit {
         struct Dummy;
 
         #[async_trait]
-        impl crate::ling::Doer for Dummy {
-            async fn follow(
-                &self,
-                instruction: crate::ling::Instruction,
-            ) -> anyhow::Result<String> {
+        impl lingproc::Doer for Dummy {
+            async fn follow(&self, instruction: lingproc::Instruction) -> anyhow::Result<String> {
                 Ok(instruction.command)
             }
         }

--- a/psyche/src/voice.rs
+++ b/psyche/src/voice.rs
@@ -1,5 +1,5 @@
-use crate::ling::{Chatter, Message};
 use crate::{Event, Mouth};
+use lingproc::{Chatter, Message};
 use pragmatic_segmenter::Segmenter;
 use std::collections::VecDeque;
 use std::sync::{

--- a/psyche/src/wits/combobulator_summarizer.rs
+++ b/psyche/src/wits/combobulator_summarizer.rs
@@ -1,10 +1,7 @@
 use crate::prompt::PromptBuilder;
-use crate::{
-    Impression, Stimulus, Summarizer,
-    ling::{Doer, Instruction},
-    wit::Episode,
-};
+use crate::{Impression, Stimulus, Summarizer, wit::Episode};
 use async_trait::async_trait;
+use lingproc::{Doer, Instruction};
 use std::sync::Arc;
 use tokio::sync::broadcast;
 
@@ -14,7 +11,8 @@ use tokio::sync::broadcast;
 ///
 /// # Example
 /// ```no_run
-/// # use psyche::{wits::CombobulatorSummarizer, ling::{Doer, Instruction}, Impression, Stimulus, Summarizer, wit::Episode};
+/// # use psyche::{wits::CombobulatorSummarizer, Impression, Stimulus, Summarizer, wit::Episode};
+/// # use lingproc::{Doer, Instruction};
 /// # use async_trait::async_trait;
 /// # struct Dummy;
 /// # #[async_trait]
@@ -109,7 +107,7 @@ impl Summarizer<Episode, String> for CombobulatorSummarizer {
 impl CombobulatorSummarizer {
     /// Describe an image using the underlying [`Doer`].
     pub async fn describe_image(&self, image: &crate::ImageData) -> anyhow::Result<String> {
-        use crate::ling::ImageData as LImageData;
+        use lingproc::ImageData as LImageData;
         let caption = self
             .doer
             .follow(Instruction {

--- a/psyche/src/wits/episode_wit.rs
+++ b/psyche/src/wits/episode_wit.rs
@@ -1,9 +1,9 @@
 use crate::Instruction;
-use crate::ling::{Doer, Instruction as LlmInstruction};
 use crate::topics::{Topic, TopicBus};
 use crate::{Impression, Stimulus, WitReport};
 use async_trait::async_trait;
 use futures::StreamExt;
+use lingproc::{Doer, Instruction as LlmInstruction};
 use std::sync::{
     Arc, Mutex,
     atomic::{AtomicBool, Ordering},

--- a/psyche/src/wits/fond_du_coeur.rs
+++ b/psyche/src/wits/fond_du_coeur.rs
@@ -1,9 +1,6 @@
-use crate::{
-    Impression, Stimulus, Summarizer,
-    ling::{Doer, Instruction},
-    wit::Moment,
-};
+use crate::{Impression, Stimulus, Summarizer, wit::Moment};
 use async_trait::async_trait;
+use lingproc::{Doer, Instruction};
 use std::sync::{Arc, Mutex};
 use tokio::sync::broadcast;
 

--- a/psyche/src/wits/heart_wit.rs
+++ b/psyche/src/wits/heart_wit.rs
@@ -1,9 +1,6 @@
-use crate::{
-    Impression, Motor, Stimulus,
-    ling::{Doer, Instruction},
-    wit::Wit,
-};
+use crate::{Impression, Motor, Stimulus, wit::Wit};
 use async_trait::async_trait;
+use lingproc::{Doer, Instruction};
 use std::sync::{Arc, Mutex};
 use tokio::sync::broadcast;
 

--- a/psyche/src/wits/memory.rs
+++ b/psyche/src/wits/memory.rs
@@ -1,7 +1,7 @@
-use crate::ling::Vectorizer;
 use crate::{Impression, Stimulus};
 use anyhow::Result;
 use async_trait::async_trait;
+use lingproc::Vectorizer;
 use serde::Serialize;
 use serde_json::Value;
 use std::sync::Arc;

--- a/psyche/src/wits/moment_wit.rs
+++ b/psyche/src/wits/moment_wit.rs
@@ -1,8 +1,8 @@
-use crate::ling::{Doer, Instruction};
 use crate::topics::{Topic, TopicBus};
 use crate::{Impression, Stimulus, WitReport};
 use async_trait::async_trait;
 use futures::StreamExt;
+use lingproc::{Doer, Instruction};
 use std::sync::{Arc, Mutex};
 use tokio::sync::broadcast;
 use tracing::debug;

--- a/psyche/src/wits/quick.rs
+++ b/psyche/src/wits/quick.rs
@@ -10,12 +10,12 @@
 //! window. On [`tick`], it condenses the recent sensations into a single
 //! [`Instant`] and publishes it on [`Topic::Instant`].
 
-use crate::ling::{Doer, Instruction};
 use crate::topics::{Topic, TopicBus};
 use crate::{Impression, Instant, Sensation, Stimulus};
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
 use futures::StreamExt;
+use lingproc::{Doer, Instruction};
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 use tokio::sync::broadcast;

--- a/psyche/src/wits/situation_wit.rs
+++ b/psyche/src/wits/situation_wit.rs
@@ -1,8 +1,8 @@
-use crate::ling::{Doer, Instruction};
 use crate::topics::{Topic, TopicBus};
 use crate::{Impression, Stimulus, WitReport};
 use async_trait::async_trait;
 use futures::StreamExt;
+use lingproc::{Doer, Instruction};
 use std::sync::{Arc, Mutex};
 use tokio::sync::broadcast;
 use tracing::debug;

--- a/psyche/src/wits/vision_wit.rs
+++ b/psyche/src/wits/vision_wit.rs
@@ -1,10 +1,10 @@
 use crate::ImageData;
-use crate::ling::{Doer, Instruction};
 use crate::traits::observer::SensationObserver;
 use crate::traits::wit::Wit;
 use crate::{Impression, Stimulus};
 use async_trait::async_trait;
 use lingproc::ImageData as LImageData;
+use lingproc::{Doer, Instruction};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use tokio::sync::{Semaphore, broadcast};

--- a/psyche/src/wits/will.rs
+++ b/psyche/src/wits/will.rs
@@ -1,10 +1,10 @@
 use crate::instruction::{Instruction, parse_instructions};
-use crate::ling::{Doer, Instruction as LlmInstruction};
 use crate::prompt::{PromptBuilder, WillPrompt};
 use crate::topics::{Topic, TopicBus};
 use crate::{Impression, Stimulus, WitReport};
 use async_trait::async_trait;
 use futures::StreamExt;
+use lingproc::{Doer, Instruction as LlmInstruction};
 use std::sync::{Arc, Mutex};
 use tokio::sync::broadcast;
 use tracing::{debug, info};

--- a/psyche/src/wits/will_summarizer.rs
+++ b/psyche/src/wits/will_summarizer.rs
@@ -1,10 +1,8 @@
 use crate::motorcall::MotorRegistry;
 use crate::prompt::PromptBuilder;
-use crate::{
-    Impression, Stimulus, Summarizer,
-    ling::{Doer, Instruction},
-};
+use crate::{Impression, Stimulus, Summarizer};
 use async_trait::async_trait;
+use lingproc::{Doer, Instruction};
 use quick_xml::{Reader, events::Event};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -24,7 +22,8 @@ use tracing::info;
 ///
 /// # Example
 /// ```no_run
-/// # use psyche::{Will, ling::{Doer, Instruction}, Impression, Stimulus, Summarizer};
+/// # use psyche::{Will, Impression, Stimulus, Summarizer};
+/// # use lingproc::{Doer, Instruction};
 /// # use async_trait::async_trait;
 /// # struct Dummy;
 /// # #[async_trait]

--- a/psyche/tests/channel_capacity.rs
+++ b/psyche/tests/channel_capacity.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use psyche::ling::{Chatter, Doer, Instruction, Message, Vectorizer};
+use lingproc::{Chatter, Doer, Instruction, Message, Vectorizer};
 use psyche::wits::memory::Memory;
 use psyche::{Ear, Mouth, Psyche};
 use serde_json::Value;
@@ -26,7 +26,7 @@ impl Ear for Dummy {
 
 #[async_trait]
 impl Chatter for Dummy {
-    async fn chat(&self, _s: &str, _h: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+    async fn chat(&self, _s: &str, _h: &[Message]) -> anyhow::Result<lingproc::ChatStream> {
         Ok(Box::pin(once(Ok("ok".into()))))
     }
     async fn update_prompt_context(&self, _c: &str) {}

--- a/psyche/tests/combobulator.rs
+++ b/psyche/tests/combobulator.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use psyche::ling::{Doer, Instruction};
+use lingproc::{Doer, Instruction};
 use psyche::{Impression, Stimulus, Summarizer, wit::Episode, wits::CombobulatorSummarizer};
 
 #[derive(Clone)]

--- a/psyche/tests/converse.rs
+++ b/psyche/tests/converse.rs
@@ -1,7 +1,7 @@
 // TODO: Fix hung tests
 
 // use async_trait::async_trait;
-// use psyche::ling::{Chatter, Doer, Instruction, Message, Vectorizer};
+// use lingproc::{Chatter, Doer, Instruction, Message, Vectorizer};
 // use psyche::{Ear, Event, Mouth, Psyche, Sensation};
 // use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -29,7 +29,7 @@
 
 //     #[async_trait]
 //     impl Chatter for BlankFirstLLM {
-//         async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+//         async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<lingproc::ChatStream> {
 //             let stream = tokio_stream::iter(vec![Ok("  ".to_string()), Ok("hello".to_string())]);
 //             Ok(Box::pin(stream))
 //         }
@@ -140,7 +140,7 @@
 
 // #[async_trait]
 // impl Chatter for Dummy {
-//     async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+//     async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<lingproc::ChatStream> {
 //         Ok(Box::pin(tokio_stream::once(Ok("hello world".to_string()))))
 //     }
 // }
@@ -163,7 +163,7 @@
 
 //     #[async_trait]
 //     impl Chatter for CountingChatter {
-//         async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+//         async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<lingproc::ChatStream> {
 //             self.calls.fetch_add(1, Ordering::SeqCst);
 //             Ok(Box::pin(tokio_stream::once(Ok("hi".to_string()))))
 //         }
@@ -311,7 +311,7 @@
 
 //     #[async_trait]
 //     impl Chatter for SilentLLM {
-//         async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+//         async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<lingproc::ChatStream> {
 //             Ok(Box::pin(tokio_stream::once(Ok(String::new()))))
 //         }
 //     }
@@ -389,7 +389,7 @@
 
 //     #[async_trait]
 //     impl Chatter for SilentLLM {
-//         async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+//         async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<lingproc::ChatStream> {
 //             Ok(Box::pin(tokio_stream::once(Ok(String::new()))))
 //         }
 //     }
@@ -467,7 +467,7 @@
 //             &self,
 //             system_prompt: &str,
 //             _: &[Message],
-//         ) -> anyhow::Result<psyche::ling::ChatStream> {
+//         ) -> anyhow::Result<lingproc::ChatStream> {
 //             assert!(system_prompt.contains("You are PETE"));
 //             Ok(Box::pin(tokio_stream::once(Ok("hi 🙂".to_string()))))
 //         }

--- a/psyche/tests/episode_wit.rs
+++ b/psyche/tests/episode_wit.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use psyche::ling::{Doer, Instruction as LlmInstruction};
+use lingproc::{Doer, Instruction as LlmInstruction};
 use psyche::topics::{Topic, TopicBus};
 use psyche::wits::EpisodeWit;
 use psyche::{Impression, Instruction, Stimulus, Wit};

--- a/psyche/tests/experience.rs
+++ b/psyche/tests/experience.rs
@@ -1,7 +1,7 @@
 // // TODO Fix hung test
 
 // use async_trait::async_trait;
-// use psyche::ling::{Chatter, Doer, Instruction, Message, Vectorizer};
+// use lingproc::{Chatter, Doer, Instruction, Message, Vectorizer};
 // use psyche::wit::Wit;
 // use psyche::{Ear, Event, Impression, Mouth, Psyche, Sensation};
 // use std::sync::{Arc, Mutex};
@@ -45,7 +45,7 @@
 
 // #[async_trait]
 // impl Chatter for Dummy {
-//     async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+//     async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<lingproc::ChatStream> {
 //         Ok(Box::pin(tokio_stream::once(Ok("hello".to_string()))))
 //     }
 // }

--- a/psyche/tests/experience_tick.rs
+++ b/psyche/tests/experience_tick.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use psyche::ling::{Chatter, Doer, Instruction, Message, Vectorizer};
+use lingproc::{Chatter, Doer, Instruction, Message, Vectorizer};
 use psyche::{Ear, Impression, Mouth, Psyche, wit::Wit};
 use std::sync::{
     Arc,
@@ -28,7 +28,7 @@ impl Ear for Dummy {
 
 #[async_trait]
 impl Chatter for Dummy {
-    async fn chat(&self, _s: &str, _h: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+    async fn chat(&self, _s: &str, _h: &[Message]) -> anyhow::Result<lingproc::ChatStream> {
         Ok(Box::pin(once(Ok("ok".into()))))
     }
     async fn update_prompt_context(&self, _c: &str) {}

--- a/psyche/tests/face_sensor.rs
+++ b/psyche/tests/face_sensor.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use futures::{StreamExt, pin_mut};
-use psyche::ling::{Chatter, Doer, Instruction, Message, Vectorizer};
+use lingproc::{Chatter, Doer, Instruction, Message, Vectorizer};
 use psyche::{
     Ear, ImageData, Mouth, Psyche, Sensation, Sensor, Topic,
     sensors::face::{DummyDetector, FaceDetector, FaceInfo, FaceSensor},
@@ -33,7 +33,7 @@ async fn emits_face_info() {
     }
     #[async_trait]
     impl Chatter for Dummy {
-        async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+        async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<lingproc::ChatStream> {
             Ok(Box::pin(tokio_stream::once(Ok("hi".to_string()))))
         }
     }

--- a/psyche/tests/heart_wit.rs
+++ b/psyche/tests/heart_wit.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use psyche::ling::{Doer, Instruction};
+use lingproc::{Doer, Instruction};
 use psyche::wits::HeartWit;
 use psyche::{Impression, Motor, Stimulus, Wit};
 use std::sync::{Arc, Mutex};

--- a/psyche/tests/identity_wit.rs
+++ b/psyche/tests/identity_wit.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use psyche::ling::{Doer, Instruction};
+use lingproc::{Doer, Instruction};
 use psyche::wit::{Moment, Wit};
 use psyche::wits::{FondDuCoeur, IdentityWit};
 use psyche::{Impression, Stimulus};

--- a/psyche/tests/ling.rs
+++ b/psyche/tests/ling.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use psyche::ling::{Chatter, Doer, Instruction, Message, Vectorizer};
+use lingproc::{Chatter, Doer, Instruction, Message, Vectorizer};
 use tokio_stream::StreamExt;
 
 struct Dummy;
@@ -13,7 +13,7 @@ impl Doer for Dummy {
 
 #[async_trait]
 impl Chatter for Dummy {
-    async fn chat(&self, _s: &str, h: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+    async fn chat(&self, _s: &str, h: &[Message]) -> anyhow::Result<lingproc::ChatStream> {
         let msg = format!("say:{}", h.len());
         Ok(Box::pin(tokio_stream::once(Ok(msg))))
     }

--- a/psyche/tests/liveness.rs
+++ b/psyche/tests/liveness.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use psyche::ling::{Chatter, Doer, Instruction, Message, Vectorizer};
+use lingproc::{Chatter, Doer, Instruction, Message, Vectorizer};
 use psyche::{Ear, Mouth, Psyche};
 use std::sync::{
     Arc,
@@ -31,7 +31,7 @@ impl Ear for Dummy {
 
 #[async_trait]
 impl Chatter for Dummy {
-    async fn chat(&self, _s: &str, _h: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+    async fn chat(&self, _s: &str, _h: &[Message]) -> anyhow::Result<lingproc::ChatStream> {
         Ok(Box::pin(once(Ok("ok".into()))))
     }
     async fn update_prompt_context(&self, _c: &str) {}

--- a/psyche/tests/memory_integration.rs
+++ b/psyche/tests/memory_integration.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use psyche::ling::Vectorizer;
+use lingproc::Vectorizer;
 use psyche::{BasicMemory, GraphStore, Impression, Memory, QdrantClient, Stimulus};
 use serde_json::{Value, json};
 use std::sync::{Arc, Mutex};

--- a/psyche/tests/memory_timeout.rs
+++ b/psyche/tests/memory_timeout.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use psyche::ling::Vectorizer;
+use lingproc::Vectorizer;
 use psyche::{BasicMemory, GraphStore, Impression, Memory, QdrantClient, Stimulus};
 use serde_json::{Value, json};
 use std::sync::{Arc, Mutex};

--- a/psyche/tests/moment_wit.rs
+++ b/psyche/tests/moment_wit.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use psyche::ling::{Doer, Instruction as LlmInstruction};
+use lingproc::{Doer, Instruction as LlmInstruction};
 use psyche::topics::{Topic, TopicBus};
 use psyche::wits::MomentWit;
 use psyche::{Impression, Stimulus, Wit};

--- a/psyche/tests/prompt.rs
+++ b/psyche/tests/prompt.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use psyche::ling::{Chatter, Doer, Instruction, Message, Vectorizer};
+use lingproc::{Chatter, Doer, Instruction, Message, Vectorizer};
 use psyche::{DEFAULT_SYSTEM_PROMPT, Ear, Mouth, Psyche};
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -38,7 +38,7 @@ impl Doer for Dummy {
 
 #[async_trait]
 impl Chatter for Dummy {
-    async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+    async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<lingproc::ChatStream> {
         Ok(Box::pin(tokio_stream::once(Ok("hi".to_string()))))
     }
 }

--- a/psyche/tests/situation_wit.rs
+++ b/psyche/tests/situation_wit.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use psyche::ling::{Doer, Instruction as LlmInstruction};
+use lingproc::{Doer, Instruction as LlmInstruction};
 use psyche::topics::{Topic, TopicBus};
 use psyche::wits::SituationWit;
 use psyche::{Impression, Stimulus, Wit};

--- a/psyche/tests/topic_bus.rs
+++ b/psyche/tests/topic_bus.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use futures::{StreamExt, pin_mut};
-use psyche::ling::{Chatter, Doer, Instruction, Message, Vectorizer};
+use lingproc::{Chatter, Doer, Instruction, Message, Vectorizer};
 use psyche::{Ear, Mouth, Psyche, Topic};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -40,7 +40,7 @@ impl Doer for Dummy {
 
 #[async_trait]
 impl Chatter for Dummy {
-    async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+    async fn chat(&self, _: &str, _: &[Message]) -> anyhow::Result<lingproc::ChatStream> {
         Ok(Box::pin(tokio_stream::once(Ok("hi".to_string()))))
     }
 }

--- a/psyche/tests/vision_wit.rs
+++ b/psyche/tests/vision_wit.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use psyche::ling::{Doer, Instruction};
+use lingproc::{Doer, Instruction};
 use psyche::{ImageData, Impression, Stimulus, VisionWit, Wit};
 use std::sync::Arc;
 

--- a/psyche/tests/voice.rs
+++ b/psyche/tests/voice.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use psyche::ling::{ChatStream, Chatter, Doer, Instruction, Message};
+use lingproc::{ChatStream, Chatter, Doer, Instruction, Message};
 use psyche::{Event, Mouth};
 use psyche::{Voice, extract_emojis};
 use std::sync::Arc;

--- a/psyche/tests/voice_control.rs
+++ b/psyche/tests/voice_control.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use psyche::ling::{ChatStream, Chatter, Doer, Instruction, Message, Vectorizer};
+use lingproc::{ChatStream, Chatter, Doer, Instruction, Message, Vectorizer};
 use psyche::{Ear, Impression, Mouth, Psyche, Sensation, Stimulus, wit::Wit};
 use std::sync::{
     Arc,

--- a/psyche/tests/will.rs
+++ b/psyche/tests/will.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use psyche::ling::{Doer, Instruction};
+use lingproc::{Doer, Instruction};
 use psyche::{Impression, Stimulus, Summarizer, WillSummarizer};
 
 #[derive(Clone)]

--- a/psyche/tests/will_handle_output.rs
+++ b/psyche/tests/will_handle_output.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use psyche::ling::{Doer, Instruction};
+use lingproc::{Doer, Instruction};
 use psyche::motorcall::{Motor, MotorRegistry};
 use psyche::wits::WillSummarizer;
 use std::collections::HashMap;

--- a/psyche/tests/will_wit.rs
+++ b/psyche/tests/will_wit.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use futures::StreamExt;
-use psyche::ling::{Doer, Instruction as LlmInstruction};
+use lingproc::{Doer, Instruction as LlmInstruction};
 use psyche::topics::{Topic, TopicBus};
 use psyche::{Impression, Stimulus, Wit};
 use psyche::{Instruction, wits::Will};

--- a/psyche/tests/wit_panic.rs
+++ b/psyche/tests/wit_panic.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use psyche::ling::{Chatter, Doer, Instruction, Message, Vectorizer};
+use lingproc::{Chatter, Doer, Instruction, Message, Vectorizer};
 use psyche::{Ear, Impression, Mouth, Psyche, Wit};
 use std::sync::Arc;
 use std::time::Duration;
@@ -25,7 +25,7 @@ impl Ear for Dummy {
 
 #[async_trait]
 impl Chatter for Dummy {
-    async fn chat(&self, _s: &str, _h: &[Message]) -> anyhow::Result<psyche::ling::ChatStream> {
+    async fn chat(&self, _s: &str, _h: &[Message]) -> anyhow::Result<lingproc::ChatStream> {
         Ok(Box::pin(once(Ok("ok".into()))))
     }
     async fn update_prompt_context(&self, _c: &str) {}

--- a/psyche/tests/wit_report.rs
+++ b/psyche/tests/wit_report.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use psyche::ling::{Doer, Instruction};
+use lingproc::{Doer, Instruction};
 use psyche::{Impression, Stimulus, Summarizer, WillSummarizer, WitReport};
 use tokio::sync::broadcast;
 


### PR DESCRIPTION
## Summary
- swap all `psyche::ling::` references for `lingproc::`
- import lingproc in crates and docs

## Testing
- `RUST_LOG=debug cargo test` *(fails: test timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6858d348e7c083208d124104ceefce03