### PR TITLE
Fix WS readiness and webcam failure handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,8 @@ Provides LLM and embedding utilities.
 * Patch DOM incrementally or debounce updates instead of replacing innerHTML.
 * Give `<details>` elements a `min-height` and manage `max-height` via the
   `--details-max-height` CSS variable so collapsed summaries remain visible.
+* Guard WebSocket sends with `readyState` checks and wait for an open connection
+  before starting sensors like the webcam or microphone.
 
 ### Hidden Debug Mode
 

--- a/frontend/test/webcam-error.test.js
+++ b/frontend/test/webcam-error.test.js
@@ -1,0 +1,6 @@
+const assert = require('assert');
+const fs = require('fs');
+
+const script = fs.readFileSync('frontend/dist/app.js', 'utf8');
+assert(script.includes('🚫 Webcam unavailable'));
+console.log('webcam-error ok');

--- a/frontend/test/ws-ready-guard.test.js
+++ b/frontend/test/ws-ready-guard.test.js
@@ -1,0 +1,7 @@
+const assert = require('assert');
+const fs = require('fs');
+
+const script = fs.readFileSync('frontend/dist/app.js', 'utf8');
+assert(script.includes('function waitForWebSocketReady()'));
+assert(script.includes('readyState === WebSocket.OPEN'));
+console.log('ws-ready-guard ok');

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This repository contains a Rust workspace with three crates:",
   "main": "index.js",
   "scripts": {
-    "test": "node frontend/test/conversation-scroll.test.js && node frontend/test/details-data-attr.test.js && node frontend/test/thought-tabs.test.js && node frontend/test/wit-detail-id.test.js"
+    "test": "node frontend/test/conversation-scroll.test.js && node frontend/test/details-data-attr.test.js && node frontend/test/thought-tabs.test.js && node frontend/test/wit-detail-id.test.js && node frontend/test/ws-ready-guard.test.js && node frontend/test/webcam-error.test.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- guard all ws.send calls with `safeSend`
- add `waitForWebSocketReady` helper and delay webcam start
- log webcam permission flow and show emoji on failure
- test for websocket guards and webcam error message
- document websocket guard in `AGENTS.md`

## Testing
- `npm test`
- `cargo test` *(fails: timed out / manual interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68599c2a80f083208263a4ef7782daa9