### PR TITLE
Add data-wit-name for debug details

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,7 @@ Provides LLM and embedding utilities.
 ## 🛠 Development Quickstart
 
 * `cargo fetch` then `cargo test`
+* `npm test` to run frontend unit tests
 * Run with `RUST_LOG=debug cargo run --features tts`
 * Visit [`http://localhost:3000/`](http://localhost:3000/) to connect frontend
 * Each Wit exposes `new()` and `with_debug()`; `new` should delegate to

--- a/frontend/dist/app.js
+++ b/frontend/dist/app.js
@@ -69,6 +69,7 @@
     let entry = witDetails[name];
     if (!entry) {
       const details = document.createElement("details");
+      details.setAttribute("data-wit-name", name);
       const summary = document.createElement("summary");
       const link = document.createElement("a");
       link.href = `/debug/wit/${name.toLowerCase()}`;

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -33,7 +33,7 @@
   </main>
 
   <aside class="sidebar">
-      <details open>
+      <details open data-wit-name="conversation">
         <summary>Conversation</summary>
         <pre id="system-prompt"></pre>
         <pre id="conversation-log"></pre>

--- a/frontend/test/details-data-attr.test.js
+++ b/frontend/test/details-data-attr.test.js
@@ -1,0 +1,13 @@
+const assert = require('assert');
+const fs = require('fs');
+const { JSDOM } = require('jsdom');
+
+const html = fs.readFileSync('frontend/dist/index.html', 'utf8');
+const dom = new JSDOM(html);
+const details = dom.window.document.querySelector('details');
+assert.strictEqual(details.getAttribute('data-wit-name'), 'conversation');
+
+const appJs = fs.readFileSync('frontend/dist/app.js', 'utf8');
+assert(appJs.includes('data-wit-name'), 'app.js should set data-wit-name attribute');
+
+console.log('ok');

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This repository contains a Rust workspace with three crates:",
   "main": "index.js",
   "scripts": {
-    "test": "node frontend/test/conversation-scroll.test.js"
+    "test": "node frontend/test/conversation-scroll.test.js && node frontend/test/details-data-attr.test.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add a reminder to run `npm test`
- mark static Conversation details with data-wit-name
- tag dynamically created wit details
- test that the attribute exists
- run both test files via npm

## Testing
- `cargo test`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68597ab5749483209c4e816f8d87bee8