### PR TITLE
Deduplicate cosine math

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,7 @@ The previous Deno-based client has been removed. Update the files in
   `ws://localhost:3000/ws`.
 * Give every new Wit a `LABEL` constant and a `with_debug` constructor for emitting `WitReport`s.
 * Re-export shared structs rather than defining duplicates across modules.
+* Put math utilities shared across crates in `lingproc::math`.
 
 ## LLM Integration
 

--- a/lingproc/src/lib.rs
+++ b/lingproc/src/lib.rs
@@ -4,11 +4,13 @@
 //! [`OllamaProvider`] implementation, and helpers for splitting LLM output into
 //! sentences or words.
 
+pub mod math;
 pub mod provider;
 pub mod segment;
 pub mod segmenter;
 pub mod types;
 
+pub use crate::math::*;
 pub use crate::provider::*;
 pub use crate::segment::*;
 pub use crate::segmenter::*;

--- a/lingproc/src/math.rs
+++ b/lingproc/src/math.rs
@@ -3,7 +3,7 @@
 /// # Examples
 ///
 /// ```rust,ignore
-/// use crate::util::math::cosine_similarity;
+/// use lingproc::math::cosine_similarity;
 /// let a = [1.0_f32, 0.0, 0.0];
 /// let b = [0.5_f32, 0.0, 0.0];
 /// assert!((cosine_similarity(&a, &b) - 1.0).abs() < 1e-6);

--- a/psyche/src/sensors/face.rs
+++ b/psyche/src/sensors/face.rs
@@ -1,10 +1,10 @@
 use crate::topics::TopicBus;
 use crate::traits::Sensor;
-use crate::util::math::cosine_similarity;
 use crate::wits::memory::QdrantClient;
 use crate::{ImageData, Sensation};
 use anyhow::Result;
 use async_trait::async_trait;
+use lingproc::math::cosine_similarity;
 use std::sync::{Arc, Mutex};
 use tracing::{debug, error};
 

--- a/psyche/src/util/mod.rs
+++ b/psyche/src/util/mod.rs
@@ -1,3 +1,3 @@
 //! Shared helper utilities used across the crate.
 
-pub mod math;
+pub use lingproc::math;

--- a/psyche/src/wits/entity_wit.rs
+++ b/psyche/src/wits/entity_wit.rs
@@ -1,11 +1,11 @@
 use crate::sensors::face::FaceInfo;
 use crate::traits::wit::Wit;
 use crate::types::ObjectInfo;
-use crate::util::math::cosine_similarity;
 use crate::wits::memory::Memory;
 use crate::wits::memory::QdrantClient;
 use crate::{Impression, Sensation, Stimulus};
 use async_trait::async_trait;
+use lingproc::math::cosine_similarity;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};


### PR DESCRIPTION
## Summary
- move cosine math utilities to `lingproc`
- update `face` sensor and `EntityWit` to use the shared function
- document preferred location for math utilities

## Testing
- `RUST_LOG=debug cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68594f5dfbbc8320b406dd9577e2ea42