### PR TITLE
Warn when embeddings missing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ Provides LLM and embedding utilities.
 
 * **LLM Traits**: `Chatter`, `Doer`, `Vectorizer`
 * **OllamaProvider**: Backend for generation and embedding
+* Vectorizers should warn if no embeddings are returned to avoid silent similarity errors
 * **Helpers**: Sentence segmentation, prompt context, instruction parsing
 
 ---

--- a/lingproc/src/provider.rs
+++ b/lingproc/src/provider.rs
@@ -127,7 +127,11 @@ impl Vectorizer for OllamaProvider {
                         embedding_len = res.embeddings.len(),
                         "ollama vectorize response"
                     );
-                    return Ok(res.embeddings.into_iter().next().unwrap_or_default());
+                    let Some(embedding) = res.embeddings.into_iter().next() else {
+                        warn!("ollama returned no embeddings");
+                        return Err(anyhow!("empty embedding"));
+                    };
+                    return Ok(embedding);
                 }
                 Ok(Err(e)) => {
                     if let ollama_rs::error::OllamaError::ReqwestError(ref re) = e {

--- a/lingproc/tests/provider.rs
+++ b/lingproc/tests/provider.rs
@@ -68,3 +68,18 @@ async fn defaults_are_used_when_none_provided() {
     let vec = provider.vectorize("a").await.unwrap();
     assert_eq!(vec, vec![1.0]);
 }
+
+#[tokio::test]
+async fn vectorize_errors_on_empty_embeddings() {
+    let server = MockServer::start_async().await;
+    let _mock = server.mock(|when, then| {
+        when.method(POST).path("/api/embed");
+        then.status(200)
+            .header("content-type", "application/json")
+            .body("{\"embeddings\": []}");
+    });
+
+    let provider = OllamaProvider::new(server.base_url(), "mistral").unwrap();
+    let result = provider.vectorize("hi").await;
+    assert!(result.is_err());
+}


### PR DESCRIPTION
## Summary
- warn and error if Ollama returns no embeddings
- document vectorizer warning policy
- test empty embedding response

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68597bfacfe48320a26f9022a4de5bd1