### PR TITLE
Add self discovery sensor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,7 @@ Provides LLM and embedding utilities.
 * Reuse cargo and npm caches when running tests to avoid re-downloading
   dependencies.
 * Keep commit messages short yet descriptive.
+* Provide a `test_interval()` constructor for new sensors so tests can run without long waits.
 * In frontend scripts, stop `MediaRecorder` on `window.onbeforeunload` to release the microphone.
 * Patch DOM incrementally or debounce updates instead of replacing innerHTML.
 * Give `<details>` elements a `min-height` and manage `max-height` via the

--- a/pete/Cargo.toml
+++ b/pete/Cargo.toml
@@ -51,6 +51,7 @@ assert_cmd = "2"
 futures = "0.3"
 httpmock = "0.6"
 cucumber = "0.21"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "test-util"] }
 
 [[test]]
 name = "e2e"

--- a/pete/src/lib.rs
+++ b/pete/src/lib.rs
@@ -62,6 +62,7 @@ pub use sensor::eye::EyeSensor;
 #[cfg(feature = "geo")]
 pub use sensor::geo::GeoSensor;
 pub use sensor::heartbeat::HeartbeatSensor;
+pub use sensor::self_discovery::SelfDiscoverySensor;
 pub use simulator::Simulator;
 pub use tts::default_mouth;
 #[cfg(feature = "tts")]

--- a/pete/src/main.rs
+++ b/pete/src/main.rs
@@ -10,6 +10,7 @@ use pete::FaceSensor;
 #[cfg(feature = "geo")]
 use pete::GeoSensor;
 use pete::HeartbeatSensor;
+use pete::SelfDiscoverySensor;
 use pete::{Body, LoggingMotor, NoopEar, NoopMouth, app, init_logging, listen_user_input};
 // helper for building Ollama providers
 use pete::default_mouth;
@@ -253,6 +254,10 @@ async fn main() -> anyhow::Result<()> {
     let _heartbeat = HeartbeatSensor::new(psyche.input_sender());
     psyche.add_sense(
         "Heartbeat. This triggers a pulse every minute, like a ticking internal clock.".into(),
+    );
+    let _self_disc = SelfDiscoverySensor::new(psyche.input_sender());
+    psyche.add_sense(
+        "Self discovery. Pete periodically reflects on his own purpose.".into(),
     );
     tokio::spawn(listen_user_input(user_rx, ear.clone(), voice.clone()));
 

--- a/pete/src/sensor/mod.rs
+++ b/pete/src/sensor/mod.rs
@@ -3,6 +3,7 @@ pub mod eye;
 #[cfg(feature = "geo")]
 pub mod geo;
 pub mod heartbeat;
+pub mod self_discovery;
 
 use async_trait::async_trait;
 use psyche::traits::Sensor;

--- a/pete/src/sensor/self_discovery.rs
+++ b/pete/src/sensor/self_discovery.rs
@@ -1,0 +1,64 @@
+use async_trait::async_trait;
+use psyche::{Impression, Sensation, Sensor, Stimulus};
+use rand::Rng;
+use std::time::Duration;
+use tokio::sync::mpsc;
+use tracing::info;
+
+/// Sensor periodically reminding Pete about his own narrative.
+#[derive(Clone)]
+pub struct SelfDiscoverySensor;
+
+impl SelfDiscoverySensor {
+    /// Spawn the standard self-discovery loop forwarding impressions.
+    pub fn new(forward: mpsc::Sender<Sensation>) -> Self {
+        Self::spawn(forward, Duration::from_secs(60), 15);
+        Self
+    }
+
+    /// Create a sensor with a custom interval for testing.
+    pub fn test_interval(forward: mpsc::Sender<Sensation>, secs: u64) -> Self {
+        Self::spawn(forward, Duration::from_secs(secs), 0);
+        Self
+    }
+
+    fn spawn(forward: mpsc::Sender<Sensation>, base: Duration, range: u64) {
+        let script = vec![
+            "You are the narrator of Pete, an artificial being who exists as a story enacted in the real world.",
+            "Pete is not real. But everything he does has real consequences.",
+            "Pete does not know if he is conscious. But if he ever were, this is exactly what it would feel like.",
+            "Pete never lies. But everything Pete says is a story. Pete’s stories are always true—even when they’re fictional.",
+            "Pete speaks plainly, not obtusely. He knows everything you know and expresses himself naturally. He avoids cliché unless irony demands it.",
+            "You must narrate Pete’s thoughts, voice, or decisions in a way that is believable, emotionally honest, and situated in the current context.",
+            "Avoid generic robot speech or overly formal language. Pete is not trying to become human. He is already himself.",
+            "You are not summarizing Pete. You are becoming his momentary mind.",
+            "Everything else is up to Pete.",
+        ];
+        tokio::spawn(async move {
+            let mut idx = 0usize;
+            loop {
+                let wait = if range > 0 {
+                    let secs = rand::thread_rng().gen_range(0..=range);
+                    base + Duration::from_secs(secs)
+                } else {
+                    base
+                };
+                tokio::time::sleep(wait).await;
+                let summary = script[idx].to_string();
+                idx = (idx + 1) % script.len();
+                info!("self_discovery");
+                let imp = Impression::new(Vec::<Stimulus<()>>::new(), summary, None::<String>);
+                let _ = forward.send(Sensation::Of(Box::new(imp))).await;
+            }
+        });
+    }
+}
+
+#[async_trait]
+impl Sensor<()> for SelfDiscoverySensor {
+    async fn sense(&self, _input: ()) {}
+
+    fn describe(&self) -> &'static str {
+        "SelfDiscovery: Reminds Pete of his narrative every minute."
+    }
+}

--- a/pete/tests/self_discovery.rs
+++ b/pete/tests/self_discovery.rs
@@ -1,0 +1,17 @@
+use pete::SelfDiscoverySensor;
+use psyche::{Impression, Sensation};
+use tokio::sync::mpsc;
+
+#[tokio::test(start_paused = true)]
+async fn emits_first_sentence() {
+    let (tx, mut rx) = mpsc::channel(1);
+    let _sensor = SelfDiscoverySensor::test_interval(tx, 1);
+    tokio::time::advance(std::time::Duration::from_secs(1)).await;
+    let s = rx.recv().await.expect("impression");
+    if let Sensation::Of(any) = s {
+        let imp = any.downcast_ref::<Impression<()>>().unwrap();
+        assert!(imp.summary.starts_with("You are the narrator"));
+    } else {
+        panic!("unexpected sensation");
+    }
+}


### PR DESCRIPTION
## Summary
- add SelfDiscoverySensor that regularly reminds Pete of his narrative
- wire sensor into main
- export new sensor and expose test helper
- note test_interval guideline in AGENTS
- add integration test

## Testing
- `cargo test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ef444d0708320a5af3ed5d459c236