### PR TITLE
Clarify Instruction type names

### DIFF
--- a/lingproc/src/provider.rs
+++ b/lingproc/src/provider.rs
@@ -1,6 +1,6 @@
 //! Providers implementing the [`Doer`], [`Chatter`], and [`Vectorizer`] traits.
 
-use crate::types::{Chatter, Doer, Instruction, Message, Role, TextStream, Vectorizer};
+use crate::types::{Chatter, Doer, LlmInstruction, Message, Role, TextStream, Vectorizer};
 use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use ollama_rs::{
@@ -34,9 +34,9 @@ impl OllamaProvider {
 #[async_trait]
 impl Doer for OllamaProvider {
     /// Follow an instruction via the Ollama API.
-    async fn follow(&self, instruction: Instruction) -> Result<String> {
+    async fn follow(&self, instruction: LlmInstruction) -> Result<String> {
         use ollama_rs::generation::images::Image;
-        let Instruction { command, images } = instruction;
+        let LlmInstruction { command, images } = instruction;
         info!(%command, image_count = images.len(), "ollama follow");
         debug!(%command, image_count = images.len(), "ollama follow request");
 

--- a/lingproc/src/types.rs
+++ b/lingproc/src/types.rs
@@ -68,12 +68,12 @@ pub struct ImageData {
     pub base64: String, // base64-encoded content
 }
 
-/// Use `Instruction` to pass natural language plus multimedia context to the
+/// Use `LlmInstruction` to pass natural language plus multimedia context to the
 /// `Doer`.
 ///
 /// Example usage:
 /// ```rust,ignore
-/// let instruction = Instruction {
+/// let instruction = LlmInstruction {
 ///     command: "Describe what you see.".to_string(),
 ///     images: vec![ImageData {
 ///         mime: "image/png".to_string(),
@@ -85,7 +85,7 @@ pub struct ImageData {
 ///
 /// In the future this struct may include audio or file attachments.
 #[derive(Debug, Clone)]
-pub struct Instruction {
+pub struct LlmInstruction {
     pub command: String,        // Natural language instruction
     pub images: Vec<ImageData>, // Optional supporting images
 }
@@ -105,7 +105,7 @@ pub struct Instruction {
 ///
 /// # Example
 /// ```rust,ignore
-/// let result = doer.follow(Instruction {
+/// let result = doer.follow(LlmInstruction {
 ///     command: "summarize what just happened".into(),
 ///     images: vec![],
 /// }).await?;
@@ -115,7 +115,7 @@ pub struct Instruction {
 pub trait Doer: Send + Sync {
     /// Follow an instruction, possibly with supporting images, and return the
     /// textual result.
-    async fn follow(&self, instruction: Instruction) -> Result<String>;
+    async fn follow(&self, instruction: LlmInstruction) -> Result<String>;
 }
 
 /// LLM-synthesized decision extracted from model output.

--- a/lingproc/tests/provider.rs
+++ b/lingproc/tests/provider.rs
@@ -1,7 +1,7 @@
 use httpmock::Method::POST;
 use httpmock::MockServer;
 use httpmock::prelude::HttpMockRequest;
-use lingproc::{Doer, ImageData, Instruction, Vectorizer, provider::OllamaProvider};
+use lingproc::{Doer, ImageData, LlmInstruction, Vectorizer, provider::OllamaProvider};
 
 #[tokio::test]
 async fn vectorize_returns_floats() {
@@ -40,7 +40,7 @@ async fn follow_includes_images() {
 
     let provider = OllamaProvider::new(server.base_url(), "mistral").unwrap();
     let res = provider
-        .follow(Instruction {
+        .follow(LlmInstruction {
             command: "look".into(),
             images: vec![ImageData {
                 mime: "image/jpeg".into(),

--- a/pete/src/psyche_factory.rs
+++ b/pete/src/psyche_factory.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use lingproc::{Chatter, Doer, Instruction, Message, Vectorizer};
+use lingproc::{Chatter, Doer, LlmInstruction, Message, Vectorizer};
 use psyche::{ContextualPrompt, Psyche};
 use std::sync::Arc;
 use tracing::info;
@@ -15,7 +15,7 @@ pub fn dummy_psyche() -> Psyche {
 
     #[async_trait]
     impl Doer for Dummy {
-        async fn follow(&self, _: Instruction) -> anyhow::Result<String> {
+        async fn follow(&self, _: LlmInstruction) -> anyhow::Result<String> {
             Ok("ok".into())
         }
     }

--- a/pete/tests/e2e.rs
+++ b/pete/tests/e2e.rs
@@ -3,7 +3,7 @@ use cucumber::{World as _, given, then, when};
 use pete::{ChannelEar, ChannelMouth, EventBus};
 use psyche::{
     self, Ear, Event, Mouth,
-    ling::{Chatter, Doer, Instruction, Message, TextStream, Vectorizer},
+    ling::{Chatter, Doer, LlmInstruction, Message, TextStream, Vectorizer},
 };
 use std::sync::{Arc, atomic::AtomicBool};
 use tokio::sync::{Mutex, broadcast};
@@ -40,7 +40,7 @@ impl Chatter for FixedLLM {
 
 #[async_trait]
 impl Doer for FixedLLM {
-    async fn follow(&self, _i: Instruction) -> anyhow::Result<String> {
+    async fn follow(&self, _i: LlmInstruction) -> anyhow::Result<String> {
         Ok("ok".into())
     }
 }

--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -85,7 +85,7 @@ mod types;
 pub use and_mouth::AndMouth;
 pub use debug::{DebugHandle, DebugInfo, debug_enabled, disable_debug, enable_debug};
 pub use default_prompt::DEFAULT_SYSTEM_PROMPT;
-pub use instruction::{Instruction, parse_instructions};
+pub use instruction::{HostInstruction, parse_instructions};
 pub use model::{Experience, Impression, Stimulus};
 pub use pending_turn::PendingTurn;
 pub use plain_mouth::PlainMouth;

--- a/psyche/src/types.rs
+++ b/psyche/src/types.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
 pub use lingproc::ImageData;
-pub type Decision = lingproc::Decision<crate::Instruction>;
+pub type Decision = lingproc::Decision<crate::HostInstruction>;
 
 /// Latitude/longitude coordinates from a positioning sensor.
 #[cfg_attr(feature = "ts", derive(TS))]

--- a/psyche/src/wits/combobulator.rs
+++ b/psyche/src/wits/combobulator.rs
@@ -2,7 +2,7 @@ use crate::prompt::PromptBuilder;
 use crate::traits::Doer;
 use crate::{ImageData, Impression, Stimulus, wit::Wit};
 use async_trait::async_trait;
-use lingproc::Instruction;
+use lingproc::LlmInstruction;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use tokio::sync::{Semaphore, broadcast};
@@ -136,7 +136,7 @@ impl Combobulator {
                 combined.push_str(&stim.what);
             }
         }
-        let instruction = Instruction {
+        let instruction = LlmInstruction {
             command: self.prompt.build(&combined),
             images: Vec::new(),
         };
@@ -163,7 +163,7 @@ impl Combobulator {
         use lingproc::ImageData as LImageData;
         let caption = self
             .doer
-            .follow(Instruction {
+            .follow(LlmInstruction {
                 command: "Describe only what you see in this image in a single sentence, in the first person. Remember, this is what you are *seeing* in the first person, so unless you're looking into a mirror, you won't be seeing yourself.".into(),
                 images: vec![LImageData { mime: image.mime.clone(), base64: image.base64.clone() }],
             })

--- a/psyche/src/wits/episode_wit.rs
+++ b/psyche/src/wits/episode_wit.rs
@@ -1,10 +1,10 @@
-use crate::Instruction;
+use crate::HostInstruction;
 use crate::topics::{Topic, TopicBus};
 use crate::traits::Doer;
 use crate::{Impression, Stimulus, WitReport};
 use async_trait::async_trait;
 use futures::StreamExt;
-use lingproc::Instruction as LlmInstruction;
+use lingproc::LlmInstruction;
 use std::sync::{
     Arc, Mutex,
     atomic::{AtomicBool, Ordering},
@@ -56,8 +56,8 @@ impl EpisodeWit {
             let mut stream = bus_clone.subscribe(Topic::Instruction);
             tokio::pin!(stream);
             while let Some(payload) = stream.next().await {
-                if let Ok(i) = Arc::downcast::<Instruction>(payload) {
-                    if matches!(*i, Instruction::BreakEpisode) {
+                if let Ok(i) = Arc::downcast::<HostInstruction>(payload) {
+                    if matches!(*i, HostInstruction::BreakEpisode) {
                         break_clone.store(true, Ordering::SeqCst);
                     }
                 }

--- a/psyche/src/wits/fond_du_coeur.rs
+++ b/psyche/src/wits/fond_du_coeur.rs
@@ -1,6 +1,6 @@
 use crate::traits::Doer;
 use crate::{Impression, Stimulus};
-use lingproc::Instruction;
+use lingproc::LlmInstruction;
 use std::sync::{Arc, Mutex};
 use tokio::sync::broadcast;
 
@@ -54,7 +54,7 @@ impl FondDuCoeur {
                 combined.push_str(&stim.what);
             }
         }
-        let instruction = Instruction {
+        let instruction = LlmInstruction {
             command: format!("Summarize Pete's life story in one paragraph:\n{combined}"),
             images: Vec::new(),
         };

--- a/psyche/src/wits/heart_wit.rs
+++ b/psyche/src/wits/heart_wit.rs
@@ -1,7 +1,7 @@
 use crate::traits::{Doer, Motor};
 use crate::{Impression, Stimulus, wit::Wit};
 use async_trait::async_trait;
-use lingproc::Instruction;
+use lingproc::LlmInstruction;
 use std::sync::{Arc, Mutex};
 use tokio::sync::broadcast;
 
@@ -65,7 +65,7 @@ impl Wit for HeartWit {
             .flat_map(|i| i.stimuli.iter().map(|s| s.what.clone()))
             .collect::<Vec<_>>()
             .join(" ");
-        let instruction = Instruction {
+        let instruction = LlmInstruction {
             command: format!("What emoji reflects Pete's mood? {summary}"),
             images: Vec::new(),
         };

--- a/psyche/src/wits/moment_wit.rs
+++ b/psyche/src/wits/moment_wit.rs
@@ -3,7 +3,7 @@ use crate::traits::Doer;
 use crate::{Impression, Stimulus, WitReport};
 use async_trait::async_trait;
 use futures::StreamExt;
-use lingproc::Instruction;
+use lingproc::LlmInstruction;
 use std::sync::{Arc, Mutex};
 use tokio::sync::broadcast;
 use tracing::debug;
@@ -72,7 +72,7 @@ impl crate::wit::Wit for MomentWit {
         let prompt = format!("Summarize these recent events:\n- {}", items.join("\n- "));
         let resp = match self
             .doer
-            .follow(Instruction {
+            .follow(LlmInstruction {
                 command: prompt.clone(),
                 images: Vec::new(),
             })

--- a/psyche/src/wits/quick.rs
+++ b/psyche/src/wits/quick.rs
@@ -16,7 +16,7 @@ use crate::{Impression, Instant, Sensation, Stimulus};
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
 use futures::StreamExt;
-use lingproc::Instruction;
+use lingproc::LlmInstruction;
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 use tokio::sync::broadcast;
@@ -128,7 +128,7 @@ impl crate::traits::wit::Wit for Quick {
         );
         let out = match self
             .doer
-            .follow(Instruction {
+            .follow(LlmInstruction {
                 command: prompt,
                 images: Vec::new(),
             })

--- a/psyche/src/wits/situation_wit.rs
+++ b/psyche/src/wits/situation_wit.rs
@@ -3,7 +3,7 @@ use crate::traits::Doer;
 use crate::{Impression, Stimulus, WitReport};
 use async_trait::async_trait;
 use futures::StreamExt;
-use lingproc::Instruction;
+use lingproc::LlmInstruction;
 use std::sync::{Arc, Mutex};
 use tokio::sync::broadcast;
 use tracing::debug;
@@ -83,7 +83,7 @@ impl crate::wit::Wit for SituationWit {
         prompt.push_str(&items.join("\n- "));
         let resp = match self
             .doer
-            .follow(Instruction {
+            .follow(LlmInstruction {
                 command: prompt.clone(),
                 images: Vec::new(),
             })

--- a/psyche/src/wits/vision_wit.rs
+++ b/psyche/src/wits/vision_wit.rs
@@ -5,7 +5,7 @@ use crate::traits::wit::Wit;
 use crate::{Impression, Stimulus};
 use async_trait::async_trait;
 use lingproc::ImageData as LImageData;
-use lingproc::Instruction;
+use lingproc::LlmInstruction;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use tokio::sync::{Semaphore, broadcast};
@@ -92,7 +92,7 @@ impl Wit for VisionWit {
         } else {
             match self
                 .doer
-                .follow(Instruction {
+                .follow(LlmInstruction {
                     command: "Describe only what you see in this image in a single sentence, in the first person. Remember, this is what you are *seeing* in the first person, so unless you're looking into a mirror, you won't be seeing yourself.".into(),
                     images: vec![LImageData { mime: img.mime.clone(), base64: img.base64.clone() }],
                 })

--- a/psyche/src/wits/will.rs
+++ b/psyche/src/wits/will.rs
@@ -1,12 +1,11 @@
-use crate::Decision;
-use crate::instruction::{Instruction, parse_instructions};
+use crate::instruction::{HostInstruction, parse_instructions};
 use crate::motorcall::InstructionRegistry;
 use crate::prompt::PromptBuilder;
 use crate::topics::{Topic, TopicBus};
 use crate::traits::Doer;
 use crate::{Decision, Impression, Stimulus, WitReport};
 use async_trait::async_trait;
-use lingproc::Instruction as LlmInstruction;
+use lingproc::LlmInstruction;
 use quick_xml::{Reader, events::Event};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};

--- a/psyche/tests/channel_capacity.rs
+++ b/psyche/tests/channel_capacity.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use lingproc::{Chatter, Doer, Instruction, Message, TextStream, Vectorizer};
+use lingproc::{Chatter, Doer, LlmInstruction, Message, TextStream, Vectorizer};
 use psyche::wits::memory::Memory;
 use psyche::{Ear, Mouth, Psyche};
 use serde_json::Value;
@@ -34,7 +34,7 @@ impl Chatter for Dummy {
 
 #[async_trait]
 impl Doer for Dummy {
-    async fn follow(&self, _i: Instruction) -> anyhow::Result<String> {
+    async fn follow(&self, _i: LlmInstruction) -> anyhow::Result<String> {
         Ok("ok".into())
     }
 }

--- a/psyche/tests/combobulator.rs
+++ b/psyche/tests/combobulator.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use lingproc::Instruction;
+use lingproc::LlmInstruction;
 use psyche::traits::Doer;
 use psyche::{Impression, Stimulus, wits::Combobulator};
 use std::sync::Arc;
@@ -9,7 +9,7 @@ struct Dummy;
 
 #[async_trait]
 impl Doer for Dummy {
-    async fn follow(&self, _: Instruction) -> anyhow::Result<String> {
+    async fn follow(&self, _: LlmInstruction) -> anyhow::Result<String> {
         Ok("All clear.".to_string())
     }
 }

--- a/psyche/tests/episode_wit.rs
+++ b/psyche/tests/episode_wit.rs
@@ -1,9 +1,9 @@
 use async_trait::async_trait;
-use lingproc::Instruction as LlmInstruction;
+use lingproc::LlmInstruction;
 use psyche::topics::{Topic, TopicBus};
 use psyche::traits::Doer;
 use psyche::wits::EpisodeWit;
-use psyche::{Impression, Instruction, Stimulus, Wit};
+use psyche::{HostInstruction, Impression, Stimulus, Wit};
 use std::sync::Arc;
 use tokio::time::{Duration, sleep};
 
@@ -37,7 +37,7 @@ async fn emits_summary_on_break() {
     sleep(Duration::from_millis(20)).await;
     publish_situations(&bus, 3);
     sleep(Duration::from_millis(20)).await;
-    bus.publish(Topic::Instruction, Instruction::BreakEpisode);
+    bus.publish(Topic::Instruction, HostInstruction::BreakEpisode);
     sleep(Duration::from_millis(20)).await;
     let out = wit.tick().await;
     assert_eq!(out.len(), 1);

--- a/psyche/tests/experience_tick.rs
+++ b/psyche/tests/experience_tick.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use lingproc::{Chatter, Doer, Instruction, Message, TextStream, Vectorizer};
+use lingproc::{Chatter, Doer, LlmInstruction, Message, TextStream, Vectorizer};
 use psyche::{Ear, Impression, Mouth, Psyche, wit::Wit};
 use std::sync::{
     Arc,
@@ -36,7 +36,7 @@ impl Chatter for Dummy {
 
 #[async_trait]
 impl Doer for Dummy {
-    async fn follow(&self, _i: Instruction) -> anyhow::Result<String> {
+    async fn follow(&self, _i: LlmInstruction) -> anyhow::Result<String> {
         Ok("ok".into())
     }
 }

--- a/psyche/tests/face_sensor.rs
+++ b/psyche/tests/face_sensor.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use futures::{StreamExt, pin_mut};
-use lingproc::{Chatter, Doer, Instruction, Message, TextStream, Vectorizer};
+use lingproc::{Chatter, Doer, LlmInstruction, Message, TextStream, Vectorizer};
 use psyche::{
     Ear, ImageData, Mouth, Psyche, Sensation, Sensor, Topic,
     sensors::face::{DummyDetector, FaceDetector, FaceInfo, FaceSensor},
@@ -27,7 +27,7 @@ async fn emits_face_info() {
     }
     #[async_trait]
     impl Doer for Dummy {
-        async fn follow(&self, _: Instruction) -> anyhow::Result<String> {
+        async fn follow(&self, _: LlmInstruction) -> anyhow::Result<String> {
             Ok("ok".into())
         }
     }

--- a/psyche/tests/heart_wit.rs
+++ b/psyche/tests/heart_wit.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use lingproc::Instruction;
+use lingproc::LlmInstruction;
 use psyche::traits::{Doer, Motor};
 use psyche::wits::HeartWit;
 use psyche::{Impression, Stimulus, Wit};
@@ -10,7 +10,7 @@ struct DummyLLM;
 
 #[async_trait]
 impl Doer for DummyLLM {
-    async fn follow(&self, _i: Instruction) -> anyhow::Result<String> {
+    async fn follow(&self, _i: LlmInstruction) -> anyhow::Result<String> {
         Ok("😊".to_string())
     }
 }

--- a/psyche/tests/identity_wit.rs
+++ b/psyche/tests/identity_wit.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use lingproc::Instruction;
+use lingproc::LlmInstruction;
 use psyche::traits::Doer;
 use psyche::wit::Wit;
 use psyche::wits::{FondDuCoeur, IdentityWit};
@@ -11,7 +11,7 @@ struct Dummy;
 
 #[async_trait]
 impl Doer for Dummy {
-    async fn follow(&self, i: Instruction) -> anyhow::Result<String> {
+    async fn follow(&self, i: LlmInstruction) -> anyhow::Result<String> {
         Ok(format!("story:{}", i.command))
     }
 }

--- a/psyche/tests/ling.rs
+++ b/psyche/tests/ling.rs
@@ -1,12 +1,12 @@
 use async_trait::async_trait;
-use lingproc::{Chatter, Doer, Instruction, Message, TextStream, Vectorizer};
+use lingproc::{Chatter, Doer, LlmInstruction, Message, TextStream, Vectorizer};
 use tokio_stream::StreamExt;
 
 struct Dummy;
 
 #[async_trait]
 impl Doer for Dummy {
-    async fn follow(&self, i: Instruction) -> anyhow::Result<String> {
+    async fn follow(&self, i: LlmInstruction) -> anyhow::Result<String> {
         Ok(format!("do:{}", i.command))
     }
 }
@@ -30,7 +30,7 @@ impl Vectorizer for Dummy {
 async fn dummy_traits() {
     let d = Dummy;
     assert_eq!(
-        d.follow(Instruction {
+        d.follow(LlmInstruction {
             command: "a".into(),
             images: Vec::new()
         })

--- a/psyche/tests/liveness.rs
+++ b/psyche/tests/liveness.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use lingproc::{Chatter, Doer, Instruction, Message, TextStream, Vectorizer};
+use lingproc::{Chatter, Doer, LlmInstruction, Message, TextStream, Vectorizer};
 use psyche::{Ear, Mouth, Psyche};
 use std::sync::{
     Arc,
@@ -39,7 +39,7 @@ impl Chatter for Dummy {
 
 #[async_trait]
 impl Doer for Dummy {
-    async fn follow(&self, _i: Instruction) -> anyhow::Result<String> {
+    async fn follow(&self, _i: LlmInstruction) -> anyhow::Result<String> {
         Ok("ok".into())
     }
 }

--- a/psyche/tests/moment_wit.rs
+++ b/psyche/tests/moment_wit.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use lingproc::Instruction as LlmInstruction;
+use lingproc::LlmInstruction;
 use psyche::topics::{Topic, TopicBus};
 use psyche::traits::Doer;
 use psyche::wits::MomentWit;

--- a/psyche/tests/prompt.rs
+++ b/psyche/tests/prompt.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use lingproc::{Chatter, Doer, Instruction, Message, TextStream, Vectorizer};
+use lingproc::{Chatter, Doer, LlmInstruction, Message, TextStream, Vectorizer};
 use psyche::{DEFAULT_SYSTEM_PROMPT, Ear, Mouth, Psyche};
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -31,7 +31,7 @@ impl Ear for Dummy {
 
 #[async_trait]
 impl Doer for Dummy {
-    async fn follow(&self, _: Instruction) -> anyhow::Result<String> {
+    async fn follow(&self, _: LlmInstruction) -> anyhow::Result<String> {
         Ok("ok".into())
     }
 }

--- a/psyche/tests/situation_wit.rs
+++ b/psyche/tests/situation_wit.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use lingproc::Instruction as LlmInstruction;
+use lingproc::LlmInstruction;
 use psyche::topics::{Topic, TopicBus};
 use psyche::traits::Doer;
 use psyche::wits::SituationWit;

--- a/psyche/tests/topic_bus.rs
+++ b/psyche/tests/topic_bus.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use futures::{StreamExt, pin_mut};
-use lingproc::{Chatter, Doer, Instruction, Message, TextStream, Vectorizer};
+use lingproc::{Chatter, Doer, LlmInstruction, Message, TextStream, Vectorizer};
 use psyche::{Ear, Mouth, Psyche, Topic};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -33,7 +33,7 @@ impl Ear for Dummy {
 
 #[async_trait]
 impl Doer for Dummy {
-    async fn follow(&self, _: Instruction) -> anyhow::Result<String> {
+    async fn follow(&self, _: LlmInstruction) -> anyhow::Result<String> {
         Ok("ok".into())
     }
 }

--- a/psyche/tests/vision_wit.rs
+++ b/psyche/tests/vision_wit.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use lingproc::Instruction;
+use lingproc::LlmInstruction;
 use psyche::traits::Doer;
 use psyche::{ImageData, Impression, Stimulus, VisionWit, Wit};
 use std::sync::Arc;
@@ -9,7 +9,7 @@ struct Dummy;
 
 #[async_trait]
 impl Doer for Dummy {
-    async fn follow(&self, _instruction: Instruction) -> anyhow::Result<String> {
+    async fn follow(&self, _instruction: LlmInstruction) -> anyhow::Result<String> {
         Ok("I see a test pattern.".into())
     }
 }

--- a/psyche/tests/voice.rs
+++ b/psyche/tests/voice.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use lingproc::{Chatter, Doer, Instruction, Message, TextStream};
+use lingproc::{Chatter, Doer, LlmInstruction, Message, TextStream};
 use psyche::{Event, Mouth};
 use psyche::{Voice, extract_emojis};
 use std::sync::Arc;
@@ -19,7 +19,7 @@ impl Chatter for DummyLLM {
 
 #[async_trait]
 impl Doer for DummyLLM {
-    async fn follow(&self, _i: Instruction) -> anyhow::Result<String> {
+    async fn follow(&self, _i: LlmInstruction) -> anyhow::Result<String> {
         Ok("ok".into())
     }
 }
@@ -59,7 +59,7 @@ impl Chatter for SpyLLM {
 
 #[async_trait]
 impl Doer for SpyLLM {
-    async fn follow(&self, _i: Instruction) -> anyhow::Result<String> {
+    async fn follow(&self, _i: LlmInstruction) -> anyhow::Result<String> {
         Ok("ok".into())
     }
 }

--- a/psyche/tests/voice_control.rs
+++ b/psyche/tests/voice_control.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use lingproc::{Chatter, Doer, Instruction, Message, TextStream, Vectorizer};
+use lingproc::{Chatter, Doer, LlmInstruction, Message, TextStream, Vectorizer};
 use psyche::{Ear, Impression, Mouth, Psyche, Sensation, Stimulus, wit::Wit};
 use std::sync::{
     Arc,
@@ -23,7 +23,7 @@ impl Chatter for RecLLM {
 
 #[async_trait]
 impl Doer for RecLLM {
-    async fn follow(&self, _i: Instruction) -> anyhow::Result<String> {
+    async fn follow(&self, _i: LlmInstruction) -> anyhow::Result<String> {
         Ok("ok".into())
     }
 }

--- a/psyche/tests/will.rs
+++ b/psyche/tests/will.rs
@@ -1,8 +1,8 @@
 use async_trait::async_trait;
-use lingproc::Instruction as LlmInstruction;
+use lingproc::LlmInstruction;
 use psyche::traits::Doer;
 use psyche::wits::Will;
-use psyche::{Impression, Instruction, Stimulus, TopicBus, Wit};
+use psyche::{HostInstruction, Impression, Stimulus, TopicBus, Wit};
 use std::sync::Arc;
 
 #[derive(Clone)]
@@ -28,7 +28,7 @@ async fn returns_decision_impression() {
     let imp = will.tick().await.pop().unwrap();
     assert_eq!(
         imp.stimuli[0].what.instructions[0],
-        Instruction::Say {
+        HostInstruction::Say {
             voice: None,
             text: "Do it".into()
         }

--- a/psyche/tests/will_handle_output.rs
+++ b/psyche/tests/will_handle_output.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use lingproc::Instruction;
+use lingproc::LlmInstruction;
 use psyche::motorcall::{InstructionExecutor, InstructionRegistry};
 use psyche::traits::Doer;
 use psyche::wits::Will;
@@ -11,7 +11,7 @@ struct Dummy;
 
 #[async_trait]
 impl Doer for Dummy {
-    async fn follow(&self, _: Instruction) -> anyhow::Result<String> {
+    async fn follow(&self, _: LlmInstruction) -> anyhow::Result<String> {
         Ok("ok".into())
     }
 }

--- a/psyche/tests/will_wit.rs
+++ b/psyche/tests/will_wit.rs
@@ -1,10 +1,10 @@
 use async_trait::async_trait;
 use futures::StreamExt;
-use lingproc::Instruction as LlmInstruction;
+use lingproc::LlmInstruction;
 use psyche::topics::{Topic, TopicBus};
 use psyche::traits::Doer;
+use psyche::{HostInstruction, wits::Will};
 use psyche::{Impression, Stimulus, Wit};
-use psyche::{Instruction, wits::Will};
 use std::sync::Arc;
 use tokio::time::{self, Duration};
 
@@ -34,11 +34,11 @@ async fn publishes_parsed_instructions() {
     let out = wit.tick().await;
     assert!(matches!(
         out[0].stimuli[0].what.instructions[0],
-        Instruction::Say { .. }
+        HostInstruction::Say { .. }
     ));
     let payload = sub.next().await.unwrap();
-    let ins = payload.downcast::<Instruction>().unwrap();
-    assert!(matches!(&*ins, Instruction::Say { text, .. } if text == "Hello"));
+    let ins = payload.downcast::<HostInstruction>().unwrap();
+    assert!(matches!(&*ins, HostInstruction::Say { text, .. } if text == "Hello"));
 }
 
 #[tokio::test]
@@ -74,10 +74,20 @@ async fn mixed_instructions() {
     tokio::pin!(sub);
     let out = wit.tick().await;
     assert_eq!(out[0].stimuli[0].what.instructions.len(), 2);
-    let first = sub.next().await.unwrap().downcast::<Instruction>().unwrap();
-    assert!(matches!(*first, Instruction::Say { .. }));
-    let second = sub.next().await.unwrap().downcast::<Instruction>().unwrap();
-    assert!(matches!(*second, Instruction::Move { .. }));
+    let first = sub
+        .next()
+        .await
+        .unwrap()
+        .downcast::<HostInstruction>()
+        .unwrap();
+    assert!(matches!(*first, HostInstruction::Say { .. }));
+    let second = sub
+        .next()
+        .await
+        .unwrap()
+        .downcast::<HostInstruction>()
+        .unwrap();
+    assert!(matches!(*second, HostInstruction::Move { .. }));
 }
 
 #[tokio::test]

--- a/psyche/tests/wit_panic.rs
+++ b/psyche/tests/wit_panic.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use lingproc::{Chatter, Doer, Instruction, Message, TextStream, Vectorizer};
+use lingproc::{Chatter, Doer, LlmInstruction, Message, TextStream, Vectorizer};
 use psyche::{Ear, Impression, Mouth, Psyche, Wit};
 use std::sync::Arc;
 use std::time::Duration;
@@ -33,7 +33,7 @@ impl Chatter for Dummy {
 
 #[async_trait]
 impl Doer for Dummy {
-    async fn follow(&self, _i: Instruction) -> anyhow::Result<String> {
+    async fn follow(&self, _i: LlmInstruction) -> anyhow::Result<String> {
         Ok("ok".into())
     }
 }

--- a/psyche/tests/wit_report.rs
+++ b/psyche/tests/wit_report.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use lingproc::Instruction as LlmInstruction;
+use lingproc::LlmInstruction;
 use psyche::traits::Doer;
 use psyche::wits::Will;
 use psyche::{Impression, Stimulus, TopicBus, Wit};


### PR DESCRIPTION
## Summary
- rename psyche's Instruction enum to HostInstruction
- rename lingproc Instruction struct to LlmInstruction
- update imports and references across crates and tests

## Testing
- `RUST_LOG=debug cargo test` *(fails: logs_skipped_detection)*
- `RUST_LOG=debug cargo test -p psyche --test face_sensor -- logs_skipped_detection --exact`

------
https://chatgpt.com/codex/tasks/task_e_68594ac5493c8320a167a5bee76a0e17