### PR TITLE
Fix TopicBus doc formatting

### DIFF
--- a/psyche/src/topics.rs
+++ b/psyche/src/topics.rs
@@ -108,7 +108,7 @@ pub struct TopicMessage {
 /// Each topic represents a cognitive stage or signal. For example,
 /// `Topic::Sensation` carries raw inputs from the world, while
 /// `Topic::Instruction` may contain a behavioral directive such as
-/// `&lt;say&gt;` or `&lt;leap&gt;`.
+/// `<say>` or `<leap>`.
 ///
 /// Key guarantees:
 /// - ✅ Type safety between stages (only the correct payload type travels on a


### PR DESCRIPTION
## Summary
- render instruction tags as Markdown code in TopicBus docs

## Testing
- `cargo test` *(fails: websocket_forwards_audio)*

------
https://chatgpt.com/codex/tasks/task_e_6859012a2f2c8320a8668817e1427f94