### PR TITLE
Document no-op wits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,5 +116,7 @@ Provides LLM and embedding utilities.
 * `cargo fetch` then `cargo test`
 * Run with `RUST_LOG=debug cargo run --features tts`
 * Visit [`http://localhost:3000/`](http://localhost:3000/) to connect frontend
+* Document intentionally empty trait methods with comments so their purpose is
+  clear.
 
 Use this document to orient new agents, tools, or contributors. If you’re confused — ask the Quick what it saw, or the Will what it wants.

--- a/psyche/src/wits/episode_wit.rs
+++ b/psyche/src/wits/episode_wit.rs
@@ -79,7 +79,11 @@ impl crate::wit::Wit for EpisodeWit {
     type Input = ();
     type Output = String;
 
-    async fn observe(&self, _: Self::Input) {}
+    async fn observe(&self, _: Self::Input) {
+        // EpisodeWit gathers input via [`TopicBus`] subscriptions at
+        // construction time. This method is required by the [`Wit`] trait
+        // but intentionally does nothing.
+    }
 
     async fn tick(&self) -> Vec<Impression<Self::Output>> {
         const MIN_ITEMS: usize = 3;

--- a/psyche/src/wits/moment_wit.rs
+++ b/psyche/src/wits/moment_wit.rs
@@ -57,7 +57,10 @@ impl crate::wit::Wit for MomentWit {
     type Input = ();
     type Output = String;
 
-    async fn observe(&self, _: Self::Input) {}
+    async fn observe(&self, _: Self::Input) {
+        // MomentWit also pulls data from the [`TopicBus`].
+        // No direct observations are expected, so this is left empty.
+    }
 
     async fn tick(&self) -> Vec<Impression<Self::Output>> {
         const MIN_ITEMS: usize = 3;

--- a/psyche/src/wits/situation_wit.rs
+++ b/psyche/src/wits/situation_wit.rs
@@ -60,7 +60,10 @@ impl crate::wit::Wit for SituationWit {
     type Input = ();
     type Output = String;
 
-    async fn observe(&self, _: Self::Input) {}
+    async fn observe(&self, _: Self::Input) {
+        // SituationWit receives moments via a [`TopicBus`] subscription.
+        // Nothing is expected through `observe`, so this is a no-op.
+    }
 
     async fn tick(&self) -> Vec<Impression<Self::Output>> {
         const MIN_ITEMS: usize = 3;


### PR DESCRIPTION
## Summary
- document empty observe methods in Wit implementations
- remind contributors to comment on empty trait methods

## Testing
- `cargo fetch`
- `cargo test` *(failed: Codex couldn't run certain commands due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_68595a7688b08320ad09445d4965ffc3