### PR TITLE
Fix sidebar detail transitions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,5 +122,8 @@ Provides LLM and embedding utilities.
   `with_debug` with `None` so devtools can uniformly enable debug output
 * Document intentionally empty trait methods with comments so their purpose is
   clear.
+* Reuse cargo and npm caches when running tests to avoid re-downloading
+  dependencies.
+* Keep commit messages short yet descriptive.
 
 Use this document to orient new agents, tools, or contributors. If you’re confused — ask the Quick what it saw, or the Will what it wants.

--- a/frontend/dist/app.js
+++ b/frontend/dist/app.js
@@ -19,25 +19,29 @@
   function animateDetails(details) {
     const summary = details.querySelector("summary");
     if (!summary) return;
+    const collapsed = summary.offsetHeight;
+    if (!details.hasAttribute("open")) {
+      details.style.maxHeight = collapsed + "px";
+    }
     summary.addEventListener("click", (e) => {
       e.preventDefault();
       const open = details.hasAttribute("open");
-      const startHeight = details.offsetHeight;
-      const summaryHeight = summary.offsetHeight;
-      details.style.height = startHeight + "px";
+      const start = details.scrollHeight;
+      details.style.maxHeight = start + "px";
       details.style.overflow = "hidden";
       requestAnimationFrame(() => {
-        details.style.transition = "height 0.2s ease";
-        details.style.height = open ? summaryHeight + "px" : details.scrollHeight + "px";
+        details.style.transition = "max-height 0.2s ease";
+        details.style.maxHeight = open ? collapsed + "px" : details.scrollHeight + "px";
       });
       details.addEventListener(
         "transitionend",
         () => {
-          details.style.removeProperty("height");
-          details.style.removeProperty("overflow");
           details.style.removeProperty("transition");
           if (open) {
             details.removeAttribute("open");
+            details.style.maxHeight = collapsed + "px";
+          } else {
+            details.style.maxHeight = "none";
           }
         },
         { once: true }

--- a/frontend/dist/styles.css
+++ b/frontend/dist/styles.css
@@ -232,7 +232,7 @@ button:hover {
   color: #aaa;
   position: relative;
   overflow: hidden;
-  transition: height 0.2s ease;
+  transition: max-height 0.2s ease;
 }
 
 .sidebar details::before {


### PR DESCRIPTION
## Summary
- use `max-height` transitions for `.sidebar details`
- adjust JS handler to animate `max-height`
- note caching and concise commit messages in `AGENTS.md`

## Testing
- `npm test`
- `cargo test --quiet --no-run`

------
https://chatgpt.com/codex/tasks/task_e_68597a8f5ab88320bcbbc90dde91bc9a