### PR TITLE
Add visual indicator for audio playback

### DIFF
--- a/frontend/dist/app.js
+++ b/frontend/dist/app.js
@@ -9,6 +9,7 @@
   const thoughtImage = document.getElementById("thought-image");
   const imageThumbnail = document.getElementById("image-thumbnail");
   const player = document.getElementById("audio-player");
+  const face = document.getElementById("face");
   const audioQueue = [];
   const conversationLog = document.getElementById("conversation-log");
   const witOutputs = {};
@@ -104,9 +105,11 @@
     const next = audioQueue.shift();
     if (!next) {
       playing = false;
+      face.classList.remove("playing");
       return;
     }
     playing = true;
+    face.classList.add("playing");
 
     const done = () => {
       player.removeEventListener("ended", done);
@@ -115,6 +118,9 @@
         ws.send(JSON.stringify({ type: "Echo", text: next.text }));
       }
       playNext();
+      if (!playing) {
+        face.classList.remove("playing");
+      }
     };
 
     if (next.audio) {

--- a/frontend/dist/styles.css
+++ b/frontend/dist/styles.css
@@ -291,3 +291,11 @@ button:hover {
   from { background-color: #444; }
   to { background-color: #222; }
 }
+@keyframes pulse-glow {
+  0%, 100% { text-shadow: 0 0 0.25rem var(--bs-primary); }
+  50% { text-shadow: 0 0 1rem var(--bs-primary); }
+}
+
+#face.playing .mien {
+  animation: pulse-glow 1s infinite;
+}


### PR DESCRIPTION
## Summary
- highlight the avatar while audio is playing so it's visible when sound is active
- keep node tests green

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68597a616a508320a9a609e97c5fc4ef