### PR TITLE
Add with_debug to IdentityWit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,5 +116,7 @@ Provides LLM and embedding utilities.
 * `cargo fetch` then `cargo test`
 * Run with `RUST_LOG=debug cargo run --features tts`
 * Visit [`http://localhost:3000/`](http://localhost:3000/) to connect frontend
+* Each Wit exposes `new()` and `with_debug()`; `new` should delegate to
+  `with_debug` with `None` so devtools can uniformly enable debug output
 
 Use this document to orient new agents, tools, or contributors. If you’re confused — ask the Quick what it saw, or the Will what it wants.

--- a/psyche/src/wits/identity_wit.rs
+++ b/psyche/src/wits/identity_wit.rs
@@ -1,11 +1,13 @@
-use crate::{Impression, wit::Wit, wits::FondDuCoeur};
+use crate::{Impression, WitReport, wit::Wit, wits::FondDuCoeur};
 use async_trait::async_trait;
 use std::sync::Mutex;
+use tokio::sync::broadcast;
 
 /// Wit that produces a single-paragraph life story from recent moments.
 pub struct IdentityWit {
     summarizer: FondDuCoeur,
     buffer: Mutex<Vec<Impression<String>>>,
+    tx: Option<broadcast::Sender<WitReport>>,
 }
 
 impl IdentityWit {
@@ -13,9 +15,15 @@ impl IdentityWit {
     pub const LABEL: &'static str = "IdentityWit";
     /// Create a new `IdentityWit` using the given summarizer.
     pub fn new(summarizer: FondDuCoeur) -> Self {
+        Self::with_debug(summarizer, None)
+    }
+
+    /// Create an `IdentityWit` that emits [`WitReport`]s via `tx`.
+    pub fn with_debug(summarizer: FondDuCoeur, tx: Option<broadcast::Sender<WitReport>>) -> Self {
         Self {
             summarizer,
             buffer: Mutex::new(Vec::new()),
+            tx,
         }
     }
 }
@@ -40,7 +48,18 @@ impl Wit for IdentityWit {
             data
         };
         match self.summarizer.digest(&inputs).await {
-            Ok(i) => vec![i],
+            Ok(i) => {
+                if let Some(tx) = &self.tx {
+                    if crate::debug::debug_enabled(Self::LABEL).await {
+                        let _ = tx.send(WitReport {
+                            name: Self::LABEL.into(),
+                            prompt: "identity digest".into(),
+                            output: i.summary.clone(),
+                        });
+                    }
+                }
+                vec![i]
+            }
             Err(_) => Vec::new(),
         }
     }

--- a/psyche/tests/identity_wit.rs
+++ b/psyche/tests/identity_wit.rs
@@ -44,3 +44,23 @@ async fn summarizes_moments_into_story() {
     assert!(summarizer.story().contains("story:"));
     psyche::disable_debug("Story").await;
 }
+
+#[tokio::test]
+async fn with_debug_emits_report() {
+    let (tx, mut rx) = broadcast::channel(8);
+    psyche::enable_debug("IdentityWit").await;
+    let summarizer = FondDuCoeur::new(Box::new(Dummy));
+    let wit = IdentityWit::with_debug(summarizer, Some(tx));
+    wit.observe(Impression::new(
+        vec![Stimulus::new("hello".to_string())],
+        "s1",
+        None::<String>,
+    ))
+    .await;
+    let out = wit.tick().await;
+    assert_eq!(out.len(), 1);
+    let report = rx.recv().await.unwrap();
+    assert_eq!(report.name, "IdentityWit");
+    assert!(report.output.contains("story:"));
+    psyche::disable_debug("IdentityWit").await;
+}


### PR DESCRIPTION
## Summary
- add `with_debug` helper for `IdentityWit`
- emit debug `WitReport` when enabled
- test debug reporting
- document `new`/`with_debug` pattern in `AGENTS.md`

## Testing
- `cargo test -p psyche --test face_sensor -- --test-threads=1 --nocapture`
- `cargo test --workspace -- --test-threads=1` *(fails: hangs during doc tests)*

------
https://chatgpt.com/codex/tasks/task_e_68595a88d688832083f18e9c1fddad25