### PR TITLE
fix webcam init race

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,8 @@ Provides LLM and embedding utilities.
 * Restart the webcam if its stream ends by listening for the track's `ended`
   event and reacquiring the camera.
 * Avoid reacquiring the webcam when an active stream is already running.
+* Start capturing only once `webcamReady` is set after the WebSocket `open`
+  event.
 
 
 ## 📝 Coding Guidelines

--- a/frontend/dist/app.js
+++ b/frontend/dist/app.js
@@ -231,6 +231,15 @@
   }
 
   ws.onmessage = handleMainMessage;
+  ws.addEventListener("open", () => {
+    webcamReady = true;
+    if (navigator.mediaDevices?.getUserMedia) {
+      setupWebcam();
+    }
+  });
+  ws.addEventListener("close", () => {
+    webcamReady = false;
+  });
 
   document.getElementById("text-form").addEventListener("submit", (e) => {
     e.preventDefault();
@@ -257,6 +266,7 @@
   }
 
   let webcamStream = null;
+  let webcamReady = false;
 
   async function setupWebcam() {
     try {
@@ -273,7 +283,9 @@
       stream.getTracks().forEach((t) =>
         t.addEventListener(
           "ended",
-          () => waitForWebSocketReady().then(setupWebcam),
+          () => {
+            if (webcamReady) setupWebcam();
+          },
           { once: true }
         )
       );
@@ -284,6 +296,7 @@
       canvas.id = "webcam-canvas";
       const ctx = canvas.getContext("2d", { willReadFrequently: true });
       setInterval(() => {
+        if (!webcamReady) return;
         const data = captureWebcamFrame(video, canvas, ctx);
         if (data === null) return;
         if (data) {
@@ -308,7 +321,7 @@
   }
 
   if (navigator.mediaDevices?.getUserMedia) {
-    waitForWebSocketReady().then(setupWebcam);
+    if (webcamReady) setupWebcam();
   }
 
   async function setupAudio() {

--- a/frontend/test/webcam-after-open.test.js
+++ b/frontend/test/webcam-after-open.test.js
@@ -1,0 +1,7 @@
+const assert = require('assert');
+const fs = require('fs');
+
+const script = fs.readFileSync('frontend/dist/app.js', 'utf8');
+assert(script.includes('let webcamReady = false'));
+assert(script.includes('if (!webcamReady) return'));
+console.log('webcam-after-open ok');

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This repository contains a Rust workspace with three crates:",
   "main": "index.js",
   "scripts": {
-    "test": "node frontend/test/conversation-scroll.test.js && node frontend/test/details-data-attr.test.js && node frontend/test/thought-tabs.test.js && node frontend/test/wit-detail-id.test.js && node frontend/test/ws-ready-guard.test.js && node frontend/test/webcam-error.test.js && node frontend/test/webcam-restart.test.js && node frontend/test/webcam-guard.test.js"
+    "test": "node frontend/test/conversation-scroll.test.js && node frontend/test/details-data-attr.test.js && node frontend/test/thought-tabs.test.js && node frontend/test/wit-detail-id.test.js && node frontend/test/ws-ready-guard.test.js && node frontend/test/webcam-error.test.js && node frontend/test/webcam-restart.test.js && node frontend/test/webcam-guard.test.js && node frontend/test/webcam-after-open.test.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- gate webcam capture behind `webcamReady`
- only start webcam after WebSocket opens
- add unit test
- document the pattern in AGENTS

## Testing
- `cargo test` *(fails: build timeout)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6859c9e43acc8320aeb9fd263e6e714a