### PR TITLE
Rename Ling to PromptBuilder

### DIFF
--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -65,7 +65,7 @@ mod motor;
 pub mod motorcall;
 mod plain_mouth;
 mod prehension;
-mod prompt;
+pub mod prompt;
 mod sensor;
 mod task_group;
 pub mod sensors {
@@ -86,14 +86,14 @@ pub use motor::{Motor, NoopMotor};
 pub use pending_turn::PendingTurn;
 pub use plain_mouth::PlainMouth;
 pub use prehension::Prehension;
-pub use prompt::{CombobulatorPrompt, ContextualPrompt, PromptBuilder, VoicePrompt, WillPrompt};
+pub use prompt::{CombobulatorPrompt, ContextualPrompt, VoicePrompt, WillPrompt};
 pub use psyche::DEFAULT_SYSTEM_PROMPT;
 pub use sensor::Sensor;
 pub use topics::{Topic, TopicBus, TopicMessage};
 pub use trim_mouth::TrimMouth;
 pub use types::{GeoLoc, Heartbeat, ImageData, ObjectInfo};
 
-pub use ling::{Feeling, Ling};
+pub use ling::{Feeling, PromptBuilder};
 pub use psyche::extract_tag as test_extract_tag;
 pub use psyche::{Conversation, Psyche};
 pub use sensation::{Event, Instant, Sensation, WitReport};

--- a/psyche/src/ling.rs
+++ b/psyche/src/ling.rs
@@ -1,4 +1,7 @@
-//! Linguistic helpers and prompt assembly utilities.
+//! Prompt assembly utilities.
+//!
+//! The [`PromptBuilder`] struct combines conversation history, mood and
+//! temporary notes to produce the system prompt given to language models.
 
 use lingproc::Message;
 
@@ -13,7 +16,7 @@ pub struct Feeling {
 }
 
 /// Central prompt builder combining conversation, mood and notes.
-pub struct Ling {
+pub struct PromptBuilder {
     conversation: std::sync::Arc<Mutex<Conversation>>,
     system_prompt: String,
     senses: Vec<String>,
@@ -21,8 +24,8 @@ pub struct Ling {
     mood: Option<Feeling>,
 }
 
-impl Ling {
-    /// Create a new `Ling` using `system_prompt` and shared `conversation`.
+impl PromptBuilder {
+    /// Create a new `PromptBuilder` using `system_prompt` and shared `conversation`.
     pub fn new(
         system_prompt: impl Into<String>,
         conversation: std::sync::Arc<Mutex<Conversation>>,

--- a/psyche/tests/contextual_prompt.rs
+++ b/psyche/tests/contextual_prompt.rs
@@ -1,5 +1,6 @@
+use psyche::prompt::PromptBuilder;
 use psyche::topics::{Topic, TopicBus};
-use psyche::{ContextualPrompt, Impression, PromptBuilder, Stimulus};
+use psyche::{ContextualPrompt, Impression, Stimulus};
 use tokio::time::{Duration, sleep};
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- rename `Ling` struct to `PromptBuilder`
- update prompt module docs and exports
- update Psyche internals and tests to use `PromptBuilder`

## Testing
- `cargo test --lib`

------
https://chatgpt.com/codex/tasks/task_e_6858dcb0026c83209b8f1b04e447c16f