### PR TITLE
Add IDs to dynamic DOM nodes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,8 @@ Provides LLM and embedding utilities.
 * Avoid blocking: all Wits run asynchronously and should tick infrequently
 * Implement simple buffer-based Wits using `BufferedWit` to avoid duplicating
   `tick`/`observe` boilerplate
+* Assign stable `id` attributes to dynamic DOM nodes in `frontend/dist/app.js`
+  to simplify e2e tests
 
 ---
 

--- a/frontend/dist/app.js
+++ b/frontend/dist/app.js
@@ -69,18 +69,24 @@
     let entry = witDetails[name];
     if (!entry) {
       const details = document.createElement("details");
+      details.id = `wit-${name}-details`;
       const summary = document.createElement("summary");
+      summary.id = `wit-${name}-summary`;
       const link = document.createElement("a");
+      link.id = `wit-${name}-debug-link`;
       link.href = `/debug/wit/${name.toLowerCase()}`;
       link.target = "_blank";
       link.textContent = "link";
       const time = document.createElement("span");
+      time.id = `wit-${name}-time`;
       time.className = "wit-time";
       summary.textContent = name + " ";
       summary.appendChild(time);
       summary.appendChild(link);
       const promptPre = document.createElement("pre");
+      promptPre.id = `wit-${name}-prompt`;
       const outputPre = document.createElement("pre");
+      outputPre.id = `wit-${name}-output`;
       outputPre.textContent = "waiting...";
       details.appendChild(summary);
       details.appendChild(promptPre);
@@ -162,6 +168,7 @@
           Object.entries(witOutputs).forEach(([name, output]) => {
             const div = document.createElement("div");
             div.className = "wit-report";
+            div.id = `wit-report-${name}`;
             div.textContent = `${name}: ${output}`;
             thoughtTabs.appendChild(div);
           });
@@ -208,6 +215,7 @@
       video.srcObject = stream;
       await video.play();
       const canvas = document.createElement("canvas");
+      canvas.id = "webcam-canvas";
       const ctx = canvas.getContext("2d", { willReadFrequently: true });
       setInterval(() => {
         if (video.videoWidth === 0) {

--- a/frontend/test/wit-detail-id.test.js
+++ b/frontend/test/wit-detail-id.test.js
@@ -1,0 +1,14 @@
+const assert = require('assert');
+const fs = require('fs');
+
+const script = fs.readFileSync('frontend/dist/app.js', 'utf8');
+
+assert(script.includes('id = `wit-${name}-details`'));
+assert(script.includes('id = `wit-${name}-summary`'));
+assert(script.includes('id = `wit-${name}-debug-link`'));
+assert(script.includes('id = `wit-${name}-time`'));
+assert(script.includes('id = `wit-${name}-prompt`'));
+assert(script.includes('id = `wit-${name}-output`'));
+assert(script.includes('div.id = `wit-report-${name}`'));
+assert(script.includes('canvas.id = "webcam-canvas"'));
+console.log('wit-detail-id ok');

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This repository contains a Rust workspace with three crates:",
   "main": "index.js",
   "scripts": {
-    "test": "node frontend/test/conversation-scroll.test.js"
+    "test": "node frontend/test/conversation-scroll.test.js && node frontend/test/wit-detail-id.test.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- ensure dynamic DOM nodes in `frontend/dist/app.js` get stable `id` attributes
- add regression test verifying ids exist
- document DOM id requirement in `AGENTS.md`
- update npm test script to run all frontend tests

## Testing
- `npm test`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68597accebd88320a762d132990ab6dc