### PR TITLE
Clarify module re-exports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,4 +123,10 @@ Provides LLM and embedding utilities.
 * Document intentionally empty trait methods with comments so their purpose is
   clear.
 
+## 📝 Coding Guidelines
+
+* When exposing items from a submodule, prefer `pub use` with a private `mod`.
+  Use `pub mod` alongside `pub use` only when external crates rely on paths like
+  `psyche::module::Item`, and add a comment explaining the duplication.
+
 Use this document to orient new agents, tools, or contributors. If you’re confused — ask the Quick what it saw, or the Will what it wants.

--- a/psyche/src/lib.rs
+++ b/psyche/src/lib.rs
@@ -8,6 +8,9 @@ pub mod topics;
 pub mod util;
 mod voice;
 
+/// Traits are organized in submodules and then re-exported for crate users.
+/// Keeping this module public enables paths like `psyche::traits::Ear` while
+/// also flattening common traits at the crate root below.
 pub mod traits {
     pub mod buffered_wit;
     pub mod doer;
@@ -68,9 +71,13 @@ mod and_mouth;
 mod debug;
 
 pub mod ling;
+/// Model types are public for introspection but also re-exported below so
+/// callers can simply `use psyche::{Experience, Impression}`.
 pub mod model;
 pub mod motor_call;
 mod plain_mouth;
+/// The `prompt` module is kept public so callers may use `psyche::prompt::*`.
+/// Key prompt types are also re-exported at the crate root for convenience.
 pub mod prompt;
 mod task_group;
 pub use task_group::TaskGroup;


### PR DESCRIPTION
## Summary
- document why some modules use both `pub mod` and `pub use`
- explain re-export pattern in AGENTS guidelines

## Testing
- `cargo test --no-run`

------
https://chatgpt.com/codex/tasks/task_e_68597d2671ac832094f43743f8fb5ee4