### PR TITLE
Rename AppState to Body

### DIFF
--- a/pete/src/lib.rs
+++ b/pete/src/lib.rs
@@ -20,7 +20,7 @@
 //!
 //! ## Components
 //!
-//! - [`AppState`]: Shared state container for the live app
+//! - [`Body`]: Shared state container for the live app
 //! - [`main.rs`]: Pete’s entry point and lifecycle wiring
 //! - [`psyche_factory.rs`]: Assembles the cognitive architecture (Wits, Topics,
 //!   Memory)
@@ -63,6 +63,6 @@ pub use simulator::Simulator;
 #[cfg(feature = "tts")]
 pub use tts_mouth::{CoquiTts, Tts, TtsMouth, TtsStream};
 pub use web::{
-    AppState, WsRequest, app, conversation_log, index, listen_user_input, log_ws_handler,
-    psyche_debug, toggle_wit_debug, wit_debug_page, ws_handler,
+    Body, WsRequest, app, conversation_log, index, listen_user_input, log_ws_handler, psyche_debug,
+    toggle_wit_debug, wit_debug_page, ws_handler,
 };

--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -11,7 +11,7 @@ use pete::FaceSensor;
 use pete::GeoSensor;
 use pete::HeartbeatSensor;
 use pete::{
-    AppState, ChannelMouth, LoggingMotor, NoopEar, NoopMouth, NoopSensor, app, init_logging,
+    Body, ChannelMouth, LoggingMotor, NoopEar, NoopMouth, NoopSensor, app, init_logging,
     listen_user_input,
 };
 #[cfg(feature = "tts")]
@@ -299,7 +299,7 @@ async fn main() -> anyhow::Result<()> {
         psyche.run().await;
     });
 
-    let state = AppState {
+    let state = Body {
         bus: bus.clone(),
         ear: ear.clone(),
         eye: eye.clone(),

--- a/pete/tests/conversation.rs
+++ b/pete/tests/conversation.rs
@@ -1,5 +1,5 @@
 use axum::{body, extract::State, response::IntoResponse};
-use pete::{AppState, ChannelEar, EventBus, EyeSensor, GeoSensor, conversation_log, dummy_psyche};
+use pete::{Body, ChannelEar, EventBus, EyeSensor, GeoSensor, conversation_log, dummy_psyche};
 use psyche::Sensor;
 use std::sync::{
     Arc,
@@ -23,7 +23,7 @@ async fn returns_log_json() {
     psyche.add_sense(eye.description());
     psyche.add_sense(geo.description());
     let debug = psyche.debug_handle();
-    let state = AppState {
+    let state = Body {
         bus: bus.clone(),
         ear,
         eye,

--- a/pete/tests/ws_audio.rs
+++ b/pete/tests/ws_audio.rs
@@ -1,6 +1,6 @@
 use axum::{Router, routing::get, serve};
 use futures::StreamExt;
-use pete::{AppState, ChannelEar, EventBus, EyeSensor, GeoSensor, dummy_psyche, ws_handler};
+use pete::{Body, ChannelEar, EventBus, EyeSensor, GeoSensor, dummy_psyche, ws_handler};
 use psyche::Event;
 use psyche::Sensor;
 use std::sync::{
@@ -25,7 +25,7 @@ async fn websocket_forwards_audio() {
     let (bus, _user_rx) = EventBus::new();
     let bus = Arc::new(bus);
     let debug = psyche.debug_handle();
-    let state = AppState {
+    let state = Body {
         bus: bus.clone(),
         ear,
         eye,

--- a/pete/tests/ws_geolocate.rs
+++ b/pete/tests/ws_geolocate.rs
@@ -1,6 +1,6 @@
 use axum::{Router, routing::get, serve};
 use futures::{SinkExt, StreamExt};
-use pete::{AppState, ChannelEar, EventBus, EyeSensor, GeoSensor, dummy_psyche, ws_handler};
+use pete::{Body, ChannelEar, EventBus, EyeSensor, GeoSensor, dummy_psyche, ws_handler};
 use psyche::{GeoLoc, Sensor};
 use std::sync::{
     Arc,
@@ -26,7 +26,7 @@ async fn websocket_forwards_geolocation() {
     let (bus, _user_rx) = EventBus::new();
     let bus = Arc::new(bus);
     let debug = psyche.debug_handle();
-    let state = AppState {
+    let state = Body {
         bus: bus.clone(),
         ear,
         eye,


### PR DESCRIPTION
## Summary
- rename `AppState` struct to `Body`
- update doc comment to describe Body's responsibilities
- adjust imports and usages across server and tests

## Testing
- `cargo fmt`
- `RUST_LOG=debug cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6858e8c866f8832090efa604737a69d0