### PR TITLE
Rename motorcall trait

### DIFF
--- a/psyche/src/motorcall.rs
+++ b/psyche/src/motorcall.rs
@@ -1,12 +1,12 @@
-//! Host-side motor execution.
+//! Execute dynamically parsed instructions.
 //!
-//! The [`Motor`] trait represents an actuator that Pete can invoke via a
-//! `<motor>` tag emitted by the [`Will`](crate::wits::Will) cognitive
+//! The [`InstructionExecutor`] trait represents a generic actuator that Pete can
+//! invoke via a `<motor>` tag emitted by the [`Will`](crate::wits::Will)
 //! component. Each implementation performs a real-world action using the given
 //! attributes and body content.
 //!
 //! ```
-//! use psyche::motorcall::{Motor, MotorRegistry};
+//! use psyche::motorcall::{InstructionExecutor, InstructionRegistry};
 //! use async_trait::async_trait;
 //! use std::sync::Arc;
 //! use std::collections::HashMap;
@@ -16,14 +16,14 @@
 //! struct RecMotor(std::sync::Mutex<Vec<(HashMap<String, String>, String)>>);
 //!
 //! #[async_trait]
-//! impl Motor for RecMotor {
+//! impl InstructionExecutor for RecMotor {
 //!     async fn execute(&self, attrs: HashMap<String, String>, content: String) {
 //!         self.0.lock().unwrap().push((attrs, content));
 //!     }
 //! }
 //!
 //! # async fn doc() {
-//! let mut registry = MotorRegistry::default();
+//! let mut registry = InstructionRegistry::default();
 //! let motor = Arc::new(RecMotor::default());
 //! registry.register("say", motor.clone());
 //! registry
@@ -39,14 +39,14 @@
 /// A simple logging motor implementation.
 ///
 /// ```
-/// use psyche::motorcall::Motor;
+/// use psyche::motorcall::InstructionExecutor;
 /// use async_trait::async_trait;
 /// use std::collections::HashMap;
 ///
 /// pub struct LoggingMotor;
 ///
 /// #[async_trait]
-/// impl Motor for LoggingMotor {
+/// impl InstructionExecutor for LoggingMotor {
 ///     async fn execute(&self, attrs: HashMap<String, String>, content: String) {
 ///         tracing::info!(?attrs, %content, "MOTOR fired");
 ///     }
@@ -56,7 +56,7 @@
 /// A text-to-speech motor might look like:
 ///
 /// ```
-/// use psyche::motorcall::Motor;
+/// use psyche::motorcall::InstructionExecutor;
 /// use async_trait::async_trait;
 /// use std::collections::HashMap;
 /// use std::sync::Arc;
@@ -71,7 +71,7 @@
 /// }
 ///
 /// #[async_trait]
-/// impl Motor for TtsMotor {
+/// impl InstructionExecutor for TtsMotor {
 ///     async fn execute(&self, attrs: HashMap<String, String>, content: String) {
 ///         let voice = attrs.get("voice").cloned();
 ///         if let Err(e) = self.tts.speak(voice, content).await {
@@ -86,17 +86,17 @@ use std::sync::Arc;
 use tracing::info;
 
 #[async_trait]
-pub trait Motor: Send + Sync {
+pub trait InstructionExecutor: Send + Sync {
     async fn execute(&self, attrs: HashMap<String, String>, content: String);
 }
 
 #[derive(Clone, Default)]
-pub struct MotorRegistry {
-    motors: HashMap<String, Arc<dyn Motor>>,
+pub struct InstructionRegistry {
+    motors: HashMap<String, Arc<dyn InstructionExecutor>>,
 }
 
-impl MotorRegistry {
-    pub fn register(&mut self, name: &str, motor: Arc<dyn Motor>) {
+impl InstructionRegistry {
+    pub fn register(&mut self, name: &str, motor: Arc<dyn InstructionExecutor>) {
         self.motors.insert(name.to_string(), motor);
     }
 

--- a/psyche/src/traits/motor.rs
+++ b/psyche/src/traits/motor.rs
@@ -2,7 +2,9 @@ use async_trait::async_trait;
 
 /// Host-side actions Pete can take.
 ///
-/// Only the `Will` should invoke these.
+/// Only the `Will` should invoke these. These typed behaviors are distinct from
+/// [`crate::motorcall::InstructionExecutor`], which handles generic instruction
+/// tags parsed from language model output.
 #[async_trait]
 pub trait Motor: Send + Sync {
     /// Speak `text` using the configured mouth.

--- a/psyche/src/wits/will.rs
+++ b/psyche/src/wits/will.rs
@@ -1,5 +1,5 @@
 use crate::instruction::{Instruction, parse_instructions};
-use crate::motorcall::MotorRegistry;
+use crate::motorcall::InstructionRegistry;
 use crate::prompt::PromptBuilder;
 use crate::topics::{Topic, TopicBus};
 use crate::traits::Doer;
@@ -31,7 +31,7 @@ pub struct Will {
     doer: Arc<dyn Doer>,
     prompt: crate::prompt::WillPrompt,
     tx: Option<broadcast::Sender<WitReport>>,
-    motor_registry: MotorRegistry,
+    motor_registry: InstructionRegistry,
     buffer: Mutex<Vec<Impression<String>>>,
     bus: TopicBus,
 }
@@ -55,7 +55,7 @@ impl Will {
             doer,
             prompt: crate::prompt::WillPrompt,
             tx,
-            motor_registry: MotorRegistry::default(),
+            motor_registry: InstructionRegistry::default(),
             buffer: Mutex::new(Vec::new()),
             bus,
         }
@@ -66,8 +66,8 @@ impl Will {
         self.prompt = prompt;
     }
 
-    /// Get mutable access to the motor registry.
-    pub fn motor_registry_mut(&mut self) -> &mut MotorRegistry {
+    /// Get mutable access to the instruction registry.
+    pub fn motor_registry_mut(&mut self) -> &mut InstructionRegistry {
         &mut self.motor_registry
     }
 

--- a/psyche/tests/motor_registry.rs
+++ b/psyche/tests/motor_registry.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use psyche::motorcall::{Motor, MotorRegistry};
+use psyche::motorcall::{InstructionExecutor, InstructionRegistry};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
@@ -7,7 +7,7 @@ use std::sync::{Arc, Mutex};
 struct RecMotor(Arc<Mutex<Vec<(HashMap<String, String>, String)>>>);
 
 #[async_trait]
-impl Motor for RecMotor {
+impl InstructionExecutor for RecMotor {
     async fn execute(&self, attrs: HashMap<String, String>, content: String) {
         self.0.lock().unwrap().push((attrs, content));
     }
@@ -16,7 +16,7 @@ impl Motor for RecMotor {
 #[tokio::test]
 async fn registry_invokes() {
     let motor = Arc::new(RecMotor::default());
-    let mut reg = MotorRegistry::default();
+    let mut reg = InstructionRegistry::default();
     reg.register("test", motor.clone());
     let mut attrs = HashMap::new();
     attrs.insert("a".into(), "b".into());

--- a/psyche/tests/will_handle_output.rs
+++ b/psyche/tests/will_handle_output.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use lingproc::Instruction;
-use psyche::motorcall::{Motor, MotorRegistry};
+use psyche::motorcall::{InstructionExecutor, InstructionRegistry};
 use psyche::traits::Doer;
 use psyche::wits::Will;
 use std::collections::HashMap;
@@ -20,7 +20,7 @@ impl Doer for Dummy {
 struct RecMotor(Arc<Mutex<Vec<String>>>);
 
 #[async_trait]
-impl Motor for RecMotor {
+impl InstructionExecutor for RecMotor {
     async fn execute(&self, _attrs: HashMap<String, String>, content: String) {
         self.0.lock().unwrap().push(content);
     }


### PR DESCRIPTION
## Summary
- rename `motorcall::Motor` trait to `InstructionExecutor`
- rename `MotorRegistry` to `InstructionRegistry`
- update Will and tests to use the new names
- clarify distinction in `traits::motor` docs

## Testing
- `cargo fmt`
- `RUST_LOG=debug cargo test` *(fails: lengthy test suite truncated)*

------
https://chatgpt.com/codex/tasks/task_e_6858fb2b96d08320bd968d8385f67d6f