### PR TITLE
Fix audio recorder cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,5 +122,6 @@ Provides LLM and embedding utilities.
   `with_debug` with `None` so devtools can uniformly enable debug output
 * Document intentionally empty trait methods with comments so their purpose is
   clear.
+* In frontend scripts, stop `MediaRecorder` on `window.onbeforeunload` to release the microphone.
 
 Use this document to orient new agents, tools, or contributors. If you’re confused — ask the Quick what it saw, or the Will what it wants.

--- a/frontend/dist/app.js
+++ b/frontend/dist/app.js
@@ -252,6 +252,14 @@
     try {
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
       const rec = new MediaRecorder(stream);
+      window.onbeforeunload = () => {
+        try {
+          if (rec.state !== "inactive") rec.stop();
+          stream.getTracks().forEach((t) => t.stop());
+        } catch (err) {
+          console.warn("recorder cleanup", err);
+        }
+      };
       rec.ondataavailable = (e) => {
         if (e.data.size > 0) {
           const reader = new FileReader();


### PR DESCRIPTION
## Summary
- stop `MediaRecorder` when the page unloads
- note front-end cleanup practice in AGENTS

## Testing
- `cargo test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68597a3f86d08320b934ae3542dec860