### PR TITLE
Optimize thoughtTabs updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,4 +123,5 @@ Provides LLM and embedding utilities.
 * Document intentionally empty trait methods with comments so their purpose is
   clear.
 
+* Patch DOM incrementally or debounce updates instead of replacing innerHTML.
 Use this document to orient new agents, tools, or contributors. If you’re confused — ask the Quick what it saw, or the Will what it wants.

--- a/frontend/dist/app.js
+++ b/frontend/dist/app.js
@@ -12,6 +12,7 @@
   const audioQueue = [];
   const conversationLog = document.getElementById("conversation-log");
   const witOutputs = {};
+  const thoughtElems = {};
   const witDetails = {};
   const witDebugContainer = document.getElementById("wit-debug");
   let playing = false;
@@ -158,13 +159,7 @@
           } else {
             witOutputs["unknown"] = m.data;
           }
-          thoughtTabs.innerHTML = "";
-          Object.entries(witOutputs).forEach(([name, output]) => {
-            const div = document.createElement("div");
-            div.className = "wit-report";
-            div.textContent = `${name}: ${output}`;
-            thoughtTabs.appendChild(div);
-          });
+          updateThoughtTabs(thoughtTabs, witOutputs, thoughtElems);
           thought.style.display = Object.keys(witOutputs).length ? "flex" : "none";
           break;
         }

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -41,6 +41,7 @@
       <div id="wit-debug"></div>
   </aside>
 
+  <script src="/thoughtTabs.js"></script>
   <script src="/app.js"></script>
 </body>
 </html>

--- a/frontend/dist/thoughtTabs.js
+++ b/frontend/dist/thoughtTabs.js
@@ -1,0 +1,26 @@
+// Update or remove DOM nodes for wit outputs
+// Usage: updateThoughtTabs(container, outputs, map)
+function updateThoughtTabs(container, outputs, elements) {
+  for (const [name, output] of Object.entries(outputs)) {
+    let node = elements[name];
+    if (!node) {
+      node = document.createElement('div');
+      node.className = 'wit-report';
+      elements[name] = node;
+      container.appendChild(node);
+    }
+    node.textContent = `${name}: ${output}`;
+  }
+  for (const name of Object.keys(elements)) {
+    if (!(name in outputs)) {
+      elements[name].remove();
+      delete elements[name];
+    }
+  }
+}
+if (typeof module !== 'undefined') {
+  module.exports = { updateThoughtTabs };
+} else {
+  window.updateThoughtTabs = updateThoughtTabs;
+}
+

--- a/frontend/test/thought-tabs.test.js
+++ b/frontend/test/thought-tabs.test.js
@@ -1,0 +1,23 @@
+const assert = require('assert');
+const { JSDOM } = require('jsdom');
+const dom = new JSDOM('<div id="tabs"></div>');
+global.window = dom.window;
+global.document = dom.window.document;
+const { updateThoughtTabs } = require('../dist/thoughtTabs.js');
+
+const container = document.getElementById('tabs');
+const map = {};
+
+updateThoughtTabs(container, {Quick: 'ok'}, map);
+assert.strictEqual(container.children.length, 1);
+const first = container.children[0];
+assert.strictEqual(first.textContent, 'Quick: ok');
+
+updateThoughtTabs(container, {Quick: 'done'}, map);
+assert.strictEqual(container.children.length, 1);
+assert.strictEqual(container.children[0], first);
+assert.strictEqual(first.textContent, 'Quick: done');
+
+updateThoughtTabs(container, {}, map);
+assert.strictEqual(container.children.length, 0);
+console.log('ok');

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This repository contains a Rust workspace with three crates:",
   "main": "index.js",
   "scripts": {
-    "test": "node frontend/test/conversation-scroll.test.js"
+    "test": "node frontend/test/conversation-scroll.test.js && node frontend/test/thought-tabs.test.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- improve Dev instructions about DOM patching
- use incremental update helper for thought display
- load helper in frontend
- test DOM updates with jsdom

## Testing
- `npm test`
- `cargo test --no-run`

------
https://chatgpt.com/codex/tasks/task_e_68597a7e21f483208cbf5b49ba2fc78a