### PR TITLE
Deduplicate Ollama provider setup

### DIFF
--- a/pete/src/lib.rs
+++ b/pete/src/lib.rs
@@ -36,6 +36,7 @@ mod event_bus;
 mod logging;
 mod motor;
 mod mouth;
+mod ollama;
 mod psyche_factory;
 mod sensor;
 mod simulator;
@@ -50,6 +51,7 @@ pub use event_bus::EventBus;
 pub use logging::init_logging;
 pub use motor::LoggingMotor;
 pub use mouth::{ChannelMouth, NoopMouth};
+pub use ollama::ollama_provider_from_args;
 #[cfg(feature = "face")]
 pub use psyche::FaceSensor;
 #[cfg(feature = "tts")]

--- a/pete/src/ollama.rs
+++ b/pete/src/ollama.rs
@@ -1,0 +1,23 @@
+use lingproc::OllamaProvider;
+
+/// Build an [`OllamaProvider`] from command line arguments.
+///
+/// This helper simply forwards the provided `host` and `model` strings to
+/// [`OllamaProvider::new`]. Use it to create providers from CLI or
+/// environment variables. The function returns an error if the host URL is
+/// invalid or if the given model is not available on the Ollama server.
+///
+/// ```
+/// use pete::ollama_provider_from_args;
+///
+/// let provider = ollama_provider_from_args("http://localhost:11434", "mistral")
+///     .expect("valid provider");
+/// ```
+///
+/// # Errors
+///
+/// Propagates any error returned by [`OllamaProvider::new`], such as an invalid
+/// URL or missing model.
+pub fn ollama_provider_from_args(host: &str, model: &str) -> anyhow::Result<OllamaProvider> {
+    Ok(OllamaProvider::new(host, model)?)
+}

--- a/pete/tests/provider_utils.rs
+++ b/pete/tests/provider_utils.rs
@@ -1,0 +1,20 @@
+use httpmock::Method::POST;
+use httpmock::MockServer;
+use lingproc::Vectorizer;
+use pete::ollama_provider_from_args;
+
+#[tokio::test]
+async fn builder_returns_provider() {
+    let server = MockServer::start_async().await;
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/api/embed");
+        then.status(200)
+            .header("content-type", "application/json")
+            .body("{\"embeddings\": [[1.0,2.0,3.0]]}");
+    });
+
+    let provider = ollama_provider_from_args(server.base_url().as_str(), "mistral").unwrap();
+    let vec = provider.vectorize("hello").await.unwrap();
+    mock.assert();
+    assert_eq!(vec, vec![1.0, 2.0, 3.0]);
+}


### PR DESCRIPTION
## Summary
- add `ollama_provider_from_args` helper
- reuse the helper in main and psyche_factory
- test the helper

## Testing
- `cargo fmt`
- `cargo fetch`
- `RUST_LOG=debug cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6858fb966cfc832096b2c8f4eab32442