### PR TITLE
Style conversation wells

### DIFF
--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -35,8 +35,14 @@
   <aside class="sidebar">
       <details open data-wit-name="conversation">
         <summary>Conversation</summary>
-        <pre id="system-prompt"></pre>
-        <pre id="conversation-log"></pre>
+        <div class="scroll-well">
+          <div class="scroll-well-label">System Prompt</div>
+          <pre id="system-prompt"></pre>
+        </div>
+        <div class="scroll-well">
+          <div class="scroll-well-label">Conversation Log</div>
+          <pre id="conversation-log"></pre>
+        </div>
       </details>
       <div id="wit-debug"></div>
   </aside>

--- a/frontend/dist/styles.css
+++ b/frontend/dist/styles.css
@@ -294,6 +294,23 @@ button:hover {
   margin: 0.5rem 0 0 0;
 }
 
+.scroll-well {
+  background-color: #111;
+  border: 1px solid #333;
+  border-radius: var(--bs-border-radius);
+  padding: 0.5rem;
+  max-height: 20vh;
+  overflow-y: auto;
+  margin-top: 0.5rem;
+}
+
+.scroll-well-label {
+  font-weight: bold;
+  font-size: 0.75rem;
+  color: var(--bs-secondary);
+  margin-bottom: 0.25rem;
+}
+
 @keyframes flash {
   from { background-color: #444; }
   to { background-color: #222; }


### PR DESCRIPTION
## Summary
- add scroll wells for the system prompt and conversation log
- style the new wells with borders and max-height

## Testing
- `cargo test` *(fails: logs_skipped_detection)*
- `npm test` *(fails to run: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_68599cb199a88320a5c7dd380d7def57