### PR TITLE
Add timestamp debug toggle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,4 +123,8 @@ Provides LLM and embedding utilities.
 * Document intentionally empty trait methods with comments so their purpose is
   clear.
 
+### Hidden Debug Mode
+
+* Press `Ctrl+D` in the frontend to toggle timestamp display on conversation messages.
+
 Use this document to orient new agents, tools, or contributors. If you’re confused — ask the Quick what it saw, or the Will what it wants.

--- a/frontend/dist/app.js
+++ b/frontend/dist/app.js
@@ -15,6 +15,14 @@
   const witDetails = {};
   const witDebugContainer = document.getElementById("wit-debug");
   let playing = false;
+  let debugMode = false;
+
+  document.addEventListener("keydown", (e) => {
+    if (e.ctrlKey && e.key === "d") {
+      debugMode = !debugMode;
+      updateConversation();
+    }
+  });
 
   function animateDetails(details) {
     const summary = details.querySelector("summary");
@@ -279,7 +287,7 @@
 
   async function updateConversation() {
     try {
-      const resp = await fetch("/conversation");
+      const resp = await fetch(`/conversation${debugMode ? "?debug=1" : ""}`);
       const msgs = await resp.json();
       const system = document.getElementById("system-prompt");
       if (system && msgs.length) {
@@ -290,7 +298,11 @@
         conversationLog.scrollHeight - 5;
       conversationLog.textContent = msgs
         .slice(1)
-        .map((m) => `${m.role}: ${m.content}`)
+        .map((m) => {
+          const ts = debugMode && m.timestamp ?
+            new Date(m.timestamp).toLocaleTimeString() + " " : "";
+          return `${ts}${m.role}: ${m.content}`;
+        })
         .join("\n");
       if (atBottom) {
         conversationLog.scrollTop = conversationLog.scrollHeight;

--- a/pete/src/lib.rs
+++ b/pete/src/lib.rs
@@ -63,10 +63,10 @@ pub use sensor::eye::EyeSensor;
 pub use sensor::geo::GeoSensor;
 pub use sensor::heartbeat::HeartbeatSensor;
 pub use simulator::Simulator;
+pub use tts::default_mouth;
 #[cfg(feature = "tts")]
 pub use tts::{CoquiTts, TtsMouth};
-pub use tts::default_mouth;
 pub use web::{
-    Body, WsRequest, app, conversation_log, index, listen_user_input, log_ws_handler,
+    Body, LogQuery, WsRequest, app, conversation_log, index, listen_user_input, log_ws_handler,
     parse_data_url, psyche_debug, toggle_wit_debug, wit_debug_page, ws_handler,
 };

--- a/pete/tests/conversation.rs
+++ b/pete/tests/conversation.rs
@@ -1,5 +1,7 @@
 use axum::{body, extract::State, response::IntoResponse};
-use pete::{Body, ChannelEar, EventBus, EyeSensor, GeoSensor, conversation_log, dummy_psyche};
+use pete::{
+    Body, ChannelEar, EventBus, EyeSensor, GeoSensor, LogQuery, conversation_log, dummy_psyche,
+};
 use psyche::traits::Sensor;
 use std::sync::{
     Arc,
@@ -33,11 +35,54 @@ async fn returns_log_json() {
         system_prompt: Arc::new(tokio::sync::Mutex::new(psyche.system_prompt())),
         psyche_debug: debug,
     };
-    let resp = conversation_log(State(state)).await.into_response();
+    let resp = conversation_log(axum::extract::Query(LogQuery { debug: None }), State(state))
+        .await
+        .into_response();
     let body = body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
     let msgs: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(msgs[0]["role"], "system");
     assert!(msgs[0]["content"].as_str().unwrap().contains("PETE"));
     assert_eq!(msgs[1]["role"], "user");
     assert_eq!(msgs[1]["content"], "hi");
+}
+
+#[tokio::test]
+async fn debug_mode_includes_timestamps() {
+    let mut psyche = dummy_psyche();
+    let conversation = psyche.conversation();
+    conversation
+        .lock()
+        .await
+        .add_message_from_user("hey".into());
+    let ear = Arc::new(ChannelEar::new(
+        psyche.input_sender(),
+        Arc::new(AtomicBool::new(false)),
+        psyche.voice(),
+    ));
+    let (bus, _user_rx) = EventBus::new();
+    let bus = Arc::new(bus);
+    let eye = Arc::new(EyeSensor::new(psyche.input_sender()));
+    let geo = Arc::new(GeoSensor::new(psyche.input_sender()));
+    psyche.add_sense(eye.description());
+    psyche.add_sense(geo.description());
+    let debug = psyche.debug_handle();
+    let state = Body {
+        bus: bus.clone(),
+        ear,
+        eye,
+        geo,
+        conversation,
+        connections: Arc::new(AtomicUsize::new(1)),
+        system_prompt: Arc::new(tokio::sync::Mutex::new(psyche.system_prompt())),
+        psyche_debug: debug,
+    };
+    let resp = conversation_log(
+        axum::extract::Query(LogQuery { debug: Some(true) }),
+        State(state),
+    )
+    .await
+    .into_response();
+    let body = body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let msgs: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert!(msgs[1]["timestamp"].is_string());
 }

--- a/psyche/src/ling.rs
+++ b/psyche/src/ling.rs
@@ -86,7 +86,7 @@ impl PromptBuilder {
 
     /// Return the full conversation history.
     pub async fn get_conversation(&self) -> Vec<Message> {
-        self.conversation.lock().await.all().to_vec()
+        self.conversation.lock().await.all()
     }
 
     /// Return the most recent `n` messages.


### PR DESCRIPTION
## Summary
- add frontend debug mode via Ctrl+D to show timestamps
- expose debug query for conversation API
- track conversation entries with timestamps
- document hidden debug mode in AGENTS.md
- test timestamp logic

## Testing
- `cargo test --workspace --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68597ac142448320ab7689121fc5f229