### PR TITLE
Rename instruction executor trait

### DIFF
--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -67,7 +67,7 @@ mod debug;
 
 pub mod ling;
 pub mod model;
-pub mod motorcall;
+pub mod motor_call;
 mod plain_mouth;
 pub mod prompt;
 mod task_group;

--- a/psyche/src/motor_call.rs
+++ b/psyche/src/motor_call.rs
@@ -1,12 +1,12 @@
 //! Execute dynamically parsed instructions.
 //!
-//! The [`InstructionExecutor`] trait represents a generic actuator that Pete can
+//! The [`MotorCall`] trait represents a generic actuator that Pete can
 //! invoke via a `<motor>` tag emitted by the [`Will`](crate::wits::Will)
 //! component. Each implementation performs a real-world action using the given
 //! attributes and body content.
 //!
 //! ```
-//! use psyche::motorcall::{InstructionExecutor, InstructionRegistry};
+//! use psyche::motor_call::{MotorCall, MotorCallRegistry};
 //! use async_trait::async_trait;
 //! use std::sync::Arc;
 //! use std::collections::HashMap;
@@ -16,14 +16,14 @@
 //! struct RecMotor(std::sync::Mutex<Vec<(HashMap<String, String>, String)>>);
 //!
 //! #[async_trait]
-//! impl InstructionExecutor for RecMotor {
+//! impl MotorCall for RecMotor {
 //!     async fn execute(&self, attrs: HashMap<String, String>, content: String) {
 //!         self.0.lock().unwrap().push((attrs, content));
 //!     }
 //! }
 //!
 //! # async fn doc() {
-//! let mut registry = InstructionRegistry::default();
+//! let mut registry = MotorCallRegistry::default();
 //! let motor = Arc::new(RecMotor::default());
 //! registry.register("say", motor.clone());
 //! registry
@@ -39,14 +39,14 @@
 /// A simple logging motor implementation.
 ///
 /// ```
-/// use psyche::motorcall::InstructionExecutor;
+/// use psyche::motor_call::MotorCall;
 /// use async_trait::async_trait;
 /// use std::collections::HashMap;
 ///
 /// pub struct LoggingMotor;
 ///
 /// #[async_trait]
-/// impl InstructionExecutor for LoggingMotor {
+/// impl MotorCall for LoggingMotor {
 ///     async fn execute(&self, attrs: HashMap<String, String>, content: String) {
 ///         tracing::info!(?attrs, %content, "MOTOR fired");
 ///     }
@@ -56,7 +56,7 @@
 /// A text-to-speech motor might look like:
 ///
 /// ```
-/// use psyche::motorcall::InstructionExecutor;
+/// use psyche::motor_call::MotorCall;
 /// use async_trait::async_trait;
 /// use std::collections::HashMap;
 /// use std::sync::Arc;
@@ -71,7 +71,7 @@
 /// }
 ///
 /// #[async_trait]
-/// impl InstructionExecutor for TtsMotor {
+/// impl MotorCall for TtsMotor {
 ///     async fn execute(&self, attrs: HashMap<String, String>, content: String) {
 ///         let voice = attrs.get("voice").cloned();
 ///         if let Err(e) = self.tts.speak(voice, content).await {
@@ -86,17 +86,17 @@ use std::sync::Arc;
 use tracing::info;
 
 #[async_trait]
-pub trait InstructionExecutor: Send + Sync {
+pub trait MotorCall: Send + Sync {
     async fn execute(&self, attrs: HashMap<String, String>, content: String);
 }
 
 #[derive(Clone, Default)]
-pub struct InstructionRegistry {
-    motors: HashMap<String, Arc<dyn InstructionExecutor>>,
+pub struct MotorCallRegistry {
+    motors: HashMap<String, Arc<dyn MotorCall>>,
 }
 
-impl InstructionRegistry {
-    pub fn register(&mut self, name: &str, motor: Arc<dyn InstructionExecutor>) {
+impl MotorCallRegistry {
+    pub fn register(&mut self, name: &str, motor: Arc<dyn MotorCall>) {
         self.motors.insert(name.to_string(), motor);
     }
 

--- a/psyche/src/traits/motor.rs
+++ b/psyche/src/traits/motor.rs
@@ -3,8 +3,8 @@ use async_trait::async_trait;
 /// Host-side actions Pete can take.
 ///
 /// Only the `Will` should invoke these. These typed behaviors are distinct from
-/// [`crate::motorcall::InstructionExecutor`], which handles generic instruction
-/// tags parsed from language model output.
+/// [`crate::motor_call::MotorCall`], which handles generic instruction tags
+/// parsed from language model output.
 #[async_trait]
 pub trait Motor: Send + Sync {
     /// Speak `text` using the configured mouth.

--- a/psyche/src/wits/will.rs
+++ b/psyche/src/wits/will.rs
@@ -1,5 +1,5 @@
 use crate::instruction::{HostInstruction, parse_instructions};
-use crate::motorcall::InstructionRegistry;
+use crate::motor_call::MotorCallRegistry;
 use crate::prompt::PromptBuilder;
 use crate::topics::{Topic, TopicBus};
 use crate::traits::Doer;
@@ -22,7 +22,7 @@ pub struct Will {
     doer: Arc<dyn Doer>,
     prompt: crate::prompt::WillPrompt,
     tx: Option<broadcast::Sender<WitReport>>,
-    motor_registry: InstructionRegistry,
+    motor_registry: MotorCallRegistry,
     buffer: Mutex<Vec<Impression<String>>>,
     bus: TopicBus,
 }
@@ -46,7 +46,7 @@ impl Will {
             doer,
             prompt: crate::prompt::WillPrompt,
             tx,
-            motor_registry: InstructionRegistry::default(),
+            motor_registry: MotorCallRegistry::default(),
             buffer: Mutex::new(Vec::new()),
             bus,
         }
@@ -58,7 +58,7 @@ impl Will {
     }
 
     /// Get mutable access to the instruction registry.
-    pub fn motor_registry_mut(&mut self) -> &mut InstructionRegistry {
+    pub fn motor_registry_mut(&mut self) -> &mut MotorCallRegistry {
         &mut self.motor_registry
     }
 

--- a/psyche/tests/motor_registry.rs
+++ b/psyche/tests/motor_registry.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use psyche::motorcall::{InstructionExecutor, InstructionRegistry};
+use psyche::motor_call::{MotorCall, MotorCallRegistry};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
@@ -7,7 +7,7 @@ use std::sync::{Arc, Mutex};
 struct RecMotor(Arc<Mutex<Vec<(HashMap<String, String>, String)>>>);
 
 #[async_trait]
-impl InstructionExecutor for RecMotor {
+impl MotorCall for RecMotor {
     async fn execute(&self, attrs: HashMap<String, String>, content: String) {
         self.0.lock().unwrap().push((attrs, content));
     }
@@ -16,7 +16,7 @@ impl InstructionExecutor for RecMotor {
 #[tokio::test]
 async fn registry_invokes() {
     let motor = Arc::new(RecMotor::default());
-    let mut reg = InstructionRegistry::default();
+    let mut reg = MotorCallRegistry::default();
     reg.register("test", motor.clone());
     let mut attrs = HashMap::new();
     attrs.insert("a".into(), "b".into());

--- a/psyche/tests/will_handle_output.rs
+++ b/psyche/tests/will_handle_output.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use lingproc::LlmInstruction;
-use psyche::motorcall::{InstructionExecutor, InstructionRegistry};
+use psyche::motor_call::{MotorCall, MotorCallRegistry};
 use psyche::traits::Doer;
 use psyche::wits::Will;
 use std::collections::HashMap;
@@ -20,7 +20,7 @@ impl Doer for Dummy {
 struct RecMotor(Arc<Mutex<Vec<String>>>);
 
 #[async_trait]
-impl InstructionExecutor for RecMotor {
+impl MotorCall for RecMotor {
     async fn execute(&self, _attrs: HashMap<String, String>, content: String) {
         self.0.lock().unwrap().push(content);
     }


### PR DESCRIPTION
## Summary
- rename `InstructionExecutor` trait to `MotorCall`
- update registry and references
- adjust doctests and tests for new naming

## Testing
- `cargo fmt`
- `cargo fetch`
- `cargo test` *(fails: doctests hang)*

------
https://chatgpt.com/codex/tasks/task_e_68594f33c9248320bf35de535cc6be4f