### PR TITLE
Consolidate cosine similarity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,3 +172,4 @@ This document reflects the current cognitive and runtime architecture of Pete Da
 * Features: `eye`, `face`, `geo`, `ear`, `heartbeat`.
 * `all-sensors` enables them all and is used by default.
 * `HeartbeatSensor::test_interval` helps with short test delays.
+\n* In doctests, use `crate::` paths to reference items within the same crate.

--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -4,6 +4,7 @@ mod instruction;
 pub mod psyche;
 pub mod sensation;
 pub mod topics;
+pub mod util;
 mod voice;
 
 pub mod traits {

--- a/psyche/src/sensors/face.rs
+++ b/psyche/src/sensors/face.rs
@@ -1,5 +1,6 @@
 use crate::topics::TopicBus;
 use crate::traits::Sensor;
+use crate::util::math::cosine_similarity;
 use crate::wits::memory::QdrantClient;
 use crate::{ImageData, Sensation};
 use anyhow::Result;
@@ -34,16 +35,6 @@ impl FaceDetector for DummyDetector {
     async fn detect_faces(&self, image: &ImageData) -> Result<Vec<(ImageData, Vec<f32>)>> {
         Ok(vec![(image.clone(), vec![0.0])])
     }
-}
-
-fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
-    if a.is_empty() || b.is_empty() {
-        return 0.0;
-    }
-    let dot: f32 = a.iter().zip(b).map(|(x, y)| x * y).sum();
-    let norm_a: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
-    let norm_b: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
-    dot / (norm_a * norm_b + 1e-5)
 }
 
 /// Sensor that emits [`FaceInfo`] sensations.

--- a/psyche/src/util/math.rs
+++ b/psyche/src/util/math.rs
@@ -1,0 +1,40 @@
+/// Mathematical utilities for embeddings and vector operations.
+///
+/// # Examples
+///
+/// ```
+/// use crate::util::math::cosine_similarity;
+/// let a = [1.0_f32, 0.0, 0.0];
+/// let b = [0.5_f32, 0.0, 0.0];
+/// assert!((cosine_similarity(&a, &b) - 1.0).abs() < 1e-6);
+/// ```
+pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    if a.is_empty() || b.is_empty() {
+        return 0.0;
+    }
+    let dot: f32 = a.iter().zip(b).map(|(x, y)| x * y).sum();
+    let norm_a: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+    let norm_b: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+    dot / (norm_a * norm_b + 1e-5)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_similarity_for_empty() {
+        assert_eq!(cosine_similarity(&[], &[]), 0.0);
+        assert_eq!(cosine_similarity(&[1.0], &[]), 0.0);
+    }
+
+    #[test]
+    fn similarity_basic() {
+        let a = [1.0_f32, 2.0, 3.0];
+        let b = [1.0_f32, 2.0, 3.0];
+        assert!((cosine_similarity(&a, &b) - 1.0).abs() < 1e-6);
+
+        let b = [0.0_f32, 0.0, 0.0];
+        assert_eq!(cosine_similarity(&a, &b), 0.0);
+    }
+}

--- a/psyche/src/util/mod.rs
+++ b/psyche/src/util/mod.rs
@@ -1,0 +1,3 @@
+//! Shared helper utilities used across the crate.
+
+pub mod math;

--- a/psyche/src/wits/entity_wit.rs
+++ b/psyche/src/wits/entity_wit.rs
@@ -1,6 +1,7 @@
 use crate::sensors::face::FaceInfo;
 use crate::traits::wit::Wit;
 use crate::types::ObjectInfo;
+use crate::util::math::cosine_similarity;
 use crate::wits::memory::Memory;
 use crate::wits::memory::QdrantClient;
 use crate::{Impression, Sensation, Stimulus};
@@ -14,13 +15,6 @@ use tokio::sync::broadcast;
 #[derive(Default)]
 pub struct InMemoryEmbeddingDb {
     vectors: Mutex<Vec<Vec<f32>>>,
-}
-
-fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
-    let dot: f32 = a.iter().zip(b).map(|(x, y)| x * y).sum();
-    let norm_a: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
-    let norm_b: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
-    dot / (norm_a * norm_b + 1e-5)
 }
 
 #[async_trait]


### PR DESCRIPTION
## Summary
- centralize `cosine_similarity` in `psyche::util::math`
- use the shared function from `FaceSensor` and `EntityWit`
- document and test the math utility
- remind in `AGENTS.md` to use crate paths in doctests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6858faddecac83208a9943df5ea697c6