### PR TITLE
Enable Quick wit

### DIFF
--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -10,13 +10,10 @@ use pete::FaceSensor;
 #[cfg(feature = "geo")]
 use pete::GeoSensor;
 use pete::HeartbeatSensor;
-use pete::{
-    Body, LoggingMotor, NoopEar, NoopMouth, app, init_logging,
-    listen_user_input,
-};
+use pete::{Body, LoggingMotor, NoopEar, NoopMouth, app, init_logging, listen_user_input};
 // helper for building Ollama providers
-use pete::ollama_provider_from_args;
 use pete::default_mouth;
+use pete::ollama_provider_from_args;
 use psyche::{Ear, GeoLoc, ImageData, Mouth, Sensation, Sensor, TrimMouth};
 use std::{
     net::SocketAddr,
@@ -108,7 +105,7 @@ async fn main() -> anyhow::Result<()> {
 
     use psyche::wits::{
         BasicMemory, Combobulator, FaceMemoryWit, FondDuCoeur, HeartWit, IdentityWit, MemoryWit,
-        Neo4jClient, QdrantClient, VisionWit, Will,
+        Neo4jClient, QdrantClient, Quick, VisionWit, Will,
     };
 
     let narrator = ollama_provider_from_args(&cli.chatter_host, &cli.chatter_model)?;
@@ -149,6 +146,11 @@ async fn main() -> anyhow::Result<()> {
         wit_tx.clone(),
     )));
     psyche.register_observing_wit(Arc::new(FaceMemoryWit::with_debug(wit_tx.clone())));
+    psyche.register_observing_wit(Arc::new(Quick::with_debug(
+        psyche.topic_bus(),
+        Arc::new(ollama_provider_from_args(&cli.wits_host, &cli.wits_model)?),
+        Some(wit_tx.clone()),
+    )));
     psyche.register_typed_wit(Arc::new(Combobulator::with_debug(
         Arc::new(ollama_provider_from_args(&cli.wits_host, &cli.wits_model)?),
         Some(wit_tx.clone()),

--- a/pete/src/psyche_factory.rs
+++ b/pete/src/psyche_factory.rs
@@ -7,6 +7,7 @@ use tracing::info;
 use crate::ear::NoopEar;
 use crate::mouth::NoopMouth;
 use crate::ollama_provider_from_args;
+use psyche::wits::Quick;
 
 /// Create a psyche with dummy providers for demos/tests.
 pub fn dummy_psyche() -> Psyche {
@@ -50,6 +51,11 @@ pub fn dummy_psyche() -> Psyche {
         wit_tx.clone(),
     )));
     psyche.register_observing_wit(Arc::new(psyche::FaceMemoryWit::with_debug(wit_tx)));
+    psyche.register_observing_wit(Arc::new(Quick::with_debug(
+        psyche.topic_bus(),
+        Arc::new(Dummy),
+        None,
+    )));
     psyche.set_turn_limit(usize::MAX);
     psyche
         .voice()
@@ -77,7 +83,7 @@ pub fn ollama_psyche(
     use crate::LoggingMotor;
     use psyche::wits::{
         BasicMemory, Combobulator, FondDuCoeur, HeartWit, IdentityWit, MemoryWit, Neo4jClient,
-        QdrantClient, Will,
+        QdrantClient, Quick, Will,
     };
 
     let narrator = ollama_provider_from_args(chatter_host, chatter_model)?;
@@ -114,6 +120,11 @@ pub fn ollama_psyche(
         wit_tx.clone(),
     )));
     psyche.register_observing_wit(Arc::new(psyche::FaceMemoryWit::with_debug(wit_tx.clone())));
+    psyche.register_observing_wit(Arc::new(Quick::with_debug(
+        psyche.topic_bus(),
+        Arc::new(ollama_provider_from_args(wits_host, wits_model)?),
+        Some(wit_tx.clone()),
+    )));
     psyche.register_typed_wit(Arc::new(Combobulator::with_debug(
         Arc::new(ollama_provider_from_args(wits_host, wits_model)?),
         Some(wit_tx.clone()),

--- a/psyche/src/sensation.rs
+++ b/psyche/src/sensation.rs
@@ -37,11 +37,22 @@ pub enum Sensation {
     Of(Box<dyn std::any::Any + Send + Sync>),
 }
 
+impl Clone for Sensation {
+    fn clone(&self) -> Self {
+        match self {
+            Self::HeardOwnVoice(t) => Self::HeardOwnVoice(t.clone()),
+            Self::HeardUserVoice(t) => Self::HeardUserVoice(t.clone()),
+            Self::Of(_) => Self::Of(Box::new(())),
+        }
+    }
+}
+
 /// A coherent bundle of recently perceived sensations.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct Instant {
     /// Time the sensations were observed.
     pub at: DateTime<Utc>,
     /// The grouped sensations.
+    #[serde(skip)]
     pub sensations: Vec<Arc<Sensation>>,
 }

--- a/psyche/src/wits/quick.rs
+++ b/psyche/src/wits/quick.rs
@@ -11,7 +11,7 @@
 //! [`Instant`] and publishes it on [`Topic::Instant`].
 
 use crate::topics::{Topic, TopicBus};
-use crate::traits::Doer;
+use crate::traits::{Doer, wit::Wit};
 use crate::{Impression, Instant, Sensation, Stimulus};
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
@@ -96,6 +96,15 @@ impl Quick {
             } else {
                 break;
             }
+        }
+    }
+}
+
+#[async_trait]
+impl crate::traits::observer::SensationObserver for Quick {
+    async fn observe_sensation(&self, payload: &(dyn std::any::Any + Send + Sync)) {
+        if let Some(s) = payload.downcast_ref::<Sensation>() {
+            self.observe(s.clone()).await;
         }
     }
 }

--- a/psyche/tests/quick.rs
+++ b/psyche/tests/quick.rs
@@ -1,0 +1,31 @@
+use async_trait::async_trait;
+use lingproc::LlmInstruction;
+use psyche::traits::Doer;
+use psyche::wits::Quick;
+use psyche::{Sensation, Topic, TopicBus, Wit};
+use std::sync::Arc;
+use tokio::time::{Duration, sleep};
+
+#[derive(Clone)]
+struct Dummy;
+
+#[async_trait]
+impl Doer for Dummy {
+    async fn follow(&self, i: LlmInstruction) -> anyhow::Result<String> {
+        Ok(format!("SUM:{}", i.command))
+    }
+}
+
+#[tokio::test]
+async fn summarizes_heard_text() {
+    let bus = TopicBus::new(8);
+    let quick = Quick::new(bus.clone(), Arc::new(Dummy));
+    // allow subscriber spawn
+    sleep(Duration::from_millis(20)).await;
+    bus.publish(Topic::Sensation, Sensation::HeardUserVoice("hi".into()));
+    sleep(Duration::from_millis(20)).await;
+    let out = quick.tick().await;
+    assert_eq!(out.len(), 1);
+    assert!(out[0].summary.starts_with("SUM:"));
+    assert_eq!(out[0].stimuli.len(), 1);
+}


### PR DESCRIPTION
## Summary
- register Quick wit in main and psyche factory
- serialize `Instant` for debugging
- implement cloning and sensor observation for Quick
- add regression test for Quick

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6859c8717448832093dd8a3d9fecfbba