### PR TITLE
Clean warnings, fix compile errors

### DIFF
--- a/pete/src/psyche_factory.rs
+++ b/pete/src/psyche_factory.rs
@@ -75,7 +75,6 @@ pub fn ollama_psyche(
     neo4j_pass: &str,
 ) -> anyhow::Result<Psyche> {
     use crate::LoggingMotor;
-    use lingproc::OllamaProvider;
     use psyche::wits::{
         BasicMemory, Combobulator, FondDuCoeur, HeartWit, IdentityWit, MemoryWit, Neo4jClient,
         QdrantClient, Will,

--- a/pete/src/tts_mouth.rs
+++ b/pete/src/tts_mouth.rs
@@ -16,7 +16,6 @@ use tracing::{error, info};
 use anyhow::Result;
 use base64::{Engine as _, engine::general_purpose};
 use reqwest::{Client, Url};
-use urlencoding::encode;
 
 /// Client for a Coqui TTS server.
 #[derive(Clone)]

--- a/pete/src/web.rs
+++ b/pete/src/web.rs
@@ -6,10 +6,10 @@ use axum::{
     },
     http::StatusCode,
     response::{Html, IntoResponse},
-    routing::{get, get_service, post},
+    routing::{get, get_service},
 };
 use serde::{Deserialize, Serialize};
-use shared::{AudioData, WsPayload};
+use shared::WsPayload;
 use std::sync::{
     Arc,
     atomic::{AtomicUsize, Ordering},
@@ -20,7 +20,7 @@ use tracing::{debug, error, info};
 
 use crate::EventBus;
 use lingproc::Role;
-use psyche::{Ear, Event, GeoLoc, ImageData, Sensor, WitReport};
+use psyche::{Ear, Event, GeoLoc, ImageData, Sensor};
 
 /// PETE's interface to the world — his `Body`.
 ///

--- a/pete/tests/input_listener.rs
+++ b/pete/tests/input_listener.rs
@@ -4,7 +4,7 @@ use tokio::sync::mpsc;
 
 #[tokio::test]
 async fn records_user_input() {
-    let mut psyche = dummy_psyche();
+    let psyche = dummy_psyche();
     let conv = psyche.conversation();
     let voice = psyche.voice();
     let speaking = std::sync::Arc::new(AtomicBool::new(false));

--- a/pete/tests/wits_loop.rs
+++ b/pete/tests/wits_loop.rs
@@ -5,7 +5,7 @@ use tokio::time::Duration;
 #[tokio::test]
 #[ignore]
 async fn vision_wit_receives_images() {
-    let mut psyche = dummy_psyche();
+    let psyche = dummy_psyche();
     psyche::enable_debug("Vision").await;
     let mut reports = psyche.wit_reports();
     let tx = psyche.input_sender();

--- a/pete/tests/ws_geolocate.rs
+++ b/pete/tests/ws_geolocate.rs
@@ -1,7 +1,7 @@
 use axum::{Router, routing::get, serve};
-use futures::{SinkExt, StreamExt};
+use futures::SinkExt;
 use pete::{Body, ChannelEar, EventBus, EyeSensor, GeoSensor, dummy_psyche, ws_handler};
-use psyche::{GeoLoc, Sensor};
+use psyche::Sensor;
 use std::sync::{
     Arc,
     atomic::{AtomicBool, AtomicUsize},

--- a/psyche/src/prompt.rs
+++ b/psyche/src/prompt.rs
@@ -68,7 +68,7 @@ impl ContextualPrompt {
             let b = bus.clone();
             let s = store.clone();
             tokio::spawn(async move {
-                let mut stream = b.subscribe(topic);
+                let stream = b.subscribe(topic);
                 tokio::pin!(stream);
                 while let Some(payload) = stream.next().await {
                     if let Ok(sval) = std::sync::Arc::downcast::<String>(payload.clone()) {

--- a/psyche/src/psyche.rs
+++ b/psyche/src/psyche.rs
@@ -609,7 +609,7 @@ impl Psyche {
             if let Some(extra) = self.pending_turn.take() {
                 debug!(%extra, "pending_turn being processed");
                 let (history, mut prompt) = {
-                    let mut pb = self.prompt_builder.lock().await;
+                    let pb = self.prompt_builder.lock().await;
                     let hist = pb.get_conversation_tail(self.max_history).await;
                     let prompt = pb.build_prompt().await;
                     (hist, prompt)

--- a/psyche/src/wits/episode_wit.rs
+++ b/psyche/src/wits/episode_wit.rs
@@ -41,7 +41,7 @@ impl EpisodeWit {
         let buf_clone = buffer.clone();
         let bus_clone = bus.clone();
         tokio::spawn(async move {
-            let mut stream = bus_clone.subscribe(Topic::Situation);
+            let stream = bus_clone.subscribe(Topic::Situation);
             tokio::pin!(stream);
             while let Some(payload) = stream.next().await {
                 if let Ok(i) = Arc::downcast::<Impression<String>>(payload) {
@@ -53,7 +53,7 @@ impl EpisodeWit {
         let break_clone = break_flag.clone();
         let bus_clone = bus.clone();
         tokio::spawn(async move {
-            let mut stream = bus_clone.subscribe(Topic::Instruction);
+            let stream = bus_clone.subscribe(Topic::Instruction);
             tokio::pin!(stream);
             while let Some(payload) = stream.next().await {
                 if let Ok(i) = Arc::downcast::<HostInstruction>(payload) {

--- a/psyche/src/wits/moment_wit.rs
+++ b/psyche/src/wits/moment_wit.rs
@@ -35,7 +35,7 @@ impl MomentWit {
         let buf_clone = buffer.clone();
         let bus_clone = bus.clone();
         tokio::spawn(async move {
-            let mut stream = bus_clone.subscribe(Topic::Instant);
+            let stream = bus_clone.subscribe(Topic::Instant);
             tokio::pin!(stream);
             while let Some(payload) = stream.next().await {
                 if let Ok(i) = Arc::downcast::<Impression<String>>(payload) {

--- a/psyche/src/wits/quick.rs
+++ b/psyche/src/wits/quick.rs
@@ -48,7 +48,7 @@ impl Quick {
         let buf_clone = buffer.clone();
         let bus_clone = bus.clone();
         tokio::spawn(async move {
-            let mut stream = bus_clone.subscribe(Topic::Sensation);
+            let stream = bus_clone.subscribe(Topic::Sensation);
             tokio::pin!(stream);
             while let Some(payload) = stream.next().await {
                 if let Ok(s) = Arc::downcast::<Sensation>(payload) {

--- a/psyche/src/wits/situation_wit.rs
+++ b/psyche/src/wits/situation_wit.rs
@@ -37,7 +37,7 @@ impl SituationWit {
         let buf_clone = buffer.clone();
         let bus_clone = bus.clone();
         tokio::spawn(async move {
-            let mut stream = bus_clone.subscribe(Topic::Moment);
+            let stream = bus_clone.subscribe(Topic::Moment);
             tokio::pin!(stream);
             while let Some(payload) = stream.next().await {
                 if let Ok(i) = Arc::downcast::<Impression<String>>(payload) {

--- a/psyche/src/wits/will.rs
+++ b/psyche/src/wits/will.rs
@@ -1,8 +1,6 @@
-use crate::instruction::{HostInstruction, parse_instructions};
-use crate::motorcall::InstructionRegistry;
-use crate::prompt::PromptFragment;
+use crate::instruction::parse_instructions;
 use crate::motor_call::MotorCallRegistry;
-use crate::prompt::PromptBuilder;
+use crate::prompt::PromptFragment;
 use crate::topics::{Topic, TopicBus};
 use crate::traits::Doer;
 use crate::{Decision, Impression, Stimulus, WitReport};

--- a/psyche/tests/channel_capacity.rs
+++ b/psyche/tests/channel_capacity.rs
@@ -1,8 +1,7 @@
 use async_trait::async_trait;
-use lingproc::{Chatter, Doer, LlmInstruction, Message, TextStream, Vectorizer};
+use lingproc::{Chatter, Doer, LlmInstruction, Message, Vectorizer};
 use psyche::wits::memory::Memory;
 use psyche::{Ear, Mouth, Psyche};
-use serde_json::Value;
 use std::sync::Arc;
 use tokio_stream::once;
 

--- a/psyche/tests/experience_tick.rs
+++ b/psyche/tests/experience_tick.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use lingproc::{Chatter, Doer, LlmInstruction, Message, TextStream, Vectorizer};
+use lingproc::{Chatter, Doer, LlmInstruction, Message, Vectorizer};
 use psyche::{Ear, Impression, Mouth, Psyche, wit::Wit};
 use std::sync::{
     Arc,

--- a/psyche/tests/face_sensor.rs
+++ b/psyche/tests/face_sensor.rs
@@ -59,7 +59,7 @@ async fn emits_face_info() {
         QdrantClient::default(),
         bus.clone(),
     );
-    let mut sub = bus.subscribe(Topic::Sensation);
+    let sub = bus.subscribe(Topic::Sensation);
     pin_mut!(sub);
     sensor
         .sense(ImageData {
@@ -99,7 +99,7 @@ async fn skips_identical_face() {
         embeddings: std::sync::Mutex::new(vec![vec![0.1, 0.0], vec![0.1, 0.0]]),
     });
     let sensor = FaceSensor::new(detector, QdrantClient::default(), bus.clone());
-    let mut sub = bus.subscribe(Topic::Sensation);
+    let sub = bus.subscribe(Topic::Sensation);
     pin_mut!(sub);
     let img = ImageData {
         mime: "image/png".into(),
@@ -119,7 +119,7 @@ async fn stores_distinct_faces() {
         embeddings: std::sync::Mutex::new(vec![vec![0.1, 0.0], vec![0.0, 0.1]]),
     });
     let sensor = FaceSensor::new(detector, QdrantClient::default(), bus.clone());
-    let mut sub = bus.subscribe(Topic::Sensation);
+    let sub = bus.subscribe(Topic::Sensation);
     pin_mut!(sub);
     let img = ImageData {
         mime: "image/png".into(),

--- a/psyche/tests/topic_bus.rs
+++ b/psyche/tests/topic_bus.rs
@@ -65,7 +65,7 @@ async fn feel_forwards_to_topic_bus() {
         ear,
     );
     let bus = psyche.topic_bus();
-    let mut sub = bus.subscribe(Topic::Sensation);
+    let sub = bus.subscribe(Topic::Sensation);
     pin_mut!(sub);
     psyche.feel("hello".to_string());
     let payload = sub.next().await.unwrap();

--- a/psyche/tests/voice.rs
+++ b/psyche/tests/voice.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use lingproc::{Chatter, Doer, LlmInstruction, Message, TextStream};
-use psyche::{Event, Mouth};
+use psyche::Mouth;
 use psyche::{Voice, extract_emojis};
 use std::sync::Arc;
 use tokio::sync::broadcast;

--- a/psyche/tests/will_handle_output.rs
+++ b/psyche/tests/will_handle_output.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use lingproc::LlmInstruction;
-use psyche::motor_call::{MotorCall, MotorCallRegistry};
+use psyche::motor_call::MotorCall;
 use psyche::traits::Doer;
 use psyche::wits::Will;
 use std::collections::HashMap;

--- a/psyche/tests/will_wit.rs
+++ b/psyche/tests/will_wit.rs
@@ -29,7 +29,7 @@ async fn publishes_parsed_instructions() {
         None::<String>,
     ))
     .await;
-    let mut sub = bus.subscribe(Topic::Instruction);
+    let sub = bus.subscribe(Topic::Instruction);
     tokio::pin!(sub);
     let out = wit.tick().await;
     assert!(matches!(
@@ -70,7 +70,7 @@ async fn mixed_instructions() {
         None::<String>,
     ))
     .await;
-    let mut sub = bus.subscribe(Topic::Instruction);
+    let sub = bus.subscribe(Topic::Instruction);
     tokio::pin!(sub);
     let out = wit.tick().await;
     assert_eq!(out[0].stimuli[0].what.instructions.len(), 2);
@@ -103,7 +103,7 @@ async fn empty_response_yields_nothing() {
     .await;
     let out = wit.tick().await;
     assert!(out.is_empty());
-    let mut sub = bus.subscribe(Topic::Instruction);
+    let sub = bus.subscribe(Topic::Instruction);
     tokio::pin!(sub);
     time::sleep(Duration::from_millis(20)).await;
     assert!(


### PR DESCRIPTION
## Summary
- remove unused imports
- fix wrong import paths and unnecessary mutability
- tidy tests to eliminate warnings

## Testing
- `cargo test --quiet`
- `cargo doc --no-deps --quiet` *(fails: unresolved link warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6859531e20488320a3d5517ce70d1f47