### PR TITLE
Improve conversation scroll retention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ Cargo.lock
 /ollama
 .env
 debug.log
+node_modules/
+package-lock.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,8 @@ The previous Deno-based client has been removed. Update the files in
 * Define CSS variables in `styles.css` to control colors and fonts.
 * Keep the thought bubble hidden until there is text to display.
 * Style the thought bubble with cloud-like lobes and center-bottom connectors.
+* When updating the conversation log, preserve scroll position unless the user
+  was already at the bottom.
 * Serve over HTTPS by passing `--tls-cert` and `--tls-key` to the `pete` binary.
 * Canvas elements that repeatedly call `getImageData` must obtain their context
   with `{ willReadFrequently: true }`.

--- a/frontend/dist/app.js
+++ b/frontend/dist/app.js
@@ -10,6 +10,7 @@
   const imageThumbnail = document.getElementById("image-thumbnail");
   const player = document.getElementById("audio-player");
   const audioQueue = [];
+  const conversationLog = document.getElementById("conversation-log");
   const witOutputs = {};
   const witDetails = {};
   const witDebugContainer = document.getElementById("wit-debug");
@@ -258,10 +259,16 @@
       if (system && msgs.length) {
         system.textContent = msgs[0].content;
       }
-      document.getElementById("conversation-log").textContent = msgs
+      const atBottom =
+        conversationLog.scrollTop + conversationLog.clientHeight >=
+        conversationLog.scrollHeight - 5;
+      conversationLog.textContent = msgs
         .slice(1)
         .map((m) => `${m.role}: ${m.content}`)
         .join("\n");
+      if (atBottom) {
+        conversationLog.scrollTop = conversationLog.scrollHeight;
+      }
     } catch (e) {
       console.error("conversation", e);
     }

--- a/frontend/test/conversation-scroll.test.js
+++ b/frontend/test/conversation-scroll.test.js
@@ -1,0 +1,23 @@
+const assert = require('assert');
+
+function updateConversation(log, msgs) {
+  const atBottom =
+    log.scrollTop + log.clientHeight >= log.scrollHeight - 5;
+  log.textContent = msgs.join('\n');
+  log.scrollHeight = log.textContent.length; // simple mock
+  if (atBottom) {
+    log.scrollTop = log.scrollHeight;
+  }
+}
+
+// starts at bottom
+const log = {scrollTop: 100, clientHeight: 20, scrollHeight: 100, textContent: ''};
+updateConversation(log, ['a', 'b', 'c']);
+assert.strictEqual(log.scrollTop, log.scrollHeight);
+
+// user scrolled up
+const log2 = {scrollTop: 0, clientHeight: 20, scrollHeight: 100, textContent: ''};
+updateConversation(log2, ['a', 'b']);
+assert.strictEqual(log2.scrollTop, 0);
+
+console.log('ok');

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "daringsby",
+  "version": "1.0.0",
+  "description": "This repository contains a Rust workspace with three crates:",
+  "main": "index.js",
+  "scripts": {
+    "test": "node frontend/test/conversation-scroll.test.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "jsdom": "^26.1.0"
+  }
+}


### PR DESCRIPTION
## Summary
- keep conversation log pinned when already scrolled to the bottom
- document the new behaviour in AGENTS.md
- ignore `node_modules` and add a simple JS test

## Testing
- `npm test`
- `cargo test` *(fails: tests hang or take too long)*

------
https://chatgpt.com/codex/tasks/task_e_6858f1d3d4e08320a3757327d9aa8e2d