### PR TITLE
Refactor Wit trait with associated types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,7 +128,7 @@ The previous Deno-based client has been removed. Update the files in
 
 * Consider adding unit tests that simulate full conversation loops (with mocked `Mouth`, `Ear`, `Voice`).
 * Consider adding CLI test scaffolding for mocking TTS/Neo4j/Qdrant.
-* Ensure that `Wit<Instant>` is fed only when it has sufficient `Sensation` inputs — fail early otherwise.
+* Ensure that `InstantWit` only emits when it has enough `Sensation` inputs — fail early otherwise.
 * Be mindful of the single-CPU assumption — prefer concurrency without heavy parallelism.
 * When skipping speech for empty responses, increment the turn counter so the conversation loop can exit.
 * Log Coqui TTS request URLs with `info!(%url, "requesting TTS")` to ease debugging misconfigured endpoints.

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ This repository contains a Rust workspace with three crates:
 The `psyche` crate defines a `Summarizer` trait used to build modular
 cognitive layers. Each `Summarizer` asynchronously digests a batch of lower
 level impressions and produces a higher-level `Impression<T>`. A lightweight
-`Wit<I, O>` trait lets you incrementally observe inputs and emit periodic
-impressions using the summarizer implementation.
+`Wit` trait lets you incrementally observe inputs and emit periodic
+impressions using the summarizer implementation. Each implementation specifies
+its input and output types via associated `Input` and `Output` types.
 
 The unified cognitive model centers on two types:
 

--- a/psyche/src/psyche.rs
+++ b/psyche/src/psyche.rs
@@ -446,10 +446,11 @@ impl Psyche {
     }
 
     /// Convenience to register a typed [`Wit`] without manual boxing.
-    pub fn register_typed_wit<I, O>(&mut self, wit: Arc<dyn Wit<I, O> + Send + Sync>)
+    pub fn register_typed_wit<W>(&mut self, wit: Arc<W>)
     where
-        I: 'static,
-        O: Serialize + Send + Sync + 'static,
+        W: Wit + Send + Sync + 'static,
+        W::Output: Serialize + Send + Sync + 'static,
+        W::Input: 'static,
     {
         self.wits
             .push(Arc::new(wit::WitAdapter::new(wit)) as Arc<dyn ErasedWit + Send + Sync>);
@@ -464,11 +465,11 @@ impl Psyche {
     }
 
     /// Register a [`Wit`] that also observes [`Sensation`]s.
-    pub fn register_observing_wit<I, O, T>(&mut self, wit: Arc<T>)
+    pub fn register_observing_wit<W>(&mut self, wit: Arc<W>)
     where
-        T: Wit<I, O> + crate::traits::observer::SensationObserver + Send + Sync + 'static,
-        I: 'static,
-        O: Serialize + Send + Sync + 'static,
+        W: Wit + crate::traits::observer::SensationObserver + Send + Sync + 'static,
+        W::Output: Serialize + Send + Sync + 'static,
+        W::Input: 'static,
     {
         self.register_observer(wit.clone());
         self.wits

--- a/psyche/src/wits/combobulator.rs
+++ b/psyche/src/wits/combobulator.rs
@@ -69,12 +69,15 @@ impl crate::traits::observer::SensationObserver for Combobulator {
 }
 
 #[async_trait]
-impl Wit<Impression<Episode>, String> for Combobulator {
-    async fn observe(&self, input: Impression<Episode>) {
+impl Wit for Combobulator {
+    type Input = Impression<Episode>;
+    type Output = String;
+
+    async fn observe(&self, input: Self::Input) {
         self.buffer.lock().unwrap().push(input);
     }
 
-    async fn tick(&self) -> Vec<Impression<String>> {
+    async fn tick(&self) -> Vec<Impression<Self::Output>> {
         let now = Instant::now();
         let image = {
             let mut last = self.last_caption_time.lock().unwrap();

--- a/psyche/src/wits/entity_wit.rs
+++ b/psyche/src/wits/entity_wit.rs
@@ -116,8 +116,11 @@ impl EntityWit {
 }
 
 #[async_trait]
-impl crate::traits::wit::Wit<Sensation, String> for EntityWit {
-    async fn observe(&self, sensation: Sensation) {
+impl crate::traits::wit::Wit for EntityWit {
+    type Input = Sensation;
+    type Output = String;
+
+    async fn observe(&self, sensation: Self::Input) {
         match sensation {
             Sensation::HeardUserVoice(text) => {
                 self.names.lock().unwrap().push(text);
@@ -133,7 +136,7 @@ impl crate::traits::wit::Wit<Sensation, String> for EntityWit {
         }
     }
 
-    async fn tick(&self) -> Vec<Impression<String>> {
+    async fn tick(&self) -> Vec<Impression<Self::Output>> {
         let faces = { self.faces.lock().unwrap().drain(..).collect::<Vec<_>>() };
         let mut names = { self.names.lock().unwrap().drain(..).collect::<Vec<_>>() };
         let objects = { self.objects.lock().unwrap().drain(..).collect::<Vec<_>>() };

--- a/psyche/src/wits/episode_wit.rs
+++ b/psyche/src/wits/episode_wit.rs
@@ -75,10 +75,13 @@ impl EpisodeWit {
 }
 
 #[async_trait]
-impl crate::wit::Wit<(), String> for EpisodeWit {
-    async fn observe(&self, _: ()) {}
+impl crate::wit::Wit for EpisodeWit {
+    type Input = ();
+    type Output = String;
 
-    async fn tick(&self) -> Vec<Impression<String>> {
+    async fn observe(&self, _: Self::Input) {}
+
+    async fn tick(&self) -> Vec<Impression<Self::Output>> {
         const MIN_ITEMS: usize = 3;
         let should_break = self.break_flag.swap(false, Ordering::SeqCst);
         let items = {

--- a/psyche/src/wits/face_memory_wit.rs
+++ b/psyche/src/wits/face_memory_wit.rs
@@ -52,12 +52,15 @@ fn similarity(a: &[f32], b: &[f32]) -> f32 {
 }
 
 #[async_trait]
-impl Wit<FaceInfo, FaceInfo> for FaceMemoryWit {
-    async fn observe(&self, info: FaceInfo) {
+impl Wit for FaceMemoryWit {
+    type Input = FaceInfo;
+    type Output = FaceInfo;
+
+    async fn observe(&self, info: Self::Input) {
         self.buffer.lock().unwrap().push(info);
     }
 
-    async fn tick(&self) -> Vec<Impression<FaceInfo>> {
+    async fn tick(&self) -> Vec<Impression<Self::Output>> {
         let items = {
             let mut buf = self.buffer.lock().unwrap();
             if buf.is_empty() {

--- a/psyche/src/wits/heart_wit.rs
+++ b/psyche/src/wits/heart_wit.rs
@@ -42,12 +42,15 @@ impl HeartWit {
 }
 
 #[async_trait]
-impl Wit<Impression<String>, String> for HeartWit {
-    async fn observe(&self, input: Impression<String>) {
+impl Wit for HeartWit {
+    type Input = Impression<String>;
+    type Output = String;
+
+    async fn observe(&self, input: Self::Input) {
         self.buffer.lock().unwrap().push(input);
     }
 
-    async fn tick(&self) -> Vec<Impression<String>> {
+    async fn tick(&self) -> Vec<Impression<Self::Output>> {
         let inputs = {
             let mut buf = self.buffer.lock().unwrap();
             if buf.is_empty() {

--- a/psyche/src/wits/identity_wit.rs
+++ b/psyche/src/wits/identity_wit.rs
@@ -25,12 +25,15 @@ impl IdentityWit {
 }
 
 #[async_trait]
-impl Wit<Impression<Moment>, String> for IdentityWit {
-    async fn observe(&self, input: Impression<Moment>) {
+impl Wit for IdentityWit {
+    type Input = Impression<Moment>;
+    type Output = String;
+
+    async fn observe(&self, input: Self::Input) {
         self.buffer.lock().unwrap().push(input);
     }
 
-    async fn tick(&self) -> Vec<Impression<String>> {
+    async fn tick(&self) -> Vec<Impression<Self::Output>> {
         let inputs = {
             let mut buf = self.buffer.lock().unwrap();
             if buf.is_empty() {

--- a/psyche/src/wits/memory_wit.rs
+++ b/psyche/src/wits/memory_wit.rs
@@ -49,12 +49,15 @@ impl MemoryWit {
 }
 
 #[async_trait]
-impl Wit<Impression<String>, Moment> for MemoryWit {
-    async fn observe(&self, input: Impression<String>) {
+impl Wit for MemoryWit {
+    type Input = Impression<String>;
+    type Output = Moment;
+
+    async fn observe(&self, input: Self::Input) {
         self.buffer.lock().unwrap().push(input);
     }
 
-    async fn tick(&self) -> Vec<Impression<Moment>> {
+    async fn tick(&self) -> Vec<Impression<Self::Output>> {
         let new_items = {
             let mut buf = self.buffer.lock().unwrap();
             if buf.is_empty() {

--- a/psyche/src/wits/moment_wit.rs
+++ b/psyche/src/wits/moment_wit.rs
@@ -53,10 +53,13 @@ impl MomentWit {
 }
 
 #[async_trait]
-impl crate::wit::Wit<(), String> for MomentWit {
-    async fn observe(&self, _: ()) {}
+impl crate::wit::Wit for MomentWit {
+    type Input = ();
+    type Output = String;
 
-    async fn tick(&self) -> Vec<Impression<String>> {
+    async fn observe(&self, _: Self::Input) {}
+
+    async fn tick(&self) -> Vec<Impression<Self::Output>> {
         const MIN_ITEMS: usize = 3;
         let items = {
             let mut buf = self.buffer.lock().unwrap();

--- a/psyche/src/wits/quick.rs
+++ b/psyche/src/wits/quick.rs
@@ -101,14 +101,17 @@ impl Quick {
 }
 
 #[async_trait]
-impl crate::traits::wit::Wit<Sensation, Instant> for Quick {
-    async fn observe(&self, input: Sensation) {
+impl crate::traits::wit::Wit for Quick {
+    type Input = Sensation;
+    type Output = Instant;
+
+    async fn observe(&self, input: Self::Input) {
         let mut buf = self.buffer.lock().unwrap();
         buf.push_back((Utc::now(), Arc::new(input)));
         Self::trim_old(&mut buf, self.window);
     }
 
-    async fn tick(&self) -> Vec<Impression<Instant>> {
+    async fn tick(&self) -> Vec<Impression<Self::Output>> {
         let items = {
             let mut buf = self.buffer.lock().unwrap();
             Self::trim_old(&mut buf, self.window);

--- a/psyche/src/wits/situation_wit.rs
+++ b/psyche/src/wits/situation_wit.rs
@@ -56,10 +56,13 @@ impl SituationWit {
 }
 
 #[async_trait]
-impl crate::wit::Wit<(), String> for SituationWit {
-    async fn observe(&self, _: ()) {}
+impl crate::wit::Wit for SituationWit {
+    type Input = ();
+    type Output = String;
 
-    async fn tick(&self) -> Vec<Impression<String>> {
+    async fn observe(&self, _: Self::Input) {}
+
+    async fn tick(&self) -> Vec<Impression<Self::Output>> {
         const MIN_ITEMS: usize = 3;
         let items = {
             let mut buf = self.buffer.lock().unwrap();

--- a/psyche/src/wits/vision_wit.rs
+++ b/psyche/src/wits/vision_wit.rs
@@ -57,12 +57,15 @@ impl VisionWit {
 }
 
 #[async_trait]
-impl Wit<ImageData, ImageData> for VisionWit {
-    async fn observe(&self, input: ImageData) {
+impl Wit for VisionWit {
+    type Input = ImageData;
+    type Output = ImageData;
+
+    async fn observe(&self, input: Self::Input) {
         *self.latest_image.lock().unwrap() = Some(input);
     }
 
-    async fn tick(&self) -> Vec<Impression<ImageData>> {
+    async fn tick(&self) -> Vec<Impression<Self::Output>> {
         let now = Instant::now();
         {
             let last = self.last_caption_time.lock().unwrap();

--- a/psyche/src/wits/will.rs
+++ b/psyche/src/wits/will.rs
@@ -118,12 +118,15 @@ impl Will {
 }
 
 #[async_trait]
-impl crate::wit::Wit<Impression<String>, Decision> for Will {
-    async fn observe(&self, input: Impression<String>) {
+impl crate::wit::Wit for Will {
+    type Input = Impression<String>;
+    type Output = Decision;
+
+    async fn observe(&self, input: Self::Input) {
         self.buffer.lock().unwrap().push(input);
     }
 
-    async fn tick(&self) -> Vec<Impression<Decision>> {
+    async fn tick(&self) -> Vec<Impression<Self::Output>> {
         let inputs = {
             let mut buf = self.buffer.lock().unwrap();
             if buf.is_empty() {

--- a/psyche/tests/experience_tick.rs
+++ b/psyche/tests/experience_tick.rs
@@ -51,9 +51,12 @@ impl Vectorizer for Dummy {
 struct CountingWit(AtomicUsize);
 
 #[async_trait]
-impl Wit<(), ()> for CountingWit {
-    async fn observe(&self, _: ()) {}
-    async fn tick(&self) -> Vec<Impression<()>> {
+impl Wit for CountingWit {
+    type Input = ();
+    type Output = ();
+
+    async fn observe(&self, _: Self::Input) {}
+    async fn tick(&self) -> Vec<Impression<Self::Output>> {
         self.0.fetch_add(1, Ordering::SeqCst);
         Vec::new()
     }

--- a/psyche/tests/voice_control.rs
+++ b/psyche/tests/voice_control.rs
@@ -61,9 +61,12 @@ impl Ear for DummyEar {
 struct TakeTurnWit(AtomicBool);
 
 #[async_trait]
-impl Wit<(), String> for TakeTurnWit {
-    async fn observe(&self, _: ()) {}
-    async fn tick(&self) -> Vec<Impression<String>> {
+impl Wit for TakeTurnWit {
+    type Input = ();
+    type Output = String;
+
+    async fn observe(&self, _: Self::Input) {}
+    async fn tick(&self) -> Vec<Impression<Self::Output>> {
         if self.0.swap(true, Ordering::SeqCst) {
             Vec::new()
         } else {

--- a/psyche/tests/wit_panic.rs
+++ b/psyche/tests/wit_panic.rs
@@ -48,9 +48,12 @@ impl Vectorizer for Dummy {
 struct PanickyWit;
 
 #[async_trait]
-impl Wit<(), ()> for PanickyWit {
-    async fn observe(&self, _: ()) {}
-    async fn tick(&self) -> Vec<Impression<()>> {
+impl Wit for PanickyWit {
+    type Input = ();
+    type Output = ();
+
+    async fn observe(&self, _: Self::Input) {}
+    async fn tick(&self) -> Vec<Impression<Self::Output>> {
         panic!("boom");
     }
 }

--- a/psyche/tests/wit_vec_tick.rs
+++ b/psyche/tests/wit_vec_tick.rs
@@ -23,10 +23,13 @@ struct DummyWit {
 }
 
 #[async_trait]
-impl Wit<(), ()> for DummyWit {
-    async fn observe(&self, _: ()) {}
+impl Wit for DummyWit {
+    type Input = ();
+    type Output = ();
 
-    async fn tick(&self) -> Vec<Impression<()>> {
+    async fn observe(&self, _: Self::Input) {}
+
+    async fn tick(&self) -> Vec<Impression<Self::Output>> {
         self.outputs.lock().unwrap().pop().unwrap_or_default()
     }
 }


### PR DESCRIPTION
## Summary
- refactor Wit trait to use associated Input/Output types
- update WitAdapter and Psyche helpers
- adjust all Wit implementations and tests
- revise README and AGENTS instructions

## Testing
- `cargo fmt`
- `cargo fetch`
- `RUST_LOG=debug cargo test` *(fails: doctest compile error)*

------
https://chatgpt.com/codex/tasks/task_e_6858fda9a5fc8320a35f2565027b1a50