### PR TITLE
Add Ollama provider defaults

### DIFF
--- a/lingproc/src/provider.rs
+++ b/lingproc/src/provider.rs
@@ -29,6 +29,17 @@ impl OllamaProvider {
         info!(%host_ref, %model, "creating Ollama provider");
         Ok(Self { client, model })
     }
+
+    /// Create a new provider using the given host and model, falling back to
+    /// sensible defaults when either is `None`.
+    ///
+    /// The default host is `http://localhost:11434` and the default model is
+    /// `mistral`.
+    pub fn new_with_defaults(host: Option<&str>, model: Option<&str>) -> Result<Self> {
+        let host = host.unwrap_or("http://localhost:11434");
+        let model = model.unwrap_or("mistral");
+        Self::new(host, model)
+    }
 }
 
 #[async_trait]

--- a/lingproc/tests/provider.rs
+++ b/lingproc/tests/provider.rs
@@ -52,3 +52,19 @@ async fn follow_includes_images() {
     mock.assert();
     assert_eq!(res, "ok");
 }
+
+#[tokio::test]
+async fn defaults_are_used_when_none_provided() {
+    let server = MockServer::start_async().await;
+    let _mock = server.mock(|when, then| {
+        when.method(POST).path("/api/embed");
+        then.status(200)
+            .header("content-type", "application/json")
+            .body("{\"embeddings\": [[1.0]]}");
+    });
+
+    let provider =
+        OllamaProvider::new_with_defaults(Some(server.base_url().as_str()), None).unwrap();
+    let vec = provider.vectorize("a").await.unwrap();
+    assert_eq!(vec, vec![1.0]);
+}

--- a/pete/src/ollama.rs
+++ b/pete/src/ollama.rs
@@ -19,5 +19,5 @@ use lingproc::OllamaProvider;
 /// Propagates any error returned by [`OllamaProvider::new`], such as an invalid
 /// URL or missing model.
 pub fn ollama_provider_from_args(host: &str, model: &str) -> anyhow::Result<OllamaProvider> {
-    Ok(OllamaProvider::new(host, model)?)
+    Ok(OllamaProvider::new_with_defaults(Some(host), Some(model))?)
 }


### PR DESCRIPTION
## Summary
- share Ollama provider construction through `new_with_defaults`
- use it inside `ollama_provider_from_args`
- test the new defaults helper

## Testing
- `RUST_LOG=debug cargo test defaults_are_used_when_none_provided --test provider -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_68594f8cb5fc8320980cd2c020f0a9e4