### PR TITLE
Improve wit debug logs

### DIFF
--- a/pete/Cargo.toml
+++ b/pete/Cargo.toml
@@ -16,7 +16,7 @@ serde_json = "1"
 shared = { path = "../shared" }
 clap = { version = "4", features = ["derive", "env"] }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["fmt"] }
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 pragmatic-segmenter = "0.1"
 dioxus = { version = "0.4.3", default-features = false, features = ["html", "macro"] }
 dioxus-ssr = "0.4.3"

--- a/pete/src/logging.rs
+++ b/pete/src/logging.rs
@@ -1,6 +1,6 @@
 use std::io::{self, Write};
 use tokio::sync::broadcast;
-use tracing_subscriber::fmt;
+use tracing_subscriber::{EnvFilter, fmt};
 
 /// Initialize logging to stdout and broadcast log lines over the provided channel.
 ///
@@ -12,7 +12,9 @@ use tracing_subscriber::fmt;
 /// init_logging(tx);
 /// ```
 pub fn init_logging(tx: broadcast::Sender<String>) {
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("debug"));
     fmt()
+        .with_env_filter(filter)
         .with_writer(move || TeeWriter {
             stdout: std::io::stdout(),
             tx: tx.clone(),

--- a/psyche/src/wits/quick.rs
+++ b/psyche/src/wits/quick.rs
@@ -20,7 +20,7 @@ use lingproc::LlmInstruction;
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 use tokio::sync::broadcast;
-use tracing::debug;
+use tracing::{debug, info};
 pub struct Quick {
     buffer: Arc<Mutex<VecDeque<(DateTime<Utc>, Arc<Sensation>)>>>,
     bus: TopicBus,
@@ -151,6 +151,7 @@ impl crate::traits::wit::Wit for Quick {
             sensations: items.clone(),
         };
         let stim = Stimulus::new(instant);
+        info!(count = items.len(), out = %out, "quick emitting instant");
         debug!(
             "quick: emitting instant from {} sensations: \"{}\"",
             items.len(),


### PR DESCRIPTION
## Summary
- default log level falls back to debug so wit logs show up
- bump pete's tracing-subscriber features
- log Quick output at info level

## Testing
- `cargo test` *(fails: tests hang at doctest TopicMessage)*

------
https://chatgpt.com/codex/tasks/task_e_6859cfd9ba7c8320ac934c02fd85be6e