### PR TITLE
Stream debug info via websocket

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ Provides LLM and embedding utilities.
 * **WebSocket** at `/ws`: Streams `Event` objects from Pete to the client
 * **Static Frontend**: Lives under `frontend/dist`; connects to `/ws`
 * **Events**: Include `Sensed`, `Spoke`, `EmotionChanged`, `Speech`, etc.
-* **Debug Panel**: Streams `WitReport`s via `/debug`
+* **Debug Panel**: `WitReport` events are delivered on `/ws` as `Think` messages
 
 ---
 
@@ -139,9 +139,6 @@ Provides LLM and embedding utilities.
 * Guard WebSocket sends with `readyState` checks and wait for an open connection
   before starting sensors like the webcam or microphone.
 
-### Hidden Debug Mode
-
-* Press `Ctrl+D` in the frontend to toggle timestamp display on conversation messages.
 
 ## 📝 Coding Guidelines
 

--- a/README.md
+++ b/README.md
@@ -96,14 +96,13 @@ cargo run -p pete --features tts -- \
 Visit [`http://localhost:3000/`](http://localhost:3000/) after launch.
 
 * WebSocket connection at `/ws`
-* Debug info streamed from Wits via `/debug`
+* Debug info now included on `/ws` as `Think` events
 * JSON endpoints:
 
   * `/conversation` – full log
   * `/debug/psyche` – tick stats
-  * `/debug/wit/{label}` – last prompt/response per Wit
 
-Events from Pete:
+Events from Pete include speech, emotion changes, wit reports and conversation updates:
 
 ```json
 { "type": "say", "data": { "words": "hi", "audio": "..." } }

--- a/frontend/dist/app.js
+++ b/frontend/dist/app.js
@@ -1,7 +1,6 @@
 (function () {
   const wsProtocol = location.protocol === "https:" ? "wss:" : "ws:";
   const ws = new WebSocket(`${wsProtocol}//${location.hostname}:3000/ws`);
-  const debugWs = new WebSocket(`${wsProtocol}//${location.hostname}:3000/debug`);
 
   function waitForWebSocketReady() {
     if (ws.readyState === WebSocket.OPEN) return Promise.resolve();
@@ -34,19 +33,12 @@
   const face = document.getElementById("face");
   const audioQueue = [];
   const conversationLog = document.getElementById("conversation-log");
+  const conversationMsgs = [];
   const witOutputs = {};
   const thoughtElems = {};
   const witDetails = {};
   const witDebugContainer = document.getElementById("wit-debug");
   let playing = false;
-  let debugMode = false;
-
-  document.addEventListener("keydown", (e) => {
-    if (e.ctrlKey && e.key === "d") {
-      debugMode = !debugMode;
-      updateConversation();
-    }
-  });
 
   function animateDetails(details) {
     const summary = details.querySelector("summary");
@@ -80,23 +72,6 @@
     });
   }
 
-  async function fetchWits() {
-    try {
-      const resp = await fetch("/debug/psyche");
-      const info = await resp.json();
-      (info.active_wits || []).forEach((name) => {
-        const entry = getWitDetail(name);
-        if (info.last_ticks && info.last_ticks[name]) {
-          entry.time.textContent = new Date(info.last_ticks[name]).toLocaleTimeString();
-        }
-      });
-    } catch (e) {
-      console.error("wits", e);
-    }
-  }
-
-  fetchWits();
-  setInterval(fetchWits, 5000);
 
   function getWitDetail(name) {
     let entry = witDetails[name];
@@ -185,17 +160,18 @@
         case "Think":
           handleThink(m);
           break;
-      }
-    } catch (e) {
-      console.error(e);
-    }
-  }
-
-  function handleDebugMessage(ev) {
-    try {
-      const m = JSON.parse(ev.data);
-      if (m.type === "Think") {
-        handleThink(m);
+        case "Chunk":
+          thought.textContent = m.data;
+          break;
+        case "SystemPrompt":
+          conversationMsgs.length = 0;
+          conversationMsgs.push({ role: "system", content: m.data, timestamp: "" });
+          updateConversation();
+          break;
+        case "ConversationEntry":
+          conversationMsgs.push(m.data);
+          updateConversation();
+          break;
       }
     } catch (e) {
       console.error(e);
@@ -255,7 +231,6 @@
   }
 
   ws.onmessage = handleMainMessage;
-  debugWs.onmessage = handleDebugMessage;
 
   document.getElementById("text-form").addEventListener("submit", (e) => {
     e.preventDefault();
@@ -357,36 +332,25 @@
     setupAudio();
   }
 
-  async function updateConversation() {
-    try {
-      const resp = await fetch(`/conversation${debugMode ? "?debug=1" : ""}`);
-      const msgs = await resp.json();
-      const system = document.getElementById("system-prompt");
-      if (system && msgs.length) {
-        system.textContent = msgs[0].content;
-      }
-      const atBottom =
-        conversationLog.scrollTop + conversationLog.clientHeight >=
-        conversationLog.scrollHeight - 5;
-      conversationLog.textContent = msgs
-        .slice(1)
-        .map((m) => {
-          const ts =
-            debugMode && m.timestamp
-              ? new Date(m.timestamp).toLocaleTimeString() + " "
-              : "";
-          return `${ts}${m.role}: ${m.content}`;
-        })
-        .join("\n");
-      if (atBottom) {
-        conversationLog.scrollTop = conversationLog.scrollHeight;
-      }
-    } catch (e) {
-      console.error("conversation", e);
+  function updateConversation() {
+    const system = document.getElementById("system-prompt");
+    if (system && conversationMsgs.length) {
+      system.textContent = conversationMsgs[0].content;
+    }
+    const atBottom =
+      conversationLog.scrollTop + conversationLog.clientHeight >=
+      conversationLog.scrollHeight - 5;
+    conversationLog.textContent = conversationMsgs
+      .slice(1)
+      .map((m) => {
+        const ts = m.timestamp ? new Date(m.timestamp).toLocaleTimeString() + " " : "";
+        return `${ts}${m.role}: ${m.content}`;
+      })
+      .join("\n");
+    if (atBottom) {
+      conversationLog.scrollTop = conversationLog.scrollHeight;
     }
   }
 
-  setInterval(updateConversation, 2000);
-  updateConversation();
   document.querySelectorAll("details").forEach(animateDetails);
 })();

--- a/frontend/dist/wit_debug.html
+++ b/frontend/dist/wit_debug.html
@@ -14,7 +14,7 @@
       const label = location.pathname.split('/').pop();
       document.getElementById('title').textContent = `Debug for ${label}`;
       const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
-      const ws = new WebSocket(`${proto}//${location.host}/debug`);
+      const ws = new WebSocket(`${proto}//${location.host}/ws`);
       const promptEl = document.getElementById('prompt');
       const streamEl = document.getElementById('stream');
       ws.onmessage = (ev) => {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "assert": "^2.1.0",
     "jsdom": "^26.1.0"
   }
 }

--- a/pete/src/lib.rs
+++ b/pete/src/lib.rs
@@ -67,6 +67,6 @@ pub use tts::default_mouth;
 #[cfg(feature = "tts")]
 pub use tts::{CoquiTts, TtsMouth};
 pub use web::{
-    Body, LogQuery, WsRequest, app, conversation_log, index, listen_user_input, log_ws_handler,
+    Body, WsRequest, app, conversation_log, index, listen_user_input, log_ws_handler,
     parse_data_url, psyche_debug, toggle_wit_debug, wit_debug_page, ws_handler,
 };

--- a/pete/tests/conversation.rs
+++ b/pete/tests/conversation.rs
@@ -1,7 +1,5 @@
 use axum::{body, extract::State, response::IntoResponse};
-use pete::{
-    Body, ChannelEar, EventBus, EyeSensor, GeoSensor, LogQuery, conversation_log, dummy_psyche,
-};
+use pete::{Body, ChannelEar, EventBus, EyeSensor, GeoSensor, conversation_log, dummy_psyche};
 use psyche::traits::Sensor;
 use std::sync::{
     Arc,
@@ -35,9 +33,7 @@ async fn returns_log_json() {
         system_prompt: Arc::new(tokio::sync::Mutex::new(psyche.system_prompt())),
         psyche_debug: debug,
     };
-    let resp = conversation_log(axum::extract::Query(LogQuery { debug: None }), State(state))
-        .await
-        .into_response();
+    let resp = conversation_log(State(state)).await.into_response();
     let body = body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
     let msgs: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(msgs[0]["role"], "system");
@@ -76,12 +72,7 @@ async fn debug_mode_includes_timestamps() {
         system_prompt: Arc::new(tokio::sync::Mutex::new(psyche.system_prompt())),
         psyche_debug: debug,
     };
-    let resp = conversation_log(
-        axum::extract::Query(LogQuery { debug: Some(true) }),
-        State(state),
-    )
-    .await
-    .into_response();
+    let resp = conversation_log(State(state)).await.into_response();
     let body = body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
     let msgs: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert!(msgs[1]["timestamp"].is_string());

--- a/pete/tests/ws_audio.rs
+++ b/pete/tests/ws_audio.rs
@@ -51,8 +51,13 @@ async fn websocket_forwards_audio() {
         text: "hi".into(),
         audio: Some("UklGRg==".into()),
     });
-    let msg = socket.next().await.unwrap().unwrap();
-    let value: serde_json::Value = serde_json::from_str(msg.to_text().unwrap()).unwrap();
+    // skip initial system prompt
+    let mut msg = socket.next().await.unwrap().unwrap();
+    let mut value: serde_json::Value = serde_json::from_str(msg.to_text().unwrap()).unwrap();
+    if value["type"] == "SystemPrompt" {
+        msg = socket.next().await.unwrap().unwrap();
+        value = serde_json::from_str(msg.to_text().unwrap()).unwrap();
+    }
     assert_eq!(value["type"], "Say");
     assert_eq!(value["data"]["audio"], "UklGRg==");
     assert_eq!(value["data"]["words"], "hi");

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -61,6 +61,12 @@ pub enum WsPayload {
         /// Additional arguments.
         args: serde_json::Value,
     },
+    /// Raw streaming text from the language model.
+    Chunk(String),
+    /// Initial system prompt for the conversation.
+    SystemPrompt(String),
+    /// A single entry in the conversation log.
+    ConversationEntry(ConversationEntry),
 }
 
 #[cfg_attr(feature = "ts", derive(ts_rs::TS))]
@@ -68,4 +74,12 @@ pub enum WsPayload {
 pub struct AudioData {
     pub base64: String,
     pub mime: String,
+}
+
+#[cfg_attr(feature = "ts", derive(ts_rs::TS))]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ConversationEntry {
+    pub role: String,
+    pub content: String,
+    pub timestamp: String,
 }


### PR DESCRIPTION
## Summary
- route `Think` and conversation data over the main websocket
- stop polling for debug info in the frontend
- always show debug panels
- document new websocket behaviour

## Testing
- `npm test`
- `cargo test` *(fails: doctest timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6859a37dc34c8320814bcd7ea0db7170