### PR TITLE
Unify WebSocket types

### DIFF
--- a/frontend/dist/app.js
+++ b/frontend/dist/app.js
@@ -112,7 +112,7 @@
       player.removeEventListener("ended", done);
       player.removeEventListener("error", done);
       if (next.text) {
-        ws.send(JSON.stringify({ type: "Echo", data: next.text }));
+        ws.send(JSON.stringify({ type: "Echo", text: next.text }));
       }
       playNext();
     };
@@ -135,17 +135,14 @@
       const m = JSON.parse(ev.data);
       switch (m.type) {
         case "Emote":
-        case "emote":
           mien.textContent = m.data;
           break;
         case "Say":
-        case "say":
           words.textContent += "\n" + m.data.words;
           words.scrollTop = words.scrollHeight;
           enqueueAudio({ audio: m.data.audio || null, text: m.data.words });
           break;
-        case "Think":
-        case "think": {
+        case "Think": {
           if (typeof m.data === "object" && m.data !== null) {
             witOutputs[m.data.name] = m.data.output;
             const { promptPre, outputPre, time, details } = getWitDetail(m.data.name);
@@ -171,10 +168,6 @@
           thought.style.display = Object.keys(witOutputs).length ? "flex" : "none";
           break;
         }
-        case "Heard":
-        case "heard":
-          // ignore for now
-          break;
       }
     } catch (e) {
       console.error(e);
@@ -189,7 +182,7 @@
     const input = document.getElementById("text-input");
     const text = input.value.trim();
     if (text) {
-      ws.send(JSON.stringify({ type: "Text", data: text }));
+      ws.send(JSON.stringify({ type: "Text", text }));
       input.value = "";
     }
   });
@@ -237,7 +230,7 @@
           thoughtImage.style.display = "block";
           imageThumbnail.src = data;
           imageThumbnail.style.display = "block";
-          ws.send(JSON.stringify({ type: "See", data: data }));
+          ws.send(JSON.stringify({ type: "See", data }));
         } else {
           ws.send(JSON.stringify({ type: "See", data: "" }));
         }

--- a/frontend/dist/wit_debug.html
+++ b/frontend/dist/wit_debug.html
@@ -20,7 +20,7 @@
       ws.onmessage = (ev) => {
         try {
           const m = JSON.parse(ev.data);
-          if ((m.type === 'Think' || m.type === 'think') && m.data.name.toLowerCase() === label) {
+          if (m.type === 'Think' && m.data.name.toLowerCase() === label) {
             promptEl.textContent = m.data.prompt;
             streamEl.textContent = m.data.output;
           }

--- a/frontend/dist/ws_message.d.ts
+++ b/frontend/dist/ws_message.d.ts
@@ -1,0 +1,26 @@
+export interface GeoLoc {
+  longitude: number;
+  latitude: number;
+}
+
+export interface AudioData {
+  base64: string;
+  mime: string;
+}
+
+export interface WitReport {
+  name: string;
+  prompt: string;
+  output: string;
+}
+
+export type WsMessage =
+  | { type: "Say"; data: { words: string; audio?: string | null } }
+  | { type: "Emote"; data: string }
+  | { type: "Think"; data: WitReport }
+  | { type: "Text"; text: string }
+  | { type: "Echo"; text: string }
+  | { type: "See"; data: string; at?: string }
+  | { type: "Hear"; data: AudioData; at?: string }
+  | { type: "Geolocate"; data: GeoLoc; at?: string }
+  | { type: "Sense"; data: Record<string, any> };

--- a/pete/src/lib.rs
+++ b/pete/src/lib.rs
@@ -65,6 +65,6 @@ pub use simulator::Simulator;
 #[cfg(feature = "tts")]
 pub use tts_mouth::{CoquiTts, TtsMouth};
 pub use web::{
-    Body, WsRequest, app, conversation_log, index, listen_user_input, log_ws_handler, psyche_debug,
+    Body, app, conversation_log, index, listen_user_input, log_ws_handler, psyche_debug,
     toggle_wit_debug, wit_debug_page, ws_handler,
 };

--- a/psyche/Cargo.toml
+++ b/psyche/Cargo.toml
@@ -18,6 +18,7 @@ uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", default-features = false, features = ["serde", "clock"] }
 serde_json = "1"
 unicode-segmentation = "1"
+ts-rs = { version = "7", optional = true }
 emojis = "0.6"
 pulldown-cmark = "0.9"
 quick-xml = "0.31"
@@ -38,3 +39,4 @@ face = []
 geo = []
 ear = []
 all-sensors = ["eye", "face", "geo", "ear"]
+ts = ["ts-rs"]

--- a/psyche/src/sensation.rs
+++ b/psyche/src/sensation.rs
@@ -1,6 +1,8 @@
 use chrono::{DateTime, Utc};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+#[cfg(feature = "ts")]
+use ts_rs::TS;
 /// Event types emitted by the [`Psyche`] during conversation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Event {
@@ -13,7 +15,8 @@ pub enum Event {
 }
 
 /// Debug information emitted by a [`Wit`].
-#[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "ts", derive(TS))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WitReport {
     /// Name of the wit generating the prompt.
     pub name: String,

--- a/psyche/src/types.rs
+++ b/psyche/src/types.rs
@@ -1,5 +1,8 @@
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "ts")]
+use ts_rs::TS;
 
+#[cfg_attr(feature = "ts", derive(TS))]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ImageData {
     pub mime: String,
@@ -7,6 +10,7 @@ pub struct ImageData {
 }
 
 /// Latitude/longitude coordinates from a positioning sensor.
+#[cfg_attr(feature = "ts", derive(TS))]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GeoLoc {
     /// Longitude in decimal degrees.

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -8,6 +8,10 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # ts_rs only used when compiling for wasm
 ts-rs = { version = "7", optional = true }
+psyche = { path = "../psyche" }
 
 [features]
 ts = ["ts-rs"]
+
+[build-dependencies]
+ts-rs = { version = "7", optional = true }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1,29 +1,50 @@
+use psyche::{GeoLoc, WitReport};
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "ts")]
+use ts_rs::TS;
 
-#[cfg_attr(all(target_arch = "wasm32", feature = "ts"), derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[cfg_attr(
+    feature = "ts",
+    ts(export, export_to = "../frontend/dist/ws_message.ts")
+)]
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(tag = "type", content = "data")]
-pub enum MessageType {
+#[serde(tag = "type", rename_all = "PascalCase", content = "data")]
+pub enum WsPayload {
     Say {
         words: String,
-        audio: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        audio: Option<String>,
     },
     Emote(String),
-    Think(String),
-    Heard(String),
-    Text(String),
-    See(String),
+    Think(WitReport),
+    Text {
+        text: String,
+    },
+    Echo {
+        text: String,
+    },
+    See {
+        data: String,
+        at: Option<String>,
+    },
     Hear {
-        base64: String,
-        mime: String,
+        data: AudioData,
+        at: Option<String>,
     },
     Geolocate {
-        longitude: f64,
-        latitude: f64,
+        data: GeoLoc,
+        at: Option<String>,
     },
-    MotorCommand {
-        target: String,
-        command: String,
-        args: serde_json::Value,
+    Sense {
+        #[cfg_attr(feature = "ts", ts(type = "Record<string, any>"))]
+        data: serde_json::Value,
     },
+}
+
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct AudioData {
+    pub base64: String,
+    pub mime: String,
 }


### PR DESCRIPTION
## Summary
- consolidate WebSocket message schema in `shared` crate
- export TypeScript definitions for the frontend
- update server code to use the unified `WsPayload` enum
- adjust frontend to rely on canonical message names

## Testing
- `npm test`
- `cargo test --workspace` *(fails: test ws_audio in pete)*

------
https://chatgpt.com/codex/tasks/task_e_6858fb4120ec8320b53e6660ab71c3fb